### PR TITLE
ship-parallel: teammate に team-auto-approve.sh が効かず permission prompt が出る (#260)

### DIFF
--- a/.claude/knowledge/cto/decisions.md
+++ b/.claude/knowledge/cto/decisions.md
@@ -124,3 +124,9 @@
 - **判断**: Claude Code built-in security check（`cd` + パイプ + リダイレクトの複合コマンドをブロックする）は hook で override 不可。対策として ship / ship-parallel の SKILL.md に「`cd` + パイプ + リダイレクトを含む compound command は避け、個別の Bash 呼び出しに分割する」旨の制約を追加する。単純な `cd && git ...` のような harmless な命令チェーンは対象外
 - **根拠**: hook の後段で動く built-in check は `permissionDecision: "allow"` を無視する。hook 側での解決は不可能であり、コマンドを生成するエージェント（teammate）への指示で上流から防ぐのが唯一の実用策
 - **代替案**: built-in check を無効化する設定を探したが、そのような設定は存在しない（2026年4月時点）
+
+### 2026-04-10: ship-parallel の Agent 起動に mode: "dontAsk" を指定（Issue #260）
+
+- **判断**: ship-parallel で Agent (teammate) を起動する際に `mode: "dontAsk"` を指定する
+- **根拠**: Agent の mode が未指定（`default`）の場合、teammate のツール呼び出しが親セッション（チームリーダー）に承認要求を上げる。この場合、worktree に `team-auto-approve.sh` が存在し settings.json のマッチャーも正しくコピーされていても、hook の `permissionDecision: "allow"` が Agent の permission レイヤーに上書きされて効かない。`dontAsk` を指定することで hook が permission を完全に制御できるようになる
+- **代替案**: `bypassPermissions` はファウンダー方針（Issue #252）で使用禁止。`dontAsk` はこの方針に矛盾せず、hook が引き続き動作するため安全性を維持できる

--- a/.claude/knowledge/cto/hooks-design-patterns.md
+++ b/.claude/knowledge/cto/hooks-design-patterns.md
@@ -138,3 +138,31 @@ Compound command contains cd with output redirection - manual approval required 
 ```
 
 このログが書き出されていれば「hook は発火しているが allow を返していない」。ログが書き出されていなければ「hook が発火していない（設定登録の問題 or マッチャーのミス）」と切り分けできる。デバッグ完了後は必ずログ行を削除すること。
+
+## Agent の permission mode と team-auto-approve.sh の関係
+
+Claude Code の Agent ツールは `mode` パラメータで permission の扱い方を制御する。
+
+### mode パラメータの選択肢
+
+`acceptEdits`, `auto`, `bypassPermissions`, `default`, `dontAsk`, `plan`
+
+### team-auto-approve.sh が機能しないケースと対処
+
+Agent の `mode` が未指定（`default`）の場合、teammate のツール呼び出しは親セッション（チームリーダー）に承認要求を上げる。この場合、以下の条件が全て揃っていても `team-auto-approve.sh` の `permissionDecision: "allow"` が Agent の permission レイヤーに上書きされて効かない:
+
+- worktree に `team-auto-approve.sh` が正しくコピーされている
+- `settings.json` のマッチャーが正しく設定されている
+- hook が発火している（`fired.log` で確認済み）
+
+**対処**: Agent 起動時に `mode: "dontAsk"` を指定する。これにより hook が permission を完全に制御できるようになる。
+
+### bypassPermissions との違い
+
+| mode | hook の動作 | 安全性 |
+|------|-------------|--------|
+| `default` | hook は発火するが allow が無視される | 承認ダイアログが出続ける |
+| `dontAsk` | hook が permission を制御する | hook のロジックで安全性を担保 |
+| `bypassPermissions` | hook を含む全 permission check をスキップ | vibecorp では使用禁止 |
+
+`bypassPermissions` はファウンダー方針（Issue #252）で使用禁止。`dontAsk` を使うことで hook の制御を保ちつつ承認ダイアログを排除できる。

--- a/templates/claude/skills/ship-parallel/SKILL.md
+++ b/templates/claude/skills/ship-parallel/SKILL.md
@@ -190,6 +190,8 @@ git worktree list
 並列グループ内の各 Issue に対して、Agent ツールを起動する。
 **同一グループの全 Agent は1つのメッセージで同時に起動する**（並列実行を最大化）。
 
+Agent 起動時は `mode: "dontAsk"` を指定する。デフォルト mode では teammate のツール呼び出しが親セッションに承認要求を送り、hook の `permissionDecision: "allow"` が上書きされるため。`dontAsk` により hook（`team-auto-approve.sh`）が permission を制御する（参照: #260）。
+
 各 Agent に渡すプロンプト:
 
 ```text

--- a/tests/test_ship_parallel.sh
+++ b/tests/test_ship_parallel.sh
@@ -262,6 +262,13 @@ else
   fail "Agent プロンプトに path resolution bypass の禁止理由が明示されていない"
 fi
 
+# 8-6: Agent 起動に mode: "dontAsk" の指定がある（#260）
+if grep -q 'dontAsk' "$SKILL_FILE"; then
+  pass "Agent 起動に dontAsk mode の指定がある"
+else
+  fail "Agent 起動に dontAsk mode の指定がない"
+fi
+
 echo ""
 
 # --- テスト9: アーキテクチャが方式I になっている ---


### PR DESCRIPTION
## Summary

- ship-parallel の Agent 起動に `mode: "dontAsk"` を指定し、teammate の permission prompt を解消
- デフォルト mode では teammate のツール呼び出しが親セッションに承認要求を送り、hook の `permissionDecision: "allow"` が上書きされていた
- `dontAsk` により hook（`team-auto-approve.sh`）が permission を制御する

## Test plan

- [x] `tests/test_ship_parallel.sh` 35/35 全 PASS（テスト 8-6 で dontAsk mode の検証を追加）
- [x] CodeRabbit: No findings
- [ ] `/ship-parallel` で実際に permission prompt が出ないことを確認（E2E 検証は #261 で自動化予定）

close https://github.com/hirokimry/vibecorp/issues/260

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * パラレルで起動するエージェントの権限処理について明確化しました。エージェント起動時の設定により権限フローがフック側で確実に制御されることを追記しています。
  * CTO決定として運用方針を追加しました。

* **テスト**
  * 設定内容を検証するテストを追加しました。スキル定義の権限関連設定が正しく反映されているかをチェックします。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->