### PR TITLE
feat: main 更新時に全 open PR のブランチを自動更新する Action を追加 (#196)

### DIFF
--- a/.github/workflows/update-pr-branches.yml
+++ b/.github/workflows/update-pr-branches.yml
@@ -32,24 +32,45 @@ jobs:
 
           UPDATED=0
           SKIPPED=0
+          FAILED=0
 
           for PR in $PR_NUMBERS; do
             echo "--- PR #${PR} を更新中 ---"
-            # 現在の head SHA を取得して expected_head_sha に渡す
-            HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha')
-            if gh api "repos/${REPO}/pulls/${PR}/update-branch" \
+            # 現在の head SHA を取得（失敗時は致命的エラー）
+            if ! HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha' 2>&1); then
+              echo "PR #${PR}: SHA 取得失敗（想定外エラー）"
+              echo "${HEAD_SHA}"
+              exit 1
+            fi
+
+            # ブランチ更新（HTTP ステータスで分岐）
+            HTTP_STATUS=$(gh api "repos/${REPO}/pulls/${PR}/update-branch" \
               --method PUT \
               --field expected_head_sha="${HEAD_SHA}" \
-              > /dev/null 2>&1; then
-              echo "PR #${PR}: 更新成功"
-              UPDATED=$((UPDATED + 1))
-            else
-              echo "PR #${PR}: 更新スキップ（コンフリクト等）"
-              SKIPPED=$((SKIPPED + 1))
-            fi
+              --include 2>&1 | head -1 | awk '{print $2}') || true
+
+            case "${HTTP_STATUS}" in
+              202)
+                echo "PR #${PR}: 更新成功"
+                UPDATED=$((UPDATED + 1))
+                ;;
+              422)
+                echo "PR #${PR}: 更新スキップ（コンフリクトまたは更新不要）"
+                SKIPPED=$((SKIPPED + 1))
+                ;;
+              *)
+                echo "PR #${PR}: 更新失敗（HTTP ${HTTP_STATUS}）"
+                FAILED=$((FAILED + 1))
+                ;;
+            esac
           done
 
           echo ""
           echo "=== 結果 ==="
           echo "更新成功: ${UPDATED} 件"
           echo "スキップ: ${SKIPPED} 件"
+          echo "失敗: ${FAILED} 件"
+
+          if [ "${FAILED}" -gt 0 ]; then
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- main への push 時に全 open PR のブランチを自動更新する GitHub Action を追加
- コンフリクト PR はスキップして続行
- 更新成功・スキップ件数をログ出力

close #196

## Test plan
- [ ] main にマージ後、残りの open PR が自動で update branch される
- [ ] コンフリクト PR がスキップされ Action が失敗しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * メインブランチへのプッシュ時に、オープン中のプルリクエストを自動で検出して各ブランチを更新するワークフローを追加しました。処理結果は更新・スキップ・失敗として集計され、失敗がある場合はワークフローが失敗として報告されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->