### PR TITLE
🐛 fix: --update 時に git fetch --tags を実行してバージョン情報を最新化

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,19 @@ log_conflict() { printf '\033[35m[CONFLICT]\033[0m %s\n' "$*" >&2; }
 # コンフリクトが発生したファイルを追跡
 CONFLICT_FILES=""
 
+fetch_latest_tags() {
+  # リモートから最新のタグ情報を取得する（--update モード用）
+  # fetch 失敗時（オフライン等）はローカルのタグで続行し、エラーで止めない
+  if git -C "$SCRIPT_DIR" fetch --tags --quiet 2>/dev/null; then
+    log_info "リモートから最新のタグ情報を取得しました"
+  else
+    log_info "タグの取得に失敗しました。ローカルのタグ情報で続行します"
+  fi
+  # fetch 後にバージョンを再取得して最新化
+  VIBECORP_VERSION=$(git -C "$SCRIPT_DIR" describe --tags --abbrev=0 2>/dev/null || echo "0.0.0-dev")
+  VIBECORP_VERSION="${VIBECORP_VERSION#v}"
+}
+
 usage() {
   local exit_code="${1:-1}"
   cat >&2 <<'USAGE'
@@ -1375,6 +1388,7 @@ main() {
   trap 'restore_original_ref' EXIT
 
   if [[ "$UPDATE_MODE" == true ]]; then
+    fetch_latest_tags
     read_vibecorp_yml
     show_version_diff
   fi

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -2144,6 +2144,51 @@ cleanup
 
 # ============================================
 echo ""
+echo "=== AE. --update 時の fetch --tags 実行 ==="
+# ============================================
+
+# AE1. --update 時に git fetch --tags のログが出力される
+create_test_repo
+bash "$INSTALL_SH" --name test-proj 2>/dev/null
+R="$TMPDIR_ROOT"
+
+STDERR_OUTPUT=$(bash "$INSTALL_SH" --update 2>&1 >/dev/null) || true
+if echo "$STDERR_OUTPUT" | grep -q "タグ"; then
+  pass "AE1: --update 時にタグ取得のログが出力される"
+else
+  fail "AE1: --update 時にタグ取得のログが出力される (ログ: ${STDERR_OUTPUT})"
+fi
+cleanup
+
+# AE2. fetch 失敗時（リモートなし）でもエラーで停止しない
+create_test_repo
+bash "$INSTALL_SH" --name test-proj 2>/dev/null
+R="$TMPDIR_ROOT"
+
+# リモートが設定されていないリポジトリで --update を実行
+# fetch は失敗するがフォールバックで続行する
+EXIT_CODE=0; bash "$INSTALL_SH" --update 2>/dev/null || EXIT_CODE=$?
+assert_exit_code "AE2: fetch 失敗時でもエラーで停止しない" "0" "$EXIT_CODE"
+cleanup
+
+# AE3. fetch 後に VIBECORP_VERSION が lock に正しく記録される
+create_test_repo
+bash "$INSTALL_SH" --name test-proj 2>/dev/null
+R="$TMPDIR_ROOT"
+
+bash "$INSTALL_SH" --update 2>/dev/null
+LOCK_VERSION=$(awk '/^version:/ { print $2 }' "$R/.claude/vibecorp.lock")
+EXPECTED_VERSION=$(git -C "$(dirname "$INSTALL_SH")" describe --tags --abbrev=0 2>/dev/null || echo "0.0.0-dev")
+EXPECTED_VERSION="${EXPECTED_VERSION#v}"
+if [ "$LOCK_VERSION" = "$EXPECTED_VERSION" ]; then
+  pass "AE3: fetch 後の VIBECORP_VERSION が lock に正しく記録される"
+else
+  fail "AE3: fetch 後の VIBECORP_VERSION が lock に正しく記録される (lock: ${LOCK_VERSION}, expected: ${EXPECTED_VERSION})"
+fi
+cleanup
+
+# ============================================
+echo ""
 echo "=== 結果: $PASSED/$TOTAL passed, $FAILED failed ==="
 
 if [ "$FAILED" -gt 0 ]; then


### PR DESCRIPTION
close https://github.com/hirokimry/vibecorp/issues/168

## Summary
- `install.sh --update` の処理冒頭で `git fetch --tags --quiet` を実行し、リモートの最新タグを取得
- fetch 失敗時（オフライン等）はローカルのタグで続行するフォールバック処理
- fetch 後に `VIBECORP_VERSION` を `git describe --tags` で再取得して最新化
- テスト3件追加（AE1〜AE3）

## Test plan
- [x] 全298テスト通過確認済み
- [x] AE1: `--update` 時にタグ取得のログが出力される
- [x] AE2: fetch 失敗時（リモートなし）でもエラーで停止しない
- [x] AE3: fetch 後の VIBECORP_VERSION が lock に正しく記録される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * `--update` オプション実行時に、Git タグから最新バージョン情報を自動取得するようになりました。
  * タグ取得に失敗した場合でも、インストール処理は継続されます。

* **テスト**
  * `--update` 実行時のバージョン同期動作に関するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->