### PR TITLE
[diagnose] install.sh のプレースホルダー置換エラーハンドリング (#221)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -613,17 +613,35 @@ copy_managed_files() {
   # macOS 互換: sed ... > tmp && mv tmp original（sed -i の BSD/GNU 差異を回避）
   local target_dirs=("$hooks_dir" "$skills_dir")
   [[ -d "$agents_dir" ]] && target_dirs+=("$agents_dir")
+  local placeholder_errors=0
   for dir in "${target_dirs[@]}"; do
-    find "$dir" -type f \( -name '*.sh' -o -name '*.md' \) | while IFS= read -r f; do
+    while IFS= read -r f; do
       if grep -q '{{' "$f" 2>/dev/null; then
-        sed \
+        local tmp
+        tmp="$(mktemp "$(dirname "$f")/.${f##*/}.XXXXXX")"
+        if sed \
           -e "s|{{PROJECT_NAME}}|${PROJECT_NAME}|g" \
           -e "s|{{PRESET}}|${PRESET}|g" \
           -e "s|{{LANGUAGE}}|$(resolve_language "$LANGUAGE")|g" \
-          "$f" > "${f}.tmp" && mv "${f}.tmp" "$f"
+          "$f" > "$tmp"; then
+          mv "$tmp" "$f"
+        else
+          log_error "プレースホルダー置換に失敗しました: $f"
+          rm -f "$tmp"
+          placeholder_errors=$((placeholder_errors + 1))
+        fi
+        # 置換後も未解決のプレースホルダーが残っていないか検証
+        if grep -q '{{' "$f" 2>/dev/null; then
+          log_error "未解決のプレースホルダーが残っています: $f"
+          placeholder_errors=$((placeholder_errors + 1))
+        fi
       fi
-    done
+    done < <(find "$dir" -type f \( -name '*.sh' -o -name '*.md' \))
   done
+  if [[ "$placeholder_errors" -gt 0 ]]; then
+    log_error "プレースホルダー置換で ${placeholder_errors} 件のエラーが発生しました"
+    return 1
+  fi
 
   # hooks に実行権限を付与
   for f in "${hooks_dir}/"*.sh; do

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -2472,6 +2472,67 @@ cleanup
 
 # ============================================
 echo ""
+echo "=== AI. プレースホルダー置換エラーハンドリング ==="
+# ============================================
+
+# AI1. 正常な置換後にプレースホルダーが残らない（既存テスト I と重複するが明示的に検証）
+create_test_repo
+bash "$INSTALL_SH" --name test-proj --preset full --language ja 2>/dev/null
+R="$TMPDIR_ROOT"
+
+# hooks 内の全ファイルにプレースホルダーが残っていないこと
+REMAINING=$(grep -rl '{{' "$R/.claude/hooks/" 2>/dev/null || true)
+if [ -z "$REMAINING" ]; then
+  pass "AI1: hooks 内にプレースホルダーが残っていない"
+else
+  fail "AI1: hooks 内にプレースホルダーが残っている: $REMAINING"
+fi
+
+# skills 内の全ファイルにプレースホルダーが残っていないこと
+REMAINING=$(grep -rl '{{' "$R/.claude/skills/" 2>/dev/null || true)
+if [ -z "$REMAINING" ]; then
+  pass "AI1: skills 内にプレースホルダーが残っていない"
+else
+  fail "AI1: skills 内にプレースホルダーが残っている: $REMAINING"
+fi
+cleanup
+
+# AI2. sed 置換が失敗した場合にエラーメッセージが出力される
+create_test_repo
+bash "$INSTALL_SH" --name test-proj 2>/dev/null
+R="$TMPDIR_ROOT"
+
+# 未知のプレースホルダーを含むファイルを hooks に配置して --update で再実行
+echo '#!/bin/bash
+# {{UNKNOWN_PLACEHOLDER}} テスト' > "$R/.claude/hooks/test-placeholder.sh"
+chmod +x "$R/.claude/hooks/test-placeholder.sh"
+
+STDERR_OUTPUT=$(bash "$INSTALL_SH" --update 2>&1 >/dev/null) || true
+if echo "$STDERR_OUTPUT" | grep -q "未解決のプレースホルダーが残っています"; then
+  pass "AI2: 未解決プレースホルダー検出時にエラーメッセージが出力される"
+else
+  fail "AI2: 未解決プレースホルダー検出時にエラーメッセージが出力される"
+fi
+# クリーンアップ
+rm -f "$R/.claude/hooks/test-placeholder.sh"
+cleanup
+
+# AI3. sed 失敗時に .tmp ファイルが残らない
+create_test_repo
+bash "$INSTALL_SH" --name test-proj 2>/dev/null
+R="$TMPDIR_ROOT"
+
+# 正常実行後に .tmp ファイルが残っていないこと
+TMP_FILES=$(find "$R/.claude/hooks/" "$R/.claude/skills/" -name '*.tmp' 2>/dev/null || true)
+if [ -z "$TMP_FILES" ]; then
+  pass "AI3: 置換後に .tmp ファイルが残っていない"
+else
+  fail "AI3: 置換後に .tmp ファイルが残っている: $TMP_FILES"
+fi
+cleanup
+
+# ============================================
+echo ""
 echo "=== 結果: $PASSED/$TOTAL passed, $FAILED failed ==="
 
 if [ "$FAILED" -gt 0 ]; then


### PR DESCRIPTION
## Summary
- `install.sh` のプレースホルダー置換処理（`sed`）にエラーハンドリングを追加
- `find | while` パイプラインをプロセス置換に変更し、失敗を `set -e` で捕捉可能に
- 置換後の未解決プレースホルダー検出・エラーメッセージ出力・一時ファイルクリーンアップを実装

## Test plan
- [x] 既存テスト 326件 全パス
- [x] AI1: hooks/skills 内にプレースホルダーが残らない
- [x] AI2: 未解決プレースホルダー検出時にエラーメッセージが出力される
- [x] AI3: 置換後に .tmp ファイルが残らない

close https://github.com/hirokimry/vibecorp/issues/221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * インストール中のプレースホルダー置換エラー検出が強化されました。未解決のプレースホルダーが残っている場合、明確なエラーメッセージが表示されるようになります。

* **テスト**
  * プレースホルダー置換エラーハンドリングに関する検証シナリオを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->