### PR TITLE
🐛 fix: sync-check の README.md 管轄を CTO → CPO に変更

### DIFF
--- a/templates/claude/skills/sync-check/SKILL.md
+++ b/templates/claude/skills/sync-check/SKILL.md
@@ -42,8 +42,8 @@ git diff --name-only
 
 | エージェント | 管轄ファイル | 起動条件 |
 |-------------|------------|---------|
-| CTO | `docs/` 内の技術設計ドキュメント、`knowledge/cto/`、`README.md` | アーキテクチャ・技術設計・エージェント定義・hooks・スキル・README 関連の変更 |
-| CPO | `docs/specification.md`、`knowledge/cpo/` | 仕様・UI・プロンプト関連の変更 |
+| CTO | `docs/` 内の技術設計ドキュメント、`knowledge/cto/` | アーキテクチャ・技術設計・エージェント定義・hooks・スキル関連の変更 |
+| CPO | `docs/specification.md`、`knowledge/cpo/`、`README.md` | 仕様・UI・プロンプト・スキル・フック・エージェント・README 関連の変更 |
 
 **拡張時（上記に加えて追加可能）:**
 
@@ -69,8 +69,8 @@ git diff --name-only
 ## チェック観点
 - 矛盾: コード変更がドキュメントの記載と食い違っていないか
 - 更新漏れ: ドキュメントに反映すべき変更が漏れていないか
-- README 乖離（CTO）: 実装と README の記載に乖離がないか
-- README 未反映（CTO）: 新しいスキル・フック・エージェントが追加されたのに README に未反映でないか
+- README 乖離（CPO）: 実装と README の記載に乖離がないか
+- README 未反映（CPO）: 新しいスキル・フック・エージェントが追加されたのに README に未反映でないか
 - POLICY.md 違反（法務のみ）: MUST/MUST NOT 制約に抵触していないか
 
 ## 制約

--- a/tests/test_sync_check_skill.sh
+++ b/tests/test_sync_check_skill.sh
@@ -35,6 +35,16 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local desc="$1"
+  local pattern="$2"
+  if grep -q "$pattern" "$SKILL_MD"; then
+    fail "$desc (パターンが検出された: $pattern)"
+  else
+    pass "$desc"
+  fi
+}
+
 # ============================================
 echo "=== sync-check SKILL.md 構造テスト ==="
 # ============================================
@@ -55,24 +65,27 @@ assert_contains "description に README.md が含まれる" "README.md"
 assert_contains "対象外判定に docs/ や knowledge/ や README.md が含まれる" \
   "docs/.*knowledge/.*README.md.*のみの変更"
 
-# 4. CTO 管轄テーブルに README.md が含まれる
-assert_contains "CTO 管轄テーブルに README.md が含まれる" \
+# 4. CPO 管轄テーブルに README.md が含まれる
+assert_contains "CPO 管轄テーブルに README.md が含まれる" \
+  "| CPO.*README.md"
+
+# 5. CTO 管轄テーブルに README.md が含まれない
+assert_not_contains "CTO 管轄テーブルに README.md が含まれない" \
   "| CTO.*README.md"
 
-# 5. CTO 起動条件に README が含まれる
-assert_contains "CTO 起動条件に README が含まれる" \
-  "README 関連の変更"
+# 6. CPO 起動条件に README が含まれる
+assert_contains "CPO 起動条件に README 関連の変更が含まれる" \
+  "| CPO.*README 関連の変更"
 
-# 6. チェック観点に README 乖離が含まれる
-assert_contains "チェック観点に README 乖離が含まれる" \
-  "README 乖離.*実装と README の記載に乖離がないか"
+# 7. チェック観点に README 乖離（CPO）が含まれる
+assert_contains "チェック観点に README 乖離（CPO）が含まれる" \
+  "README 乖離（CPO）.*実装と README の記載に乖離がないか"
 
-# 7. チェック観点に README 未反映が含まれる
-assert_contains "チェック観点に README 未反映が含まれる" \
-  "README 未反映.*スキル・フック・エージェントが追加されたのに README に未反映"
+# 8. チェック観点に README 未反映（CPO）が含まれる
+assert_contains "チェック観点に README 未反映（CPO）が含まれる" \
+  "README 未反映（CPO）.*スキル・フック・エージェントが追加されたのに README に未反映"
 
-# 8. 軽微な変更リストから README.md が除外されている
-#    （.gitignore 等の軽微な変更に README.md が含まれていないこと）
+# 9. 軽微な変更リストから README.md が除外されている
 if grep -q '\.gitignore.*README\.md.*軽微な変更' "$SKILL_MD"; then
   fail "軽微な変更リストから README.md が除外されている (まだ含まれている)"
 else


### PR DESCRIPTION
## Summary

- sync-check SKILL.md の CTO 管轄テーブルから README.md を削除し、CPO 管轄テーブルに移動
- CPO の起動条件に README 関連の変更を追加
- チェック観点の README 乖離・未反映を CTO → CPO に変更
- テストを CPO 管轄検証に更新（9/9 通過）

close https://github.com/hirokimry/vibecorp/issues/173

## Test plan

- [x] `bash tests/test_sync_check_skill.sh` — 9/9 passed
- [x] `bash tests/test_hooks.sh` — 67/67 passed
- [x] 既存テストに破壊なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * 責任マトリックスを更新し、CPOのカバー範囲にREADME関連チェックを追加。

* **Tests**
  * テストアサーションを新しい責任割り当てに対応させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->