### PR TITLE
docs: README.md をプラグイン仕様書として網羅的に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ path/to/vibecorp/install.sh --update
 | プリセット | スキル | フック | エージェント | ユースケース |
 |---|---|---|---|---|
 | **minimal** | /review, /review-loop, /pr-review-loop, /pr, /commit, /issue, /ship, /plan, /branch, /plan-review-loop, /ship-parallel, /worktree | protect-files, block-api-bypass, team-auto-approve | なし | 個人〜小規模 |
-| **standard** | 上記 + /review-to-rules, /sync-check, /sync-edit, /session-harvest, /harvest-all | 上記 + review-to-rules-gate, sync-gate, session-harvest-gate | CTO, CPO | チーム開発 |
-| **full** | 上記 + /diagnose, /context7 | 上記 + role-gate, diagnose-guard | C-suite全員 + 分析員（14ロール） | AI企業・コンプライアンス重視 |
+| **standard** | 上記 + /review-to-rules, /sync-check, /sync-edit, /session-harvest, /harvest-all, /context7 | 上記 + review-to-rules-gate, sync-gate, session-harvest-gate | CTO, CPO | チーム開発 |
+| **full** | 上記 + /diagnose | 上記 + role-gate, diagnose-guard | C-suite全員 + 分析員（14ロール） | AI企業・コンプライアンス重視 |
 
 ## インストールされるもの
 
@@ -124,7 +124,7 @@ your-project/
 | `/branch` | Issue URL からブランチを自動作成（`dev/{Issue番号}_{要約}` 形式）。`--worktree` オプションで git worktree も同時作成 |
 | `/worktree` | git worktree のライフサイクル管理。`list`（一覧）、`clean`（マージ済み削除）、`remove`（手動削除） |
 
-### standard プリセットで追加（5スキル）
+### standard プリセットで追加（6スキル）
 
 | スキル | 説明 |
 |---|---|
@@ -133,13 +133,13 @@ your-project/
 | `/sync-edit` | `/sync-check` で検出された不整合を、各職種エージェントが管轄ファイルのみ編集して修正 |
 | `/session-harvest` | セッション中の知見を rules / knowledge / docs に自動反映。マージ前に知識を蓄積する |
 | `/harvest-all` | コードベース全体を棚卸しし、ドキュメント化されていない暗黙知を docs / rules / knowledge に反映 |
+| `/context7` | Context7 CLI 経由でライブラリ・フレームワークの最新ドキュメントを取得・要約 |
 
-### full プリセットで追加（2スキル）
+### full プリセットで追加（1スキル）
 
 | スキル | 説明 |
 |---|---|
 | `/diagnose` | コードベースを自律的に診断し、改善点を発見 → フィルタリング → GitHub Issue 起票。実装は行わない |
-| `/context7` | Context7 CLI 経由でライブラリ・フレームワークの最新ドキュメントを取得・要約 |
 
 ## フック一覧
 


### PR DESCRIPTION
## Summary

closes #170

- README.md を vibecorp の仕様書として網羅的に更新
- 前提条件に `gh` CLI を追加、プリセット表に agents 列を追加、「minimal のみ」表記を削除
- 全19スキル、全8フック、全14エージェントの一覧と説明を追加
- ゲートフックとスタンプの関係、vibecorp.yml 全セクション、--update の 3-way マージ挙動を追加
- 主要スキル（/ship, /diagnose, /harvest-all, /review-loop, /context7）の使い方を追加

## Test plan

- [x] README.md の内容が install.sh のプリセット定義と一致することを確認（CTO レビューで /context7 の帰属不一致を検出・修正済み）
- [x] 全スキル（19）・フック（8）・エージェント（14）が漏れなく記載されていることを確認（CTO レビューで全件一致を確認）
- [x] vibecorp.yml のテンプレート内容と README の記載が一致することを確認（CTO レビューで全フィールド一致を確認）
- [x] Markdown のレンダリングが正常であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメンテーション

* Agent、Knowledge、Docsディレクトリのインストール手順を追加
* プリセット別の機能比較表を拡充  
* `--update`インストールオプションと設定例を記載
* Hook登録およびスキル管理に関する詳細ドキュメントを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->