### PR TITLE
docs: team-auto-approve の allow vs approve の違いを注記

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ your-project/
 |---|---|---|---|
 | `team-auto-approve.sh` | minimal 以上 | `PreToolUse` | チームモードでの安全なツールコールを自動承認。チームメイトが `settings.local.json` の allow リストを継承しない問題の回避策 |
 
+> **注意**: `team-auto-approve.sh` をカスタマイズする場合、`permissionDecision` には必ず `"allow"` を使用すること。`"approve"` は deprecated であり、Write / Edit 等のツールに対して効果がない。
+
 ## ゲートフックとスタンプ
 
 ゲートフックはスタンプファイル（`/tmp/.{project}-*`）で状態管理する。対応するスキルを実行するとスタンプが発行され、ゲートが通過可能になる。スタンプは確認後に自動削除される（ワンタイム）。

--- a/docs/team-permissions.md
+++ b/docs/team-permissions.md
@@ -75,6 +75,8 @@ hooks はチームメイトにも伝播する。この性質を利用し、PreTo
 
 ## 安全性の多層構造
 
+> **allow と approve の違い**: `permissionDecision` には `"allow"` を使用すること。`"approve"` は deprecated であり、Write / Edit 等のツールに対して効果がない。カスタマイズ時にこの違いを間違えると、ファイル書き込み系の自動承認が機能しなくなる。
+
 ```text
 第1層: team-auto-approve.sh（allow のゲートキーパー）
   - 機密ファイル（.env, secrets, credentials, MVV.md）は allow しない

--- a/templates/docs/team-permissions.md
+++ b/templates/docs/team-permissions.md
@@ -58,6 +58,8 @@ hooks はチームメイトにも伝播する。この性質を利用し、PreTo
 
 ### 安全性の多層構造
 
+> **allow と approve の違い**: `permissionDecision` には `"allow"` を使用すること。`"approve"` は deprecated であり、Write / Edit 等のツールに対して効果がない。カスタマイズ時にこの違いを間違えると、ファイル書き込み系の自動承認が機能しなくなる。
+
 ```text
 第1層: team-auto-approve.sh（allow のゲートキーパー）
   - 機密ファイル（.env, secrets, credentials, MVV.md）は allow しない


### PR DESCRIPTION
## Summary
- README のフック一覧に `team-auto-approve.sh` カスタマイズ時の allow/approve の違いに関する注意書きを追加
- `docs/team-permissions.md` および `templates/docs/team-permissions.md` の安全性セクションにも同様の注記を追加
- `approve` は deprecated で Write/Edit に効かないため、誤用によるバグを未然に防止する

close #191

## Test plan
- [ ] README.md の注記が正しくレンダリングされること
- [ ] docs/team-permissions.md の注記が正しくレンダリングされること
- [ ] templates/docs/team-permissions.md の注記が正しくレンダリングされること


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 権限設定の安全な利用方法に関する注記を複数のドキュメントに追加。`permissionDecision` パラメータの正しい指定値と、非推奨となった値の影響に関する明確なガイダンスを追加することで、ユーザーが自動承認機能を適切に構成できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->