### PR TITLE
[diagnose] block-api-bypass.sh の専用テストを追加 (#218)

### DIFF
--- a/tests/test_block_api_bypass.sh
+++ b/tests/test_block_api_bypass.sh
@@ -136,6 +136,34 @@ else
   fail "approve ブロックの JSON 構造検証 (構造が不正)"
 fi
 
+# 13. env ラッパー付き直接マージ → deny
+OUTPUT=$(make_bash_input "env gh api repos/owner/repo/${MERGE_PATH}/123/${MERGE_SUFFIX} -X PUT" | run_hook block-api-bypass.sh)
+assert_blocked "env ラッパー付き直接マージ → deny" "$OUTPUT"
+
+# 14. command ラッパー付き直接マージ → deny
+OUTPUT=$(make_bash_input "command gh api repos/owner/repo/${MERGE_PATH}/123/${MERGE_SUFFIX} -X PUT" | run_hook block-api-bypass.sh)
+assert_blocked "command ラッパー付き直接マージ → deny" "$OUTPUT"
+
+# 15. KEY=VALUE 付き直接マージ → deny
+OUTPUT=$(make_bash_input "KEY=VALUE gh api repos/owner/repo/${MERGE_PATH}/123/${MERGE_SUFFIX} -X PUT" | run_hook block-api-bypass.sh)
+assert_blocked "KEY=VALUE 付き直接マージ → deny" "$OUTPUT"
+
+# 16. 複数環境変数連結付き直接マージ → deny
+OUTPUT=$(make_bash_input "GH_TOKEN=abc GITHUB_HOST=example.com gh api repos/owner/repo/${MERGE_PATH}/123/${MERGE_SUFFIX} -X PUT" | run_hook block-api-bypass.sh)
+assert_blocked "複数環境変数連結付き直接マージ → deny" "$OUTPUT"
+
+# 17. env ラッパー付き approve → deny
+OUTPUT=$(make_bash_input "env gh api repos/owner/repo/issues/123/comments -X POST -f body=\"${CR_APPROVE}\"" | run_hook block-api-bypass.sh)
+assert_blocked "env ラッパー付き approve → deny" "$OUTPUT"
+
+# 18. command ラッパー付き approve → deny
+OUTPUT=$(make_bash_input "command gh api repos/owner/repo/issues/123/comments -X POST -f body=\"${CR_APPROVE}\"" | run_hook block-api-bypass.sh)
+assert_blocked "command ラッパー付き approve → deny" "$OUTPUT"
+
+# 19. KEY=VALUE 付き approve → deny
+OUTPUT=$(make_bash_input "KEY=VALUE gh api repos/owner/repo/issues/123/comments -X POST -f body=\"${CR_APPROVE}\"" | run_hook block-api-bypass.sh)
+assert_blocked "KEY=VALUE 付き approve → deny" "$OUTPUT"
+
 # --- 結果サマリ ---
 echo ""
 echo "=== 結果: $PASSED/$TOTAL passed, $FAILED failed ==="


### PR DESCRIPTION
close https://github.com/hirokimry/vibecorp/issues/218

## Summary
- `tests/test_block_api_bypass.sh` を新規作成
- `test_hooks.sh` に含まれていた block-api-bypass テストを独立した専用テストファイルとして整備
- 12テストケース: 直接マージブロック、CodeRabbit approve ブロック、通常コマンド許可、JSON構造検証

## Test plan
- [x] `bash tests/test_block_api_bypass.sh` で 12/12 PASS 確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **テスト**
  * APIバイパス防止フックの動作を検証するエンドツーエンドのBashテストスイートを追加しました。19件のシナリオを実行し、マージやコメント送信、トークンやコマンドの変種など許可/拒否パターンを網羅。拒否応答のJSON構造検証と各テストのPASS/FAIL出力、最終サマリを提供し、失敗時は非ゼロで終了します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->