### PR TITLE
📦 template: role-gate.sh テンプレート

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -310,10 +310,14 @@ copy_managed_files() {
     minimal)
       rm -f "${hooks_dir}/review-to-rules-gate.sh"
       rm -f "${hooks_dir}/sync-gate.sh"
+      rm -f "${hooks_dir}/role-gate.sh"
       rm -rf "${skills_dir}/review-to-rules"
       rm -rf "${skills_dir}/sync-check"
       rm -rf "${skills_dir}/sync-edit"
       rm -rf "${agents_dir}"
+      ;;
+    standard)
+      rm -f "${hooks_dir}/role-gate.sh"
       ;;
   esac
 
@@ -615,7 +619,16 @@ generate_settings_json() {
       new_settings=$(echo "$new_settings" | jq '
         .hooks.PreToolUse |= [
           .[]
-          | .hooks |= [.[] | select((.command | contains("review-to-rules-gate") | not) and (.command | contains("sync-gate") | not))]
+          | .hooks |= [.[] | select((.command | contains("review-to-rules-gate") | not) and (.command | contains("sync-gate") | not) and (.command | contains("role-gate") | not))]
+          | select((.hooks | length) > 0)
+        ]
+      ')
+      ;;
+    standard)
+      new_settings=$(echo "$new_settings" | jq '
+        .hooks.PreToolUse |= [
+          .[]
+          | .hooks |= [.[] | select(.command | contains("role-gate") | not)]
           | select((.hooks | length) > 0)
         ]
       ')

--- a/templates/claude/hooks/role-gate.sh
+++ b/templates/claude/hooks/role-gate.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# role-gate.sh — エージェントが管轄外のファイルを編集することをブロックするフック
+# ロールファイル(/tmp/.{{PROJECT_NAME}}-agent-role)にロール名が書かれている場合のみ動作
+# ロールファイルが存在しなければスキップ（通常セッション＝人間操作時は制約なし）
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# vibecorp.yml からプロジェクト名を取得
+VIBECORP_YML="${CLAUDE_PROJECT_DIR:-.}/.claude/vibecorp.yml"
+PROJECT_NAME="vibecorp-project"
+if [ -f "$VIBECORP_YML" ]; then
+  RAW_NAME=$(awk '/^name:[[:space:]]*/ { sub(/^name:[[:space:]]*/, ""); sub(/[[:space:]]*$/, ""); print; exit }' "$VIBECORP_YML")
+  if [ -n "${RAW_NAME:-}" ]; then
+    PROJECT_NAME=$(printf '%s' "$RAW_NAME" | tr -cs 'A-Za-z0-9._-' '_')
+  fi
+fi
+
+# ロールファイルからロール名を読み取る
+ROLE_FILE="/tmp/.${PROJECT_NAME}-agent-role"
+if [ ! -f "$ROLE_FILE" ]; then
+  exit 0
+fi
+
+ROLE=$(cat "$ROLE_FILE" | tr -d '[:space:]')
+if [ -z "$ROLE" ]; then
+  exit 0
+fi
+
+# knowledge/ 配下は全ロール編集可
+if [[ "$FILE_PATH" == */knowledge/* ]] || [[ "$FILE_PATH" == knowledge/* ]]; then
+  exit 0
+fi
+
+# docs/ 配下以外はチェック対象外（許可）
+IS_DOCS=false
+if [[ "$FILE_PATH" == */docs/* ]] || [[ "$FILE_PATH" == docs/* ]]; then
+  IS_DOCS=true
+fi
+
+if [ "$IS_DOCS" = false ]; then
+  exit 0
+fi
+
+# 管轄マッピング: ロール → 編集可能なファイルパターン（docs/ 配下のみ）
+is_allowed() {
+  local role="$1"
+  local path="$2"
+
+  case "$role" in
+    cpo)
+      [[ "$path" == *docs/specification.md ]] && return 0
+      [[ "$path" == *docs/screen-flow.md ]] && return 0
+      [[ "$path" == *docs/ai-prompt-design.md ]] && return 0
+      ;;
+    cto)
+      [[ "$path" == *docs/specification.md ]] && return 0
+      ;;
+    legal)
+      [[ "$path" == *docs/POLICY.md ]] && return 0
+      ;;
+    accounting)
+      [[ "$path" == *docs/cost-analysis.md ]] && return 0
+      ;;
+    security)
+      [[ "$path" == *docs/SECURITY.md ]] && return 0
+      ;;
+    # coo は分析専用ロール — docs/ 配下の編集権限なし
+    # 未知のロールも docs/ 配下はブロック
+  esac
+
+  return 1
+}
+
+if is_allowed "$ROLE" "$FILE_PATH"; then
+  exit 0
+fi
+
+# 管轄外 → deny
+jq -n --arg role "$ROLE" --arg file "$FILE_PATH" '{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": ("ロール [" + $role + "] は " + $file + " の編集権限がありません。管轄外のファイルは編集できません。")
+  }
+}'
+exit 0

--- a/templates/settings.json.tpl
+++ b/templates/settings.json.tpl
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/protect-files.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/role-gate.sh"
           }
         ]
       },

--- a/tests/test_role_gate.sh
+++ b/tests/test_role_gate.sh
@@ -1,0 +1,374 @@
+#!/bin/bash
+# test_role_gate.sh — role-gate.sh のユニットテスト
+# 使い方: bash tests/test_role_gate.sh
+
+set -euo pipefail
+
+HOOKS_DIR="$(cd "$(dirname "$0")/../templates/claude/hooks" && pwd)"
+PASSED=0
+FAILED=0
+TOTAL=0
+TMPDIR_ROOT=""
+
+# --- ヘルパー ---
+
+pass() {
+  PASSED=$((PASSED + 1))
+  TOTAL=$((TOTAL + 1))
+  echo "  PASS: $1"
+}
+
+fail() {
+  FAILED=$((FAILED + 1))
+  TOTAL=$((TOTAL + 1))
+  echo "  FAIL: $1"
+}
+
+assert_blocked() {
+  local desc="$1"
+  local output="$2"
+  if echo "$output" | grep -q '"permissionDecision": "deny"'; then
+    pass "$desc"
+  else
+    fail "$desc (期待: deny, 実際: allow)"
+  fi
+}
+
+assert_allowed() {
+  local desc="$1"
+  local output="$2"
+  if echo "$output" | grep -q '"permissionDecision": "deny"'; then
+    fail "$desc (期待: allow, 実際: deny)"
+  else
+    pass "$desc"
+  fi
+}
+
+run_hook() {
+  bash "$HOOKS_DIR/$1"
+}
+
+# --- セットアップ / クリーンアップ ---
+
+setup_project_dir() {
+  TMPDIR_ROOT=$(mktemp -d)
+  mkdir -p "${TMPDIR_ROOT}/.claude"
+  export CLAUDE_PROJECT_DIR="$TMPDIR_ROOT"
+}
+
+write_vibecorp_yml() {
+  cat > "${TMPDIR_ROOT}/.claude/vibecorp.yml" <<'YAML'
+name: test-project
+preset: full
+language: ja
+base_branch: main
+YAML
+}
+
+write_role_file() {
+  local role="$1"
+  echo "$role" > "/tmp/.test-project-agent-role"
+}
+
+cleanup() {
+  if [ -n "$TMPDIR_ROOT" ] && [ -d "$TMPDIR_ROOT" ]; then
+    rm -rf "$TMPDIR_ROOT"
+  fi
+  rm -f /tmp/.test-project-agent-role
+  rm -f /tmp/.vibecorp-project-agent-role
+  rm -f /tmp/.my-project-agent-role
+  # サニタイズ名のクリーンアップ
+  local sanitized
+  sanitized=$(printf '%s' "hello world!@#" | tr -cs 'A-Za-z0-9._-' '_')
+  rm -f "/tmp/.${sanitized}-agent-role"
+}
+trap cleanup EXIT
+
+# ============================================
+echo "=== role-gate.sh ==="
+# ============================================
+
+setup_project_dir
+write_vibecorp_yml
+
+# --- CPO ロール ---
+echo ""
+echo "--- CPO ロール ---"
+
+write_role_file "cpo"
+
+# 1. CPO が管轄内(docs/specification.md)を編集 → 許可
+OUTPUT=$(echo '{"tool_input":{"file_path":"docs/specification.md"}}' | run_hook role-gate.sh)
+assert_allowed "CPO が docs/specification.md を編集 → 許可" "$OUTPUT"
+
+# 2. CPO が管轄内(docs/screen-flow.md)を編集 → 許可
+OUTPUT=$(echo '{"tool_input":{"file_path":"docs/screen-flow.md"}}' | run_hook role-gate.sh)
+assert_allowed "CPO が docs/screen-flow.md を編集 → 許可" "$OUTPUT"
+
+# 3. CPO が管轄内(docs/ai-prompt-design.md)を編集 → 許可
+OUTPUT=$(echo '{"tool_input":{"file_path":"docs/ai-prompt-design.md"}}' | run_hook role-gate.sh)
+assert_allowed "CPO が docs/ai-prompt-design.md を編集 → 許可" "$OUTPUT"
+
+# 4. CPO が管轄外(docs/SECURITY.md)を編集 → deny
+OUTPUT=$(echo '{"tool_input":{"file_path":"docs/SECURITY.md"}}' | run_hook role-gate.sh)
+assert_blocked "CPO が docs/SECURITY.md を編集 → deny" "$OUTPUT"
+
+# 5. CPO が管轄外(docs/POLICY.md)を編集 → deny
+OUTPUT=$(echo '{"tool_input":{"file_path":"docs/POLICY.md"}}' | run_hook role-gate.sh)
+assert_blocked "CPO が docs/POLICY.md を編集 → deny" "$OUTPUT"
+
+# --- CTO ロール ---
+echo ""
+echo "--- CTO ロール ---"
+
+write_role_file "cto"
+
+# 6. CTO が管轄内(docs/specification.md)を編集 → 許可
+OUTPUT=$(echo '{"tool_input":{"file_path":"docs/specification.md"}}' | run_hook role-gate.sh)
+assert_allowed "CTO が docs/specification.md を編集 → 許可" "$OUTPUT"
+
+# 7. CTO が管轄外(docs/screen-flow.md)を編集 → deny
+OUTPUT=$(echo '{"tool_input":{"file_path":"docs/screen-flow.md"}}' | run_hook role-gate.sh)
+assert_blocked "CTO が docs/screen-flow.md を編集 → deny" "$OUTPUT"
+
+# --- legal ロール ---
+echo ""
+echo "--- legal ロール ---"
+
+write_role_file "legal"
+
+# 8. legal が管轄内(docs/POLICY.md)を編集 → 許可
+OUTPUT=$(echo '{"tool_input":{"file_path":"docs/POLICY.md"}}' | run_hook role-gate.sh)
+assert_allowed "legal が docs/POLICY.md を編集 → 許可" "$OUTPUT"
+
+# 9. legal が管轄外(docs/specification.md)を編集 → deny
+OUTPUT=$(echo '{"tool_input":{"file_path":"docs/specification.md"}}' | run_hook role-gate.sh)
+assert_blocked "legal が docs/specification.md を編集 → deny" "$OUTPUT"
+
+# --- accounting ロール ---
+echo ""
+echo "--- accounting ロール ---"
+
+write_role_file "accounting"
+
+# 10. accounting が管轄内(docs/cost-analysis.md)を編集 → 許可
+OUTPUT=$(echo '{"tool_input":{"file_path":"docs/cost-analysis.md"}}' | run_hook role-gate.sh)
+assert_allowed "accounting が docs/cost-analysis.md を編集 → 許可" "$OUTPUT"
+
+# 11. accounting が管轄外(docs/SECURITY.md)を編集 → deny
+OUTPUT=$(echo '{"tool_input":{"file_path":"docs/SECURITY.md"}}' | run_hook role-gate.sh)
+assert_blocked "accounting が docs/SECURITY.md を編集 → deny" "$OUTPUT"
+
+# --- security ロール ---
+echo ""
+echo "--- security ロール ---"
+
+write_role_file "security"
+
+# 12. security が管轄内(docs/SECURITY.md)を編集 → 許可
+OUTPUT=$(echo '{"tool_input":{"file_path":"docs/SECURITY.md"}}' | run_hook role-gate.sh)
+assert_allowed "security が docs/SECURITY.md を編集 → 許可" "$OUTPUT"
+
+# 13. security が管轄外(docs/cost-analysis.md)を編集 → deny
+OUTPUT=$(echo '{"tool_input":{"file_path":"docs/cost-analysis.md"}}' | run_hook role-gate.sh)
+assert_blocked "security が docs/cost-analysis.md を編集 → deny" "$OUTPUT"
+
+# --- COO ロール（分析専用、docs/ 編集権限なし） ---
+echo ""
+echo "--- COO ロール ---"
+
+write_role_file "coo"
+
+# 14. COO が docs/ 配下を編集 → deny
+OUTPUT=$(echo '{"tool_input":{"file_path":"docs/specification.md"}}' | run_hook role-gate.sh)
+assert_blocked "COO が docs/specification.md を編集 → deny" "$OUTPUT"
+
+# --- knowledge/ 配下 ---
+echo ""
+echo "--- knowledge/ 配下 ---"
+
+write_role_file "cpo"
+
+# 15. knowledge/ 配下は全ロール編集可
+OUTPUT=$(echo '{"tool_input":{"file_path":"knowledge/cpo/decisions.md"}}' | run_hook role-gate.sh)
+assert_allowed "CPO が knowledge/ 配下を編集 → 許可" "$OUTPUT"
+
+write_role_file "cto"
+
+# 16. CTO が knowledge/ 配下を編集 → 許可
+OUTPUT=$(echo '{"tool_input":{"file_path":"knowledge/cto/tech-principles.md"}}' | run_hook role-gate.sh)
+assert_allowed "CTO が knowledge/ 配下を編集 → 許可" "$OUTPUT"
+
+write_role_file "coo"
+
+# 17. COO が knowledge/ 配下を編集 → 許可
+OUTPUT=$(echo '{"tool_input":{"file_path":"knowledge/coo/notes.md"}}' | run_hook role-gate.sh)
+assert_allowed "COO が knowledge/ 配下を編集 → 許可" "$OUTPUT"
+
+# --- docs/ 外のファイル ---
+echo ""
+echo "--- docs/ 外のファイル ---"
+
+write_role_file "cpo"
+
+# 18. docs/ 外(README.md)はチェック対象外 → 許可
+OUTPUT=$(echo '{"tool_input":{"file_path":"README.md"}}' | run_hook role-gate.sh)
+assert_allowed "docs/ 外のファイル(README.md) → 許可" "$OUTPUT"
+
+# 19. docs/ 外(install.sh)はチェック対象外 → 許可
+OUTPUT=$(echo '{"tool_input":{"file_path":"install.sh"}}' | run_hook role-gate.sh)
+assert_allowed "docs/ 外のファイル(install.sh) → 許可" "$OUTPUT"
+
+# --- ロールファイル未設定 ---
+echo ""
+echo "--- ロールファイル未設定 ---"
+
+rm -f /tmp/.test-project-agent-role
+
+# 20. ロールファイルなし → 許可（通常セッション）
+OUTPUT=$(echo '{"tool_input":{"file_path":"docs/SECURITY.md"}}' | run_hook role-gate.sh)
+assert_allowed "ロールファイル未設定 → 許可" "$OUTPUT"
+
+# --- ロールファイル空 ---
+echo ""
+echo "--- ロールファイル空 ---"
+
+echo "" > /tmp/.test-project-agent-role
+
+# 21. ロールファイルが空 → 許可
+OUTPUT=$(echo '{"tool_input":{"file_path":"docs/SECURITY.md"}}' | run_hook role-gate.sh)
+assert_allowed "ロールファイルが空 → 許可" "$OUTPUT"
+
+# --- 未知のロール ---
+echo ""
+echo "--- 未知のロール ---"
+
+write_role_file "unknown_role"
+
+# 22. 未知のロール → docs/ 配下はブロック
+OUTPUT=$(echo '{"tool_input":{"file_path":"docs/specification.md"}}' | run_hook role-gate.sh)
+assert_blocked "未知のロール → docs/ 配下はブロック" "$OUTPUT"
+
+# 23. 未知のロール → knowledge/ 配下は許可
+OUTPUT=$(echo '{"tool_input":{"file_path":"knowledge/test.md"}}' | run_hook role-gate.sh)
+assert_allowed "未知のロール → knowledge/ 配下は許可" "$OUTPUT"
+
+# 24. 未知のロール → docs/ 外は許可
+OUTPUT=$(echo '{"tool_input":{"file_path":"install.sh"}}' | run_hook role-gate.sh)
+assert_allowed "未知のロール → docs/ 外は許可" "$OUTPUT"
+
+# --- 深いパス ---
+echo ""
+echo "--- 深いパスでのマッチ ---"
+
+write_role_file "security"
+
+# 25. 絶対パスでの docs/ マッチ → 管轄内は許可
+OUTPUT=$(echo '{"tool_input":{"file_path":"/home/user/project/docs/SECURITY.md"}}' | run_hook role-gate.sh)
+assert_allowed "絶対パスでの管轄内ファイル → 許可" "$OUTPUT"
+
+# 26. 絶対パスでの docs/ マッチ → 管轄外はブロック
+OUTPUT=$(echo '{"tool_input":{"file_path":"/home/user/project/docs/specification.md"}}' | run_hook role-gate.sh)
+assert_blocked "絶対パスでの管轄外ファイル → deny" "$OUTPUT"
+
+# --- file_path が空 / キー欠落 ---
+echo ""
+echo "--- file_path 異常値 ---"
+
+write_role_file "cpo"
+
+# 27. file_path が空 → 許可
+OUTPUT=$(echo '{"tool_input":{"file_path":""}}' | run_hook role-gate.sh)
+assert_allowed "file_path が空 → 許可" "$OUTPUT"
+
+# 28. file_path キー欠落 → 許可
+OUTPUT=$(echo '{"tool_input":{"other_key":"value"}}' | run_hook role-gate.sh)
+assert_allowed "file_path キー欠落 → 許可" "$OUTPUT"
+
+# --- deny 出力の JSON 構造検証 ---
+echo ""
+echo "--- JSON 構造検証 ---"
+
+write_role_file "cpo"
+
+# 29. deny 出力の JSON 構造検証
+OUTPUT=$(echo '{"tool_input":{"file_path":"docs/SECURITY.md"}}' | run_hook role-gate.sh)
+VALID=true
+echo "$OUTPUT" | jq -e '.hookSpecificOutput.hookEventName' >/dev/null 2>&1 || VALID=false
+echo "$OUTPUT" | jq -e '.hookSpecificOutput.permissionDecision' >/dev/null 2>&1 || VALID=false
+echo "$OUTPUT" | jq -e '.hookSpecificOutput.permissionDecisionReason' >/dev/null 2>&1 || VALID=false
+if [ "$VALID" = true ]; then
+  pass "deny 出力の JSON 構造検証"
+else
+  fail "deny 出力の JSON 構造検証 (hookEventName/permissionDecision/permissionDecisionReason が不足)"
+fi
+
+# 30. deny メッセージにロール名が含まれる
+REASON=$(echo "$OUTPUT" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+if echo "$REASON" | grep -q "cpo"; then
+  pass "deny メッセージにロール名が含まれる"
+else
+  fail "deny メッセージにロール名が含まれる (実際: $REASON)"
+fi
+
+# --- vibecorp.yml がない場合 ---
+echo ""
+echo "--- vibecorp.yml 異常系 ---"
+
+# 31. vibecorp.yml なし → デフォルト名でロールファイル参照
+mv "${TMPDIR_ROOT}/.claude/vibecorp.yml" "${TMPDIR_ROOT}/.claude/vibecorp.yml.bak"
+echo "cpo" > /tmp/.vibecorp-project-agent-role
+OUTPUT=$(echo '{"tool_input":{"file_path":"docs/SECURITY.md"}}' | run_hook role-gate.sh)
+assert_blocked "vibecorp.yml なし → デフォルト名で deny" "$OUTPUT"
+rm -f /tmp/.vibecorp-project-agent-role
+mv "${TMPDIR_ROOT}/.claude/vibecorp.yml.bak" "${TMPDIR_ROOT}/.claude/vibecorp.yml"
+
+# 32. vibecorp.yml からプロジェクト名取得
+cat > "${TMPDIR_ROOT}/.claude/vibecorp.yml" <<'YAML'
+name: my-project
+preset: full
+YAML
+echo "cpo" > /tmp/.my-project-agent-role
+OUTPUT=$(echo '{"tool_input":{"file_path":"docs/SECURITY.md"}}' | run_hook role-gate.sh)
+assert_blocked "vibecorp.yml からプロジェクト名取得 → ロールファイル名一致" "$OUTPUT"
+rm -f /tmp/.my-project-agent-role
+
+# 33. プロジェクト名のサニタイズ
+cat > "${TMPDIR_ROOT}/.claude/vibecorp.yml" <<'YAML'
+name: hello world!@#
+preset: full
+YAML
+SANITIZED_NAME=$(printf '%s' "hello world!@#" | tr -cs 'A-Za-z0-9._-' '_')
+echo "cpo" > "/tmp/.${SANITIZED_NAME}-agent-role"
+OUTPUT=$(echo '{"tool_input":{"file_path":"docs/SECURITY.md"}}' | run_hook role-gate.sh)
+assert_blocked "プロジェクト名のサニタイズ → ロールファイル名に不正文字なし" "$OUTPUT"
+rm -f "/tmp/.${SANITIZED_NAME}-agent-role"
+
+# --- CLAUDE_PROJECT_DIR 未設定 ---
+echo ""
+echo "--- CLAUDE_PROJECT_DIR 未設定 ---"
+
+# 34. CLAUDE_PROJECT_DIR 未設定時に異常終了しない
+unset CLAUDE_PROJECT_DIR
+rm -f /tmp/.vibecorp-project-agent-role
+EMPTY_DIR=$(mktemp -d)
+set +e
+OUTPUT=$(cd "$EMPTY_DIR" && echo '{"tool_input":{"file_path":"docs/SECURITY.md"}}' | run_hook role-gate.sh 2>/dev/null)
+EXIT_CODE=$?
+set -e
+rm -rf "$EMPTY_DIR"
+if [ "$EXIT_CODE" = "0" ]; then
+  pass "CLAUDE_PROJECT_DIR 未設定時に異常終了しない"
+else
+  fail "CLAUDE_PROJECT_DIR 未設定時に異常終了しない (exit $EXIT_CODE)"
+fi
+assert_allowed "CLAUDE_PROJECT_DIR 未設定 → 許可（ロールファイルなし）" "$OUTPUT"
+export CLAUDE_PROJECT_DIR="$TMPDIR_ROOT"
+
+# ============================================
+echo ""
+echo "=== 結果: $PASSED/$TOTAL passed, $FAILED failed ==="
+
+if [ "$FAILED" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## 概要

エージェントが管轄外のファイルを編集することをブロックする `role-gate.sh` フックテンプレートを追加。

close https://github.com/hirokimry/vibecorp/issues/20

## 変更内容

- `templates/claude/hooks/role-gate.sh` — 新規作成
  - `/tmp/.{{PROJECT_NAME}}-agent-role` からロール名を読み取り、管轄マッピングに基づいてアクセス制御
  - `knowledge/` 配下は全ロール編集可
  - `docs/` 配下は管轄ファイルのみ編集可
  - ロールファイル未設定時はスキップ（通常セッションに影響なし）
- `templates/settings.json.tpl` — `Edit|Write` matcher にフックエントリ追加
- `install.sh` — minimal/standard プリセットでの除外ロジック追加
- `tests/test_role_gate.sh` — 35件のユニットテスト

## 管轄マッピング

| ロール | 管轄ファイル |
|--------|-------------|
| cpo | `docs/specification.md`, `docs/screen-flow.md`, `docs/ai-prompt-design.md` |
| cto | `docs/specification.md` |
| legal | `docs/POLICY.md` |
| accounting | `docs/cost-analysis.md` |
| security | `docs/SECURITY.md` |
| coo | なし（分析専用） |

## テスト結果

- `test_role_gate.sh`: 35/35 passed
- `test_hooks.sh`: 67/67 passed（既存テスト回帰なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ロールベースのアクセス制御機能が導入されました。プロジェクトロール設定に基づいて、`docs/`ディレクトリ内のファイル編集をロール別に制御できるようになります。編集前の権限検証が自動的に行われます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->