### PR TITLE
🐛 fix: release.yml のタグ既存時・変更なし時のエラーハンドリング

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,14 +210,34 @@ jobs:
             } > CHANGELOG.md
           fi
 
+          # ── タグが既に存在する場合はスキップ ────────────
+          if git tag -l | grep -qF "${NEW_TAG}"; then
+            echo "タグ ${NEW_TAG} は既に存在します"
+            # GitHub Release が未作成なら作成
+            if ! gh release view "${NEW_TAG}" > /dev/null 2>&1; then
+              echo "GitHub Release を作成します"
+              RELEASE_NOTES=$(printf '%s' "$CHANGELOG_ENTRY")
+              gh release create "${NEW_TAG}" \
+                --title "v${NEW_VERSION}" \
+                --notes "$RELEASE_NOTES"
+              echo "リリース完了: ${NEW_TAG}"
+            else
+              echo "GitHub Release も既に存在するためスキップ"
+            fi
+            exit 0
+          fi
+
           # ── コミット・タグ・push ────────────────────
           git add install.sh CHANGELOG.md
-          git commit -m "chore(release): v${NEW_VERSION}"
+          if git diff --cached --quiet; then
+            echo "変更がないためコミットをスキップ"
+          else
+            git commit -m "chore(release): v${NEW_VERSION}"
+          fi
           git tag -a "${NEW_TAG}" -m "リリース v${NEW_VERSION}"
           git push origin main --follow-tags
 
           # ── GitHub Release 作成 ──────────────────────
-          # CHANGELOG エントリからリリースノートを生成
           RELEASE_NOTES=$(printf '%s' "$CHANGELOG_ENTRY")
           gh release create "${NEW_TAG}" \
             --title "v${NEW_VERSION}" \


### PR DESCRIPTION
## Summary
- タグが既に存在する場合は GitHub Release のみ作成してスキップ
- `git commit` 前に変更有無を確認し、変更なしならスキップ
- v0.1.0 タグ push 時に release.yml が `nothing to commit` で失敗した問題を修正

## Test plan
- [x] タグ既存時のフロー分岐を追加
- [x] `git diff --cached --quiet` で変更なし判定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * リリースワークフローの効率化：重複タグの検出時の処理を改善し、ステージされた変更がない場合のコミット作成をスキップするようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->