### PR TITLE
🔍 investigate: ship-parallel の既存 team-auto-approve.sh が効かなかった原因を特定し対策する

### DIFF
--- a/templates/claude/hooks/team-auto-approve.sh
+++ b/templates/claude/hooks/team-auto-approve.sh
@@ -155,13 +155,54 @@ if [ "$TOOL_NAME" = "Bash" ]; then
   fi
 
   # && や ; で連結されたコマンドを各セグメントに分割し、全セグメントを検証
+  # quote（'...' や "..."）内の ; / && は区切り文字として扱わない。
+  # 単純な文字列 split（sed 's/;/\n/g'）だと awk '{print; exit}' のような quote 内の ; を
+  # 誤って segment 境界と認識してしまうため、quote 状態を追跡しながら分割する。
   all_safe=true
   while IFS= read -r segment; do
     if ! is_safe_segment "$segment"; then
       all_safe=false
       break
     fi
-  done < <(echo "$COMMAND" | sed 's/&&/\n/g; s/;/\n/g')
+  done < <(echo "$COMMAND" | awk '
+    BEGIN { sq = "\047"; dq = "\042" }
+    {
+      s = $0
+      out = ""
+      in_single = 0
+      in_double = 0
+      i = 1
+      len = length(s)
+      while (i <= len) {
+        c = substr(s, i, 1)
+        if (!in_double && c == sq) {
+          in_single = !in_single
+          out = out c
+          i++
+          continue
+        }
+        if (!in_single && c == dq) {
+          in_double = !in_double
+          out = out c
+          i++
+          continue
+        }
+        if (!in_single && !in_double && c == ";") {
+          out = out "\n"
+          i++
+          continue
+        }
+        if (!in_single && !in_double && c == "&" && substr(s, i+1, 1) == "&") {
+          out = out "\n"
+          i += 2
+          continue
+        }
+        out = out c
+        i++
+      }
+      print out
+    }
+  ')
 
   if [ "$all_safe" = true ]; then
     jq -n '{

--- a/tests/test_team_auto_approve.sh
+++ b/tests/test_team_auto_approve.sh
@@ -217,6 +217,42 @@ assert_not_auto_approved "cd && git push --force → 自動承認しない" "$OU
 
 # ============================================
 echo ""
+echo "=== team-auto-approve.sh: Bash（quote 内の ; や && の誤分割）==="
+# ============================================
+# Issue #252: quote 内の ; を segment 区切りとして誤認識していた。
+# クォート保護された ; / && は分割してはならない。
+
+# awk の action ブロック内の ;（シングルクォート内）→ 自動承認
+OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"awk '\''/^preset:/ { sub(/^preset:/, \"\"); print; exit }'\'' .claude/vibecorp.yml"}}' | run_hook)
+assert_auto_approved "awk '{...; print; exit}' → 自動承認（quote 内 ;）" "$OUTPUT"
+
+# sed の複数コマンド（シングルクォート内 ;）→ 自動承認
+OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"sed '\''s/a/b/; s/c/d/'\'' file.txt"}}' | run_hook)
+assert_auto_approved "sed 's/a/b/; s/c/d/' → 自動承認（quote 内 ;）" "$OUTPUT"
+
+# echo 'a; b' → 自動承認（シングルクォート内 ;）
+OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"echo '\''a; b'\''"}}' | run_hook)
+assert_auto_approved "echo 'a; b' → 自動承認（quote 内 ;）" "$OUTPUT"
+
+# echo "a; b" → 自動承認（ダブルクォート内 ;）
+OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"echo \"a; b\""}}' | run_hook)
+assert_auto_approved 'echo "a; b" → 自動承認（quote 内 ;）' "$OUTPUT"
+
+# echo 'a && b' → 自動承認（シングルクォート内 &&）
+OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"echo '\''a && b'\''"}}' | run_hook)
+assert_auto_approved "echo 'a && b' → 自動承認（quote 内 &&）" "$OUTPUT"
+
+# quote 内に rm -rf を書いても、シェルは実行しない（単なる文字列）→ 自動承認
+# ただしこの hook は文字列判定なので rm 検出で弾くのも許容。ここでは弾かれないことを確認する。
+OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"echo '\''hello world'\''"}}' | run_hook)
+assert_auto_approved "echo 'hello world' → 自動承認" "$OUTPUT"
+
+# 重要な安全確認: quote の外にある rm は検出されなければならない（保護処理がバイパスを生まないこと）
+OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"echo '\''safe text'\'' && rm -rf /tmp/x"}}' | run_hook)
+assert_not_auto_approved "echo 'safe' && rm -rf → 自動承認しない（quote 外 rm を検出）" "$OUTPUT"
+
+# ============================================
+echo ""
 echo "=== team-auto-approve.sh: Bash（||, |, コマンド置換） ==="
 # ============================================
 


### PR DESCRIPTION
## 関連 Issue

close https://github.com/hirokimry/vibecorp/issues/252

## 概要

### 背景

`/ship-parallel` 実行中に teammate の Bash ツール呼び出しで毎回 permission 確認ダイアログが表示され、18時間セッションが停止した。

### 真因

`team-auto-approve.sh` のコマンド分割処理（`; / &&` による segment 分割）が quote-unaware な実装だった。

**Before（問題のある動作）**

```bash
# sed で単純に ; と && を改行に置換していた
done < <(echo "$COMMAND" | sed 's/&&/\n/g; s/;/\n/g')
```

`awk '/^preset:/ { sub(/^preset:/, ""); print; exit }' file` のようなコマンドで、quote 内の `{ ...; print; exit }` の `;` を segment 境界と誤認識。分割された `print` や `exit` は safe list に存在しないため permission ダイアログが発生。

**After（修正後の動作）**

```bash
# quote 状態（シングル/ダブル）を追跡しながら分割する awk 実装に置き換え
# quote 内の ; / && はリテラル文字として扱い、segment 境界としない
done < <(echo "$COMMAND" | awk '
  BEGIN { sq = "\047"; dq = "\042" }
  { ... quote 状態を追跡しながら分割 ... }
')
```

quote 内の `;` / `&&` を正しくリテラル扱いし、quote 外の区切り文字のみで segment 分割するようになった。

### 追加発見（このPRのスコープ外）

spike 中に別の permission ブロックを発見:

```text
Compound command contains cd with output redirection
- manual approval required to prevent path resolution bypass
```

これは Claude Code 本体の built-in security check であり、hook で override 不可。別 Issue で対応予定。

## テスト計画

- [ ] 既存 54 テスト PASS（回帰なし）
- [ ] 新規 7 テスト PASS（quote 内 `;`/`&&` のケースを網羅）
  - `awk '{...; print; exit}'` → 自動承認（シングルクォート内 `;`）
  - `sed 's/a/b/; s/c/d/'` → 自動承認（シングルクォート内 `;`）
  - `echo 'a; b'` → 自動承認（シングルクォート内 `;`）
  - `echo "a; b"` → 自動承認（ダブルクォート内 `;`）
  - `echo 'a && b'` → 自動承認（シングルクォート内 `&&`）
  - `echo 'hello world'` → 自動承認
  - `echo 'safe' && rm -rf /tmp/x` → 自動承認しない（quote 外の `rm -rf` を正しく検出）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
- コマンド検証ロジックが改善されました。単引用符または二重引用符で囲まれたテキスト内のセミコロンやアンパサンド（&&）が、コマンド区切り文字として誤認識されることがなくなります。引用符内の特殊文字の取り扱いの精度が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->