### PR TITLE
🧪 test: 既存プロジェクト移行検証

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -100,18 +100,79 @@ detect_repo_root() {
   fi
 }
 
-copy_templates() {
-  # hooks, skills を Claude Code の規約パスにコピー
-  # rules は copy_rules() で .claude/rules/ へ個別コピー（既存スキップのため）
+read_lock_list() {
+  # lock ファイルから指定セクションのファイル一覧を取得
+  # 使い方: read_lock_list <lock_file> <section_name>
+  # awk でブロック単位に抽出（grep -A N はセクション境界を越えるため使わない）
+  local lock_file="$1"
+  local section="$2"
+
+  [[ -f "$lock_file" ]] || return 0
+
+  awk -v section="$section" '
+    /^  [a-z]+:/ {
+      current = $1
+      gsub(/:$/, "", current)
+      next
+    }
+    current == section && /^    - / {
+      sub(/^    - /, "")
+      print
+    }
+  ' "$lock_file"
+}
+
+remove_managed_files() {
+  # lock に記載された vibecorp 管理ファイルのみ削除
+  local lock="${REPO_ROOT}/.claude/vibecorp.lock"
   local hooks_dir="${REPO_ROOT}/.claude/hooks"
   local skills_dir="${REPO_ROOT}/.claude/skills"
 
-  mkdir -p "${REPO_ROOT}/.claude"
+  [[ -f "$lock" ]] || return 0
 
-  # 再実行時のネスト防止: 既存ディレクトリを削除してからコピー
-  rm -rf "$hooks_dir" "$skills_dir"
-  cp -R "${SCRIPT_DIR}/templates/claude/hooks" "$hooks_dir"
-  cp -R "${SCRIPT_DIR}/templates/claude/skills" "$skills_dir"
+  # lock 記載の hooks を削除
+  while IFS= read -r name; do
+    [[ -n "$name" ]] && rm -f "${hooks_dir}/${name}"
+  done < <(read_lock_list "$lock" "hooks")
+
+  # lock 記載の skills を削除
+  while IFS= read -r name; do
+    [[ -n "$name" ]] && rm -rf "${skills_dir}/${name}"
+  done < <(read_lock_list "$lock" "skills")
+
+  log_info "管理ファイルを削除（lock ベース）"
+}
+
+copy_managed_files() {
+  # テンプレートをコピー（既存ユーザーファイルはスキップ）
+  local hooks_dir="${REPO_ROOT}/.claude/hooks"
+  local skills_dir="${REPO_ROOT}/.claude/skills"
+
+  mkdir -p "$hooks_dir" "$skills_dir"
+
+  # hooks: 同名ファイルが既存ならスキップ
+  for src in "${SCRIPT_DIR}/templates/claude/hooks/"*.sh; do
+    [[ -f "$src" ]] || continue
+    local name
+    name=$(basename "$src")
+    if [[ -f "${hooks_dir}/${name}" ]]; then
+      log_skip "hooks/${name} は既存のためスキップ"
+    else
+      cp "$src" "${hooks_dir}/${name}"
+    fi
+  done
+
+  # skills: 同名ディレクトリが既存ならスキップ
+  for src_dir in "${SCRIPT_DIR}/templates/claude/skills/"*/; do
+    [[ -d "$src_dir" ]] || continue
+    local name
+    name=$(basename "$src_dir")
+    if [[ -d "${skills_dir}/${name}" ]]; then
+      log_skip "skills/${name} は既存のためスキップ"
+    else
+      cp -R "$src_dir" "${skills_dir}/${name}"
+    fi
+  done
 
   # プレースホルダー置換
   # macOS 互換: sed ... > tmp && mv tmp original（sed -i の BSD/GNU 差異を回避）
@@ -129,7 +190,9 @@ copy_templates() {
   done
 
   # hooks に実行権限を付与
-  chmod +x "${hooks_dir}/"*.sh
+  for f in "${hooks_dir}/"*.sh; do
+    [[ -f "$f" ]] && chmod +x "$f"
+  done
 
   # プリセット別削除（引き算方式）
   case "$PRESET" in
@@ -169,17 +232,28 @@ generate_vibecorp_lock() {
   local vibecorp_commit
   vibecorp_commit=$(git -C "${SCRIPT_DIR}" rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
-  # インストール済みファイルのマニフェストを生成
+  # vibecorp が管理するファイルのマニフェストを生成（テンプレート由来のみ）
   local hooks_list="" skills_list="" rules_list=""
 
-  for f in "${REPO_ROOT}/.claude/hooks/"*.sh; do
-    [[ -f "$f" ]] && hooks_list="${hooks_list}  - $(basename "$f")"$'\n'
+  # テンプレートに存在し、プリセット削除後も残っているファイルを記録
+  for f in "${SCRIPT_DIR}/templates/claude/hooks/"*.sh; do
+    [[ -f "$f" ]] || continue
+    local name
+    name=$(basename "$f")
+    # 実際に配置先に存在するもののみ記録（プリセット削除分を除外）
+    [[ -f "${REPO_ROOT}/.claude/hooks/${name}" ]] && hooks_list="${hooks_list}    - ${name}"$'\n'
   done
-  for d in "${REPO_ROOT}/.claude/skills/"*/; do
-    [[ -d "$d" ]] && skills_list="${skills_list}  - $(basename "$d")"$'\n'
+  for d in "${SCRIPT_DIR}/templates/claude/skills/"*/; do
+    [[ -d "$d" ]] || continue
+    local name
+    name=$(basename "$d")
+    [[ -d "${REPO_ROOT}/.claude/skills/${name}" ]] && skills_list="${skills_list}    - ${name}"$'\n'
   done
   for f in "${SCRIPT_DIR}/templates/claude/rules/"*.md; do
-    [[ -f "$f" ]] && rules_list="${rules_list}  - $(basename "$f")"$'\n'
+    [[ -f "$f" ]] || continue
+    local name
+    name=$(basename "$f")
+    [[ -f "${REPO_ROOT}/.claude/rules/${name}" ]] && rules_list="${rules_list}    - ${name}"$'\n'
   done
 
   cat > "$lock" <<YAML
@@ -200,6 +274,7 @@ YAML
 generate_settings_json() {
   local settings="${REPO_ROOT}/.claude/settings.json"
   local template="${SCRIPT_DIR}/templates/settings.json.tpl"
+  local lock="${REPO_ROOT}/.claude/vibecorp.lock"
 
   # テンプレートにプリセットフィルタを適用
   local new_settings
@@ -222,16 +297,25 @@ generate_settings_json() {
     echo "$new_settings" | jq '.' > "$settings"
     log_info "settings.json を生成"
   else
-    # 既存: ユーザーフックを保持し、vibecorp フックのみ差し替え
+    # 既存: lock のフック名リストで vibecorp 管理判定（パス文字列判定をやめる）
+    local managed_hooks_json="[]"
+    if [[ -f "$lock" ]]; then
+      # lock 記載のフック名から jq フィルタ用の JSON 配列を生成
+      managed_hooks_json=$(read_lock_list "$lock" "hooks" | jq -R -s 'split("\n") | map(select(length > 0))')
+    fi
+
     local new_hooks
     new_hooks=$(echo "$new_settings" | jq '.hooks.PreToolUse')
 
-    jq --argjson new "$new_hooks" '
-      def strip_vibecorp_hooks:
-        .hooks |= map(select(.command | contains(".claude/hooks/") | not));
-      # 既存から vibecorp フックを除去し、新規と結合後、同一 matcher をマージ
+    jq --argjson new "$new_hooks" --argjson managed "$managed_hooks_json" '
+      def is_managed_hook:
+        (.command | split("/") | last) as $basename |
+        any($managed[]; . == $basename);
+      def strip_managed_hooks:
+        .hooks |= map(select(is_managed_hook | not));
+      # 既存から vibecorp 管理フックを除去し、新規と結合後、同一 matcher をマージ
       .hooks.PreToolUse = (
-        [(.hooks.PreToolUse // [])[] | strip_vibecorp_hooks | select((.hooks | length) > 0)]
+        [(.hooks.PreToolUse // [])[] | strip_managed_hooks | select((.hooks | length) > 0)]
         + $new
         | group_by(.matcher)
         | map({matcher: .[0].matcher, hooks: [.[].hooks[]]})
@@ -312,13 +396,14 @@ main() {
   validate_language
   check_prerequisites
   detect_repo_root
-  copy_templates
+  remove_managed_files
+  copy_managed_files
   generate_vibecorp_yml
-  generate_vibecorp_lock
   generate_settings_json
   copy_rules
   generate_claude_md
   generate_mvv_md
+  generate_vibecorp_lock
   print_completion
 }
 

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -497,6 +497,164 @@ cleanup
 
 # ============================================
 echo ""
+echo "=== K. 既存フック保持（独自フック + vibecorp フック共存） ==="
+# ============================================
+
+# K1. ユーザー独自フックが install 後も残る
+create_test_repo
+mkdir -p "$TMPDIR_ROOT/.claude/hooks"
+echo '#!/bin/bash' > "$TMPDIR_ROOT/.claude/hooks/my-guard.sh"
+echo 'echo "ユーザー独自ガード"' >> "$TMPDIR_ROOT/.claude/hooks/my-guard.sh"
+chmod +x "$TMPDIR_ROOT/.claude/hooks/my-guard.sh"
+bash "$INSTALL_SH" --name test-proj 2>/dev/null
+R="$TMPDIR_ROOT"
+
+assert_file_exists "ユーザー独自フック(my-guard.sh)が残る" "$R/.claude/hooks/my-guard.sh"
+assert_file_contains "ユーザー独自フックの内容が保持" "$R/.claude/hooks/my-guard.sh" "ユーザー独自ガード"
+
+# K2. vibecorp フックも同時に存在する
+assert_file_exists "vibecorp フック(protect-files.sh)も存在" "$R/.claude/hooks/protect-files.sh"
+
+# K3. 再実行でもユーザー独自フックは消えない
+bash "$INSTALL_SH" --name test-proj 2>/dev/null
+assert_file_exists "再実行後もユーザー独自フックが残る" "$R/.claude/hooks/my-guard.sh"
+assert_file_contains "再実行後もユーザー独自フックの内容が保持" "$R/.claude/hooks/my-guard.sh" "ユーザー独自ガード"
+
+# K4. lock にユーザー独自フックが含まれない
+assert_file_not_contains "lock にユーザー独自フックなし" "$R/.claude/vibecorp.lock" "my-guard.sh"
+
+cleanup
+
+# ============================================
+echo ""
+echo "=== L. 既存スキル保持（同名スキルスキップ） ==="
+# ============================================
+
+# L1. ユーザーがカスタマイズした同名スキルはスキップ
+create_test_repo
+mkdir -p "$TMPDIR_ROOT/.claude/skills/review"
+echo "# カスタムレビュースキル" > "$TMPDIR_ROOT/.claude/skills/review/SKILL.md"
+bash "$INSTALL_SH" --name test-proj 2>/dev/null
+R="$TMPDIR_ROOT"
+
+REVIEW_CONTENT=$(cat "$R/.claude/skills/review/SKILL.md")
+if [ "$REVIEW_CONTENT" = "# カスタムレビュースキル" ]; then
+  pass "同名スキル(review)はユーザー版を保持"
+else
+  fail "同名スキル(review)はユーザー版を保持 (上書きされた)"
+fi
+
+# L2. ユーザー独自スキルも保持
+mkdir -p "$TMPDIR_ROOT/.claude/skills/my-deploy"
+echo "# デプロイスキル" > "$TMPDIR_ROOT/.claude/skills/my-deploy/SKILL.md"
+bash "$INSTALL_SH" --name test-proj 2>/dev/null
+assert_file_exists "ユーザー独自スキルが残る" "$R/.claude/skills/my-deploy/SKILL.md"
+assert_file_contains "ユーザー独自スキルの内容が保持" "$R/.claude/skills/my-deploy/SKILL.md" "デプロイスキル"
+
+# L3. lock にユーザー独自スキルが含まれない
+assert_file_not_contains "lock にユーザー独自スキルなし" "$R/.claude/vibecorp.lock" "my-deploy"
+
+cleanup
+
+# ============================================
+echo ""
+echo "=== M. lock ベース再インストール（管理ファイルのみ差し替え） ==="
+# ============================================
+
+# M1. vibecorp 管理フックは差し替えられる
+create_test_repo
+bash "$INSTALL_SH" --name test-proj 2>/dev/null
+R="$TMPDIR_ROOT"
+
+# protect-files.sh の内容を変更（古いバージョンを模擬）
+echo "# 古いバージョン" > "$R/.claude/hooks/protect-files.sh"
+# ユーザー独自フックを追加
+echo '#!/bin/bash' > "$R/.claude/hooks/sync-gate.sh"
+echo 'echo "ユーザー独自同期ゲート"' >> "$R/.claude/hooks/sync-gate.sh"
+
+# 再実行で管理ファイルは差し替え、ユーザーファイルは保持
+bash "$INSTALL_SH" --name test-proj 2>/dev/null
+
+assert_file_not_contains "管理フックが差し替え済み" "$R/.claude/hooks/protect-files.sh" "古いバージョン"
+assert_file_exists "ユーザー独自フック(sync-gate.sh)が残る" "$R/.claude/hooks/sync-gate.sh"
+assert_file_contains "ユーザー独自フックの内容が保持" "$R/.claude/hooks/sync-gate.sh" "ユーザー独自同期ゲート"
+
+# M2. vibecorp 管理スキルも差し替えられる
+echo "# 古いレビュー" > "$R/.claude/skills/review/SKILL.md"
+mkdir -p "$R/.claude/skills/my-custom"
+echo "# カスタム" > "$R/.claude/skills/my-custom/SKILL.md"
+
+bash "$INSTALL_SH" --name test-proj 2>/dev/null
+
+assert_file_not_contains "管理スキルが差し替え済み" "$R/.claude/skills/review/SKILL.md" "古いレビュー"
+assert_file_exists "ユーザー独自スキルが残る" "$R/.claude/skills/my-custom/SKILL.md"
+
+cleanup
+
+# ============================================
+echo ""
+echo "=== N. 同名ファイル初回移行（スキップ動作） ==="
+# ============================================
+
+# N1. 初回（lock なし）で同名フックが既存ならスキップ
+create_test_repo
+mkdir -p "$TMPDIR_ROOT/.claude/hooks"
+echo '#!/bin/bash' > "$TMPDIR_ROOT/.claude/hooks/protect-files.sh"
+echo 'echo "ユーザーカスタム版 protect-files"' >> "$TMPDIR_ROOT/.claude/hooks/protect-files.sh"
+
+bash "$INSTALL_SH" --name test-proj 2>/dev/null
+R="$TMPDIR_ROOT"
+
+assert_file_contains "初回で同名フックはスキップ（ユーザー版保持）" "$R/.claude/hooks/protect-files.sh" "ユーザーカスタム版 protect-files"
+
+# N2. 初回（lock なし）で同名スキルが既存ならスキップ
+cleanup
+create_test_repo
+mkdir -p "$TMPDIR_ROOT/.claude/skills/commit"
+echo "# ユーザーカスタム commit" > "$TMPDIR_ROOT/.claude/skills/commit/SKILL.md"
+
+bash "$INSTALL_SH" --name test-proj 2>/dev/null
+R="$TMPDIR_ROOT"
+
+COMMIT_CONTENT=$(cat "$R/.claude/skills/commit/SKILL.md")
+if [ "$COMMIT_CONTENT" = "# ユーザーカスタム commit" ]; then
+  pass "初回で同名スキルはスキップ（ユーザー版保持）"
+else
+  fail "初回で同名スキルはスキップ（ユーザー版保持） (上書きされた)"
+fi
+
+# N3. settings.json のユーザー独自フック参照も保持（lock なし初回）
+cleanup
+create_test_repo
+mkdir -p "$TMPDIR_ROOT/.claude"
+cat > "$TMPDIR_ROOT/.claude/settings.json" <<'JSON'
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/sync-gate.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+JSON
+
+bash "$INSTALL_SH" --name test-proj 2>/dev/null
+R="$TMPDIR_ROOT"
+
+assert_file_contains "初回でもユーザー独自フック参照が保持" "$R/.claude/settings.json" "sync-gate.sh"
+assert_file_contains "vibecorp フックも追加" "$R/.claude/settings.json" "protect-files.sh"
+
+cleanup
+
+# ============================================
+echo ""
 echo "=== 結果: $PASSED/$TOTAL passed, $FAILED failed ==="
 
 if [ "$FAILED" -gt 0 ]; then


### PR DESCRIPTION
## 概要

### 背景

既存プロジェクトへ vibecorp を導入する際、`install.sh` がテンプレート由来かユーザー独自かを区別できず、ユーザーが追加した hooks・skills を上書き・削除してしまう問題があった。

### Before / After

**Before**
- 再インストール時にテンプレート由来かどうかをパス文字列で判定していたため、ユーザーが追加したフック・スキルが削除される恐れがあった
- `generate_vibecorp_lock` がファイルコピー前に実行されるため、lock の内容と実態が一致しないケースがあった

**After**
- `vibecorp.lock` に記録されたファイル名のみを「vibecorp 管理ファイル」として扱い、それ以外はユーザー独自ファイルとして保持する
- `remove_managed_files` → `copy_managed_files` → `generate_vibecorp_lock` の順に実行し、lock が常にコピー後の実態を反映するようにした
- テンプレートに存在しないユーザー独自の hooks・skills は再インストール後も消えない

### テスト追加（K〜N セクション）

| セクション | 内容 |
|---|---|
| K | 既存フック保持（ユーザー独自フックと vibecorp フックの共存） |
| L | 既存スキル保持（ユーザー独自スキルの保持） |
| M | lock ベース再インストール（lock 記載ファイルのみ差し替え） |
| N | 同名ファイル初回移行（lock 未記載の同名ファイルをユーザー独自として保持） |

## Issue

close https://github.com/hirokimry/vibecorp/issues/25

## チェックリスト

- [x] テストが通ることを確認した
- [x] 既存の挙動に意図しない変化がないことを確認した

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * インストール時のファイル管理が改善され、ユーザーが作成したカスタムファイルが適切に保持されるようになりました
  * 再インストール時にシステム管理ファイルのみが更新される仕組みが実装されました
  * インストールプロセスの信頼性と安定性が向上しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->