### PR TITLE
🐛 fix: coo/organization.md の管轄パスに分析員チームの knowledge ディレクトリを追加

### DIFF
--- a/templates/claude/knowledge/coo/organization.md
+++ b/templates/claude/knowledge/coo/organization.md
@@ -26,9 +26,9 @@ AI組織構成は `docs/ai-organization.md` を参照すること。
 | CTO | .claude/knowledge/cto/, .claude/rules/ |
 | CPO | .claude/knowledge/cpo/, docs/specification.md |
 | COO | .claude/knowledge/coo/, docs/ai-organization.md |
-| CFO | .claude/knowledge/cfo/, docs/cost-analysis.md |
-| CLO | .claude/knowledge/clo/, docs/POLICY.md |
-| CISO | .claude/knowledge/ciso/, docs/SECURITY.md |
+| CFO | .claude/knowledge/cfo/, .claude/knowledge/accounting/, docs/cost-analysis.md |
+| CLO | .claude/knowledge/clo/, .claude/knowledge/legal/, docs/POLICY.md |
+| CISO | .claude/knowledge/ciso/, .claude/knowledge/security/, docs/SECURITY.md |
 
 ## ナレッジ配置場所
 


### PR DESCRIPTION
close https://github.com/hirokimry/vibecorp/issues/144

## Summary

- CFO/CLO/CISO の管轄ファイルマッピングに分析員チームの knowledge ディレクトリを追加
- 並列 ship (#19, #22, #23) で生じた整合性ずれの修正

## 変更内容

`templates/claude/knowledge/coo/organization.md` の管轄パスを修正:

| エージェント | 修正前 | 修正後 |
|---|---|---|
| CFO | `knowledge/cfo/` | `knowledge/cfo/`, `knowledge/accounting/` |
| CLO | `knowledge/clo/` | `knowledge/clo/`, `knowledge/legal/` |
| CISO | `knowledge/ciso/` | `knowledge/ciso/`, `knowledge/security/` |

## Test plan

- [x] 管轄パスが実際の knowledge テンプレートディレクトリと一致すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * CFO、CLO、CISO 各ロールが利用可能なナレッジベースを拡充しました。各ロールの既存の情報アクセスを維持しながら、新たな関連資料へのアクセスを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->