### PR TITLE
📦 template: リポジトリ保護ルールセットの自動設定

### DIFF
--- a/setup-rulesets.sh
+++ b/setup-rulesets.sh
@@ -40,6 +40,13 @@ generate_ruleset_json() {
     "name": "vibecorp-protection",
     "target": "branch",
     "enforcement": "active",
+    "bypass_actors": [
+      {
+        "actor_id": 5,
+        "actor_type": "RepositoryRole",
+        "bypass_mode": "always"
+      }
+    ],
     "conditions": {
       "ref_name": {
         "include": ["~ALL"],

--- a/tests/test_setup_rulesets.sh
+++ b/tests/test_setup_rulesets.sh
@@ -186,7 +186,23 @@ else
   fail "integration_id が省略されている (integration_id が含まれている)"
 fi
 
-# C12. ルールセット名が vibecorp-protection
+# C12. bypass_actors に RepositoryRole (admin) が含まれる
+VALUE=$(echo "$RULESET_JSON" | jq -r '.bypass_actors[0].actor_type')
+if [ "$VALUE" = "RepositoryRole" ]; then
+  pass "bypass_actors に RepositoryRole が含まれる"
+else
+  fail "bypass_actors に RepositoryRole が含まれる (実際: $VALUE)"
+fi
+
+# C13. bypass_actors の actor_id が 5 (Admin)
+VALUE=$(echo "$RULESET_JSON" | jq -r '.bypass_actors[0].actor_id')
+if [ "$VALUE" = "5" ]; then
+  pass "bypass_actors の actor_id が 5 (Admin)"
+else
+  fail "bypass_actors の actor_id が 5 (Admin) (実際: $VALUE)"
+fi
+
+# C14. ルールセット名が vibecorp-protection
 VALUE=$(echo "$RULESET_JSON" | jq -r '.name')
 if [ "$VALUE" = "vibecorp-protection" ]; then
   pass "ルールセット名が vibecorp-protection"
@@ -194,7 +210,7 @@ else
   fail "ルールセット名が vibecorp-protection (実際: $VALUE)"
 fi
 
-# C13. JSON 全体が有効
+# C15. JSON 全体が有効
 if echo "$RULESET_JSON" | jq empty 2>/dev/null; then
   pass "JSON 全体が有効"
 else


### PR DESCRIPTION
## Summary

close https://github.com/hirokimry/vibecorp/issues/84

GitHub Rulesets API でリポジトリ保護を自動設定する `setup-rulesets.sh` を追加。

- 全ブランチ保護: PR レビュー1件承認 + CI (test + CodeRabbit) 必須
- admin バイパス: Repository Admin は直接 push 可能
- 冪等性: `vibecorp-protection` 名で管理（既存あれば更新）
- `--delete` オプションで削除可能
- integration_id 省略方式（リポジトリ固有値に依存しない）
- テスト19件追加（全 PASS）

## Test plan

- [x] テスト19件 PASS（引数パース、前提条件チェック、JSON構造検証、bypass_actors検証）
- [x] 既存テスト（test_install.sh 93件）に影響なし
- [x] 実際のルールセット作成・更新を手動確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * GitHubルールセット設定の自動セットアップ機能を追加しました。

* **テスト**
  * セットアップスクリプトの単体テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->