### PR TITLE
✨ feat: install.sh の実装

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,9 +43,9 @@ parse_args() {
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --name)     [[ $# -ge 2 ]] || { log_error "--name に値が必要です"; usage; }; PROJECT_NAME="$2"; shift 2 ;;
-      --preset)   [[ $# -ge 2 ]] || { log_error "--preset に値が必要です"; usage; }; PRESET="$2"; shift 2 ;;
-      --language) [[ $# -ge 2 ]] || { log_error "--language に値が必要です"; usage; }; LANGUAGE="$2"; shift 2 ;;
+      --name)     [[ $# -ge 2 && "$2" != --* && "$2" != -h ]] || { log_error "--name に値が必要です"; usage; }; PROJECT_NAME="$2"; shift 2 ;;
+      --preset)   [[ $# -ge 2 && "$2" != --* && "$2" != -h ]] || { log_error "--preset に値が必要です"; usage; }; PRESET="$2"; shift 2 ;;
+      --language) [[ $# -ge 2 && "$2" != --* && "$2" != -h ]] || { log_error "--language に値が必要です"; usage; }; LANGUAGE="$2"; shift 2 ;;
       -h|--help)  usage 0 ;;
       *)          log_error "不明なオプション: $1"; usage ;;
     esac
@@ -150,7 +150,11 @@ update_gitignore() {
   if [[ -f "$gitignore" ]] && grep -qxF "$entry" "$gitignore"; then
     log_skip ".gitignore に ${entry} は追記済み"
   else
-    echo "$entry" >> "$gitignore"
+    # 末尾改行がない場合に行が連結されるのを防止
+    if [[ -f "$gitignore" ]] && [[ -s "$gitignore" ]] && [[ -n "$(tail -c 1 "$gitignore")" ]]; then
+      printf '\n' >> "$gitignore"
+    fi
+    printf '%s\n' "$entry" >> "$gitignore"
     log_info ".gitignore に ${entry} を追記"
   fi
 }


### PR DESCRIPTION
## Summary

- vibecorp プラグインのコアインストーラー `install.sh` を新規実装
- `install.sh --name <project-name>` で導入先 git リポジトリに minimal プリセットの構成を展開
- テンプレートコピー、settings.json マージ、冪等性、入力バリデーションを実装

## 主な機能

- テンプレートコピー（hooks/skills）+ プリセット別引き算削除
- settings.json の新規生成/既存マージ（ユーザーフック保持）
- vibecorp.yml/lock, CLAUDE.md, MVV.md, rules/ の生成
- .gitignore 追記（重複防止）
- 冪等性確保（再実行で安全に動作）
- 入力バリデーション（name, language, 引数不足）

closes #7

## Test plan

- [x] 新規 git リポジトリで `install.sh --name test-project` を実行し全ファイル生成を確認
- [x] 二重実行で冪等性を確認（yml/CLAUDE.md/MVV.md がスキップ、settings.json がマージ）
- [x] settings.json マージ時にユーザーフックが保持されることを確認
- [x] エラーケース確認（--name なし、不正名、git リポ外、--name 引数不足）
- [x] minimal プリセットで review-to-rules-gate.sh / review-to-rules/ が除去されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * リポジトリ内にプラグイン用のインストール機能を追加し、自動で構成ディレクトリを作成
  * コマンドラインでプロジェクト名・プリセット・言語を指定可能（ヘルプと入力検証あり）
  * 必要な外部コマンドを事前確認して失敗時に中断
  * テンプレートから設定・フック・スキル・ルール・ドキュメントを生成し、既存ファイルは保護・安全にマージ
  * プレースホルダ置換と実行権限の付与、インストール記録（バージョン・タイムスタンプ・コミット短縮）を保存
  * 完了時に要約バナーを表示
<!-- end of auto-generated comment: release notes by coderabbit.ai -->