### PR TITLE
feat: コンテナベースイメージと sandbox entrypoint を実装 (#266)

### DIFF
--- a/.claude/knowledge/cto/containerization.md
+++ b/.claude/knowledge/cto/containerization.md
@@ -1,0 +1,64 @@
+# コンテナ化実装ノウハウ
+
+docker/claude-sandbox/ の実装（Issue #266）で得られた知見。
+`node:*-slim` / `node:*` ベースの non-root コンテナを立てる際に参照すること。
+
+## node:*-slim の UID 1000 衝突
+
+`node:20-slim`（および `node:*-slim` / `node:*` 全般）には UID/GID 1000 の `node` ユーザーが既に存在する。
+`useradd -m -u 1000 claude` を直接実行すると `useradd: UID 1000 is not unique` で失敗する。
+
+対策: 既存ユーザーを削除してから作成する。
+
+```dockerfile
+RUN userdel -r node && useradd -m -u 1000 -s /bin/bash claude
+```
+
+## setpriv によるユーザー降格に必要な capability
+
+`setpriv --reuid=1000 --regid=1000` は `CAP_SETUID` / `CAP_SETGID` を必要とする。
+`--cap-drop ALL` でこれらも落とすと `setpriv` がエラーになる。
+
+対策: `--cap-add SETUID --cap-add SETGID` を追加する。
+
+```bash
+docker run \
+  --cap-drop ALL \
+  --cap-add NET_ADMIN \
+  --cap-add SETUID \
+  --cap-add SETGID \
+  ...
+```
+
+降格後に全 capability を drop するには `setpriv --bounding-set=-all` を使う。
+個別指定（`-cap_net_admin,-cap_sys_admin` 等）より安全で、将来の capability 追加にも対応できる。
+
+## docker run には --secret フラグが存在しない
+
+Docker secrets（`--secret`）は swarm / compose 専用機能。`docker run` では使えない。
+
+代替: bind mount で readonly マウントする。
+
+```bash
+docker run \
+  --mount type=bind,source=/path/to/anthropic_api_key,target=/run/secrets/anthropic_api_key,readonly \
+  ...
+```
+
+`docker compose` を使う場合は `secrets:` セクションが利用できる。
+
+## iptables egress allowlist の CDN IP ローテーション問題
+
+起動時に `getent ahosts` で解決した IP を iptables の ACCEPT ルールに追加する方式は、
+Anthropic / GitHub が CDN（Cloudflare 等）で IP をローテーションすると通信が失敗する。
+
+現状の対策: `--ctstate ESTABLISHED,RELATED` ルールで一度確立したセッションをフォールバックとして維持する。
+
+将来的な解決策: HTTPS フォワードプロキシ（tinyproxy / squid）を sidecar として立て、
+コンテナのデフォルトルートをプロキシに向けることで IP ローテーションを吸収できる。
+Phase 2 以降で要再評価。
+
+## 関連する decisions.md エントリ
+
+- 2026-04-11: docker/claude-sandbox/ のリポジトリトップレベル配置判断
+- 2026-04-11: seccomp プロファイルを ALLOW デフォルト + 特定 syscall denial 構成で実装

--- a/.claude/knowledge/cto/decisions.md
+++ b/.claude/knowledge/cto/decisions.md
@@ -166,3 +166,24 @@
 - **判断**: spike-loop SKILL.md が宣言している制約（`--force`/`-D` 禁止、Bash 1 コマンド 1 呼び出し、`2>/dev/null`・`|| echo` 等のフォールバック禁止）を、自身の例示コードで違反していた。プロセス kill・worktree 削除・ブランチ削除のコマンドを `pgrep` / `git worktree remove <path>`（force なし）/ `git branch -d <branch>`（小文字）に修正。uncommitted 変更や未マージブランチは安全に削除できないため手動対応とする設計を採用した。合わせて `headless-claude.md` のサンプルコードも同制約に合わせて修正（`kill "$pid" 2>/dev/null || true` → `kill "$pid"`、パイプを使った `last_ts` 取得 → `awk 'END { print $1 }' "$COMMAND_LOG"` に置き換え）
 - **根拠**: ドキュメント内の制約とサンプルコードが矛盾しているとエージェントが誤ったパターンを学習する。ルールとサンプルの整合性はドキュメントの信頼性の基本
 - **代替案**: フォールバックを許容して制約を緩める案も検討したが、spike-loop の制約は Claude Code built-in security check への対策として設計されたものであり（Issue #258）、緩めることは安全性の低下につながるため採用しなかった
+
+### 2026-04-11: docker/claude-sandbox/ のリポジトリトップレベル配置判断（Issue #266）
+
+- **判断**: コンテナ隔離環境のイメージ定義（`Dockerfile` / `entrypoint.sh` / `seccomp.json` / `README.md` / `.dockerignore`）を `docker/claude-sandbox/` としてリポジトリトップレベルに配置する。`.claude/` 配下には置かない
+- **根拠**:
+  - `docker/` は Docker エコシステムの業界標準配置パターンであり、他リポジトリや外部利用者から発見しやすい
+  - `.claude/` は Claude Code 規約パスのための予約空間であり、Docker 関連ファイルを混入させると規約の意味が希薄になる
+  - `docs/file-placement.md` が禁じているのは `.claude/vibecorp/` のような Claude Code 規約外の独自 namespace の作成であり、リポジトリトップへの新規ディレクトリ追加は別論点
+  - `templates/` は `install.sh` で配布先にコピーされる source of truth であり、コンテナ定義は配布先でも vibecorp ソースと同じ構造を保ちたい（`templates/` 配下ではない）
+- **代替案**:
+  - `.claude/docker/` 配置案 → 却下。Claude Code 規約空間の汚染になり、規約と独自要素の境界が曖昧になる
+  - `templates/docker/` 配置案 → 却下。`templates/` は配布先コピー用であり、vibecorp 本体の開発時点でイメージを使うユースケース（CI でのビルドテスト等）に対応しづらい
+
+### 2026-04-11: seccomp プロファイルを ALLOW デフォルト + 特定 syscall denial 構成で実装（Issue #266）
+
+- **判断**: `docker/claude-sandbox/seccomp.json` を `defaultAction: SCMP_ACT_ALLOW` + `ptrace` / `mount` / `pivot_root` / `bpf` / `unshare` / `setns` / `reboot` / `kexec_load` / `swapon` / `swapoff` / `init_module` / `perf_event_open` の明示的な `SCMP_ACT_ERRNO` 拒否で構成する。Docker default seccomp profile（800 行超の allowlist）は同梱しない
+- **根拠**:
+  - Docker default profile を同梱すると常に Docker 最新版との乖離リスクを抱えることになり、メンテナンスコストが高い
+  - 本イメージは `--cap-drop ALL` + `--cap-add NET_ADMIN` + `setpriv` による bounding set drop + `--read-only` + `no-new-privileges` + `--pids-limit` 等の多層防御を前提としており、seccomp は追加防御層として位置付けられる
+  - 攻撃面として最も危険な syscall 群（コンテナエスケープ経路、debugger 介入、カーネル操作）を明示的に拒否することで、ALLOW デフォルトでも実質的な isolation を維持できる
+- **代替案**: Docker default profile をベースにして同梱する案 → 却下（保守性の問題）。Phase 2 以降で厳格化の必要性が出た場合は再評価する

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -20,3 +20,20 @@ else
   exit 1
 fi
 ```
+
+## trap cleanup EXIT でのリソース解放
+
+`set -euo pipefail` 下のテストスクリプトで `trap cleanup EXIT` を使う場合、cleanup 内でのリソース解放コマンドはテスト結果に影響させてはならない。
+
+- Docker イメージ・コンテナ・一時ファイルの削除は失敗しても終了コードに影響させない
+- サブシェル `( set +e; ... )` で失敗を隔離するか、リダイレクト `>/dev/null 2>&1` で抑制する
+
+```bash
+cleanup() {
+  # サブシェルで隔離（set +e がサブシェル内にのみ適用される）
+  ( set +e; docker rmi -f "$IMAGE_TAG" >/dev/null 2>&1 )
+}
+trap cleanup EXIT
+```
+
+この失敗抑制はテストのフォールバック禁止ルールの対象外。cleanup の目的はリソース解放であり、失敗しても後続テストへの影響はないため。

--- a/docker/claude-sandbox/.dockerignore
+++ b/docker/claude-sandbox/.dockerignore
@@ -1,0 +1,6 @@
+README.md
+*.md
+.git
+.gitignore
+tests/
+node_modules/

--- a/docker/claude-sandbox/Dockerfile
+++ b/docker/claude-sandbox/Dockerfile
@@ -1,0 +1,45 @@
+# claude CLI を --dangerously-skip-permissions 付きで安全に実行するためのコンテナイメージ
+# 参考: .claude/knowledge/ciso/decisions.md / .claude/knowledge/cto/decisions.md / Issue #266
+FROM node:20-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV CLAUDE_PROJECT_DIR=/workspace
+
+# 必要パッケージのインストール
+# - tini: PID 1 の zombie reaping
+# - iptables, iproute2: entrypoint.sh での egress allowlist 設定
+# - util-linux: setpriv（non-root 降格と capability bounding set drop）
+# - dnsutils: getent 代替の dig 等（デバッグ用途）
+# - ca-certificates, curl, git: claude CLI 動作に必要
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        tini \
+        iptables \
+        iproute2 \
+        util-linux \
+        dnsutils \
+        ca-certificates \
+        curl \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+# claude CLI の global install
+RUN npm install -g @anthropic-ai/claude-code@latest \
+    && npm cache clean --force
+
+# non-root ユーザーの作成
+# node:20-slim には既に UID/GID 1000 の node ユーザーが存在するため削除してから claude を作成する
+RUN userdel -r node \
+    && useradd -m -u 1000 -s /bin/bash claude \
+    && mkdir -p /workspace /state /home/claude/.claude \
+    && chown -R claude:claude /workspace /state /home/claude
+
+# entrypoint のコピー
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+WORKDIR /workspace
+
+# tini を PID 1 にして entrypoint を実行
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]
+CMD ["claude", "--version"]

--- a/docker/claude-sandbox/README.md
+++ b/docker/claude-sandbox/README.md
@@ -51,7 +51,7 @@ docker run --rm \
 
 ### 補足
 
-- `--user` は指定しない。entrypoint.sh が root で iptables 設定後、`setpriv --reuid=1000 --regid=1000 --bounding-set=-cap_net_admin,-cap_net_raw,-cap_sys_admin` で降格する。事前に `--user 1000:1000` を指定すると iptables の OUTPUT 書き換えが行えなくなり egress allowlist が機能しないため禁止
+- `--user` は指定しない。entrypoint.sh が root で iptables 設定後、`setpriv --reuid=1000 --regid=1000 --clear-groups --inh-caps=-all --bounding-set=-all` で降格する。事前に `--user 1000:1000` を指定すると iptables の OUTPUT 書き換えが行えなくなり egress allowlist が機能しないため禁止
 - `CLAUDE_PROJECT_DIR` は Dockerfile の `ENV` で `/workspace` に設定済み
 - `docker run` には `--secret` フラグが存在しないため、`--mount type=bind ... target=/run/secrets/...,readonly` でシークレットを注入する。`docker compose` 利用時は `secrets:` セクションを使用する（後述）
 - `--network bridge` を前提とする。`--network=host` や `--network=none` では Docker 内部 DNS（`127.0.0.11:53`）前提が崩れる

--- a/docker/claude-sandbox/README.md
+++ b/docker/claude-sandbox/README.md
@@ -1,0 +1,144 @@
+# claude-sandbox
+
+`claude` CLI を `--dangerously-skip-permissions` 付きで安全に実行するためのコンテナイメージ定義。
+
+- 親 Issue: [#265](https://github.com/hirokimry/vibecorp/issues/265)
+- 本 Issue: [#266](https://github.com/hirokimry/vibecorp/issues/266)（Phase 1-1）
+- 設計判断: `.claude/knowledge/cto/decisions.md`
+- セキュリティ最低条件: `docs/SECURITY.md` の「コンテナ隔離の最低条件」セクション
+
+## 目的
+
+`--dangerously-skip-permissions` を伴う無人実行（`full` プリセットの spike-loop / ship-parallel / autopilot 等）をホスト環境から隔離された条件で実行する。CISO 最低条件 10 項目（docker.sock 非マウント / egress allowlist / secrets ファイル注入 / `.ssh` `.gnupg` 非マウント / GitHub token 最小スコープ / read-only FS / non-root / seccomp / resource limit / 定期更新）を全て満たすイメージとランタイム設定を提供する。
+
+本 Phase 1-1 ではスタンドアロンで動作するベースイメージとテストスイートのみを提供する。spike-loop / ship-parallel への統合は Phase 1-2（#267）以降で行う。
+
+## ビルド
+
+```bash
+docker build -t vibecorp/claude-sandbox:dev docker/claude-sandbox/
+```
+
+初回ビルドは 5 分以内に完了することを受け入れ基準としている（`tests/test_container_sandbox.sh` で計測）。
+
+## 推奨起動コマンド
+
+CISO 最低条件 1〜9 を全て満たす `docker run` の最小形。Phase 1-1 では claude CLI 起動の確認のみを目的とし、worktree / spike-loop との統合は Phase 1-2 以降で扱う。
+
+```bash
+docker run --rm \
+    --init \
+    --read-only \
+    --tmpfs /tmp:rw,size=256m \
+    --tmpfs /state:rw,size=256m,uid=1000,gid=1000 \
+    --tmpfs /home/claude/.cache:rw,size=256m \
+    --cap-drop ALL \
+    --cap-add NET_ADMIN \
+    --cap-add SETUID \
+    --cap-add SETGID \
+    --security-opt seccomp=./seccomp.json \
+    --security-opt no-new-privileges \
+    --memory 2g --cpus 2 --pids-limit 512 \
+    --network bridge \
+    -v "$(pwd)/workspace:/workspace:rw" \
+    --mount type=bind,source="$HOME/.gitconfig",target=/home/claude/.gitconfig,readonly \
+    --mount type=bind,source="$HOME/.config/gh",target=/home/claude/.config/gh,readonly \
+    --mount type=bind,source="$PWD/secrets/anthropic_api_key",target=/run/secrets/anthropic_api_key,readonly \
+    --mount type=bind,source="$PWD/secrets/github_token",target=/run/secrets/github_token,readonly \
+    vibecorp/claude-sandbox:dev \
+    claude -p --permission-mode dontAsk --verbose "$@"
+```
+
+### 補足
+
+- `--user` は指定しない。entrypoint.sh が root で iptables 設定後、`setpriv --reuid=1000 --regid=1000 --bounding-set=-cap_net_admin,-cap_net_raw,-cap_sys_admin` で降格する。事前に `--user 1000:1000` を指定すると iptables の OUTPUT 書き換えが行えなくなり egress allowlist が機能しないため禁止
+- `CLAUDE_PROJECT_DIR` は Dockerfile の `ENV` で `/workspace` に設定済み
+- `docker run` には `--secret` フラグが存在しないため、`--mount type=bind ... target=/run/secrets/...,readonly` でシークレットを注入する。`docker compose` 利用時は `secrets:` セクションを使用する（後述）
+- `--network bridge` を前提とする。`--network=host` や `--network=none` では Docker 内部 DNS（`127.0.0.11:53`）前提が崩れる
+
+### docker compose での例
+
+`docker compose` を利用する場合のシークレット注入例:
+
+```yaml
+services:
+  claude-sandbox:
+    image: vibecorp/claude-sandbox:dev
+    init: true
+    read_only: true
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_ADMIN
+      - SETUID
+      - SETGID
+    security_opt:
+      - "seccomp=./seccomp.json"
+      - "no-new-privileges"
+    mem_limit: 2g
+    cpus: 2
+    pids_limit: 512
+    tmpfs:
+      - /tmp:size=256m
+      - /state:size=256m,uid=1000,gid=1000
+      - /home/claude/.cache:size=256m
+    volumes:
+      - ./workspace:/workspace:rw
+      - ${HOME}/.gitconfig:/home/claude/.gitconfig:ro
+      - ${HOME}/.config/gh:/home/claude/.config/gh:ro
+    secrets:
+      - anthropic_api_key
+      - github_token
+
+secrets:
+  anthropic_api_key:
+    file: ./secrets/anthropic_api_key
+  github_token:
+    file: ./secrets/github_token
+```
+
+## 禁止事項
+
+以下の操作は CISO 最低条件に抵触する。絶対に行わないこと。
+
+| 禁止操作 | 理由 |
+|----------|------|
+| `-v /var/run/docker.sock:/var/run/docker.sock` | docker.sock はコンテナエスケープの直接経路 |
+| `-v $HOME/.ssh:/home/claude/.ssh` | SSH 秘密鍵の流出経路。Phase 2-1 で deploy key 方式を設計 |
+| `-v $HOME/.gnupg:/home/claude/.gnupg` | GPG 秘密鍵の流出経路 |
+| `-e ANTHROPIC_API_KEY=...` | env 経由は `env` コマンド 1 発で露出。必ず `/run/secrets/` ファイル注入 |
+| `-e GH_TOKEN=...` | 同上 |
+| `--user 1000:1000`（事前降格） | iptables 設定ができず egress allowlist が機能しない |
+| `--privileged` | seccomp / capability drop を全て無効化する |
+| `--network host` | ホストネットワーク名前空間に侵入、isolation 崩壊 |
+
+## CISO 最低条件チェックリスト対応表
+
+| # | 最低条件 | 実装 |
+|---|----------|------|
+| 1 | docker.sock 非マウント | 本 README で禁止を明記、テストで触らない |
+| 2 | egress allowlist（`api.anthropic.com` / `api.github.com` / `github.com` のみ許可） | `entrypoint.sh` が `iptables -P OUTPUT DROP` → DNS / allowlist ホストのみ ACCEPT |
+| 3 | secrets を環境変数で渡さない | `/run/secrets/anthropic_api_key` / `/run/secrets/github_token` を `--mount type=bind` で ro 注入 |
+| 4 | `.ssh` / `.gnupg` 非マウント | 本 README で禁止を明記。Phase 2-1 で deploy key 方式を設計 |
+| 5 | GitHub token 最小スコープ | fine-grained token で対象リポジトリ・対象操作のみに制限（運用ガイド） |
+| 6 | read-only FS + 最小 overlay | `--read-only` + 必要な tmpfs（`/tmp` / `/state` / `/home/claude/.cache`）のみ |
+| 7 | non-root 実行 | UID/GID 1000 の `claude` ユーザー + `setpriv` による bounding set drop |
+| 8 | seccomp プロファイル | `seccomp.json` で `ptrace` / `mount` / `pivot_root` / `bpf` / `unshare` / `setns` / `reboot` / `kexec_load` / `swapon` / `swapoff` / `init_module` / `perf_event_open` を拒否 |
+| 9 | resource limit | `--memory` / `--cpus` / `--pids-limit` を必須化 |
+| 10 | 定期更新・脆弱性スキャン | 運用セクション参照（本 Issue スコープ外） |
+
+## 運用
+
+- ベースイメージ（`node:20-slim`）は定期的に `docker pull` して再ビルドする
+- `@anthropic-ai/claude-code` は `@latest` で再ビルドすることで自動更新される（再現性が必要な運用ではイメージタグを固定する）
+- 脆弱性スキャンは `trivy image vibecorp/claude-sandbox:dev` 等を利用（自動化は別 Issue）
+
+## TODO（本 Issue スコープ外）
+
+- spike-loop 統合（Phase 1-2 / #267）
+- worktree ↔ コンテナマウント設計と deploy key 方式による GitHub push（Phase 2-1 / #268）
+- 全ヘッドレス実行のコンテナ統合（Phase 2-2 / #269）
+- `install.sh` 統合と `full` プリセット条件付き必須化（Phase 2-3 / #270）
+- 脆弱性スキャンの自動化（別 Issue）
+- Docker default seccomp profile をベースにしたより厳格なプロファイルへの移行
+- CDN IP ローテーション対策としての HTTPS フォワードプロキシ（tinyproxy / squid）sidecar 方式の評価

--- a/docker/claude-sandbox/entrypoint.sh
+++ b/docker/claude-sandbox/entrypoint.sh
@@ -20,32 +20,71 @@ ALLOWED_HOSTS=(
 configure_egress_allowlist() {
     # OUTPUT チェーンのデフォルトポリシーを DROP に変更
     iptables -P OUTPUT DROP
+    # ip6tables が利用可能な環境では IPv6 側も同様に DROP にする（IPv6 経由の漏洩防止）
+    if command -v ip6tables >/dev/null; then
+        ip6tables -P OUTPUT DROP
+    fi
 
     # loopback は常時許可
     iptables -A OUTPUT -o lo -j ACCEPT
+    if command -v ip6tables >/dev/null; then
+        ip6tables -A OUTPUT -o lo -j ACCEPT
+    fi
 
     # DNS 解決用（53/udp, 53/tcp）
     iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
     iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+    if command -v ip6tables >/dev/null; then
+        ip6tables -A OUTPUT -p udp --dport 53 -j ACCEPT
+        ip6tables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+    fi
 
     # allowlist ホストを DNS 解決して ACCEPT ルール追加
     # 注: CDN IP ローテーション対策として ESTABLISHED,RELATED も許可する
+    # IPv4 と IPv6 を分けて解決する（ahosts は両方を返すため iptables に食わせると失敗する）
     local host ip
     for host in "${ALLOWED_HOSTS[@]}"; do
         while read -r ip; do
             if [[ -n "$ip" ]]; then
                 iptables -A OUTPUT -p tcp -d "$ip" --dport 443 -j ACCEPT
             fi
-        done < <(getent ahosts "$host" | awk '{ print $1 }' | sort -u)
+        done < <(getent ahostsv4 "$host" | awk '{ print $1 }' | sort -u)
+
+        if command -v ip6tables >/dev/null; then
+            while read -r ip; do
+                if [[ -n "$ip" ]]; then
+                    ip6tables -A OUTPUT -p tcp -d "$ip" --dport 443 -j ACCEPT
+                fi
+            done < <(getent ahostsv6 "$host" | awk '{ print $1 }' | sort -u)
+        fi
     done
 
     # 既存接続と関連接続は許可（CDN IP ローテーションへの部分的フォールバック）
     iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+    if command -v ip6tables >/dev/null; then
+        ip6tables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+    fi
 }
 
 load_secrets() {
     # Docker secrets のファイル経由注入
     # host 側からの -e ANTHROPIC_API_KEY= 等の env 渡しは禁止
+    # secret file が無いのに env が設定済みの場合は、host 側の -e 渡しと判定して明示的に拒否する
+    if [[ ! -f /run/secrets/anthropic_api_key && -n "${ANTHROPIC_API_KEY:-}" ]]; then
+        echo "エラー: ANTHROPIC_API_KEY が env で注入されています。" >&2
+        echo "        host 側からの -e 渡しは禁止です。" >&2
+        echo "        /run/secrets/anthropic_api_key を bind mount で注入してください。" >&2
+        echo "        詳細: docs/SECURITY.md の「コンテナ隔離の最低条件」項目 3 を参照。" >&2
+        exit 1
+    fi
+    if [[ ! -f /run/secrets/github_token && -n "${GH_TOKEN:-}" ]]; then
+        echo "エラー: GH_TOKEN が env で注入されています。" >&2
+        echo "        host 側からの -e 渡しは禁止です。" >&2
+        echo "        /run/secrets/github_token を bind mount で注入してください。" >&2
+        echo "        詳細: docs/SECURITY.md の「コンテナ隔離の最低条件」項目 3 を参照。" >&2
+        exit 1
+    fi
+
     if [[ -f /run/secrets/anthropic_api_key ]]; then
         ANTHROPIC_API_KEY="$(cat /run/secrets/anthropic_api_key)"
         export ANTHROPIC_API_KEY

--- a/docker/claude-sandbox/entrypoint.sh
+++ b/docker/claude-sandbox/entrypoint.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# claude-sandbox entrypoint
+#
+# 処理順序:
+#   1. root 権限で iptables OUTPUT allowlist を設定
+#   2. /run/secrets/ からシークレットを読み取り env に展開
+#   3. setpriv で UID/GID 1000 に降格し、capability bounding set から
+#      NET_ADMIN / NET_RAW / SYS_ADMIN を drop（降格後の再取得を不可能にする）
+#
+# 参照: Issue #266 / .claude/knowledge/ciso/decisions.md
+set -euo pipefail
+set -o pipefail
+
+ALLOWED_HOSTS=(
+    api.anthropic.com
+    api.github.com
+    github.com
+)
+
+configure_egress_allowlist() {
+    # OUTPUT チェーンのデフォルトポリシーを DROP に変更
+    iptables -P OUTPUT DROP
+
+    # loopback は常時許可
+    iptables -A OUTPUT -o lo -j ACCEPT
+
+    # DNS 解決用（53/udp, 53/tcp）
+    iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+    iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+
+    # allowlist ホストを DNS 解決して ACCEPT ルール追加
+    # 注: CDN IP ローテーション対策として ESTABLISHED,RELATED も許可する
+    local host ip
+    for host in "${ALLOWED_HOSTS[@]}"; do
+        while read -r ip; do
+            if [[ -n "$ip" ]]; then
+                iptables -A OUTPUT -p tcp -d "$ip" --dport 443 -j ACCEPT
+            fi
+        done < <(getent ahosts "$host" | awk '{ print $1 }' | sort -u)
+    done
+
+    # 既存接続と関連接続は許可（CDN IP ローテーションへの部分的フォールバック）
+    iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+}
+
+load_secrets() {
+    # Docker secrets のファイル経由注入
+    # host 側からの -e ANTHROPIC_API_KEY= 等の env 渡しは禁止
+    if [[ -f /run/secrets/anthropic_api_key ]]; then
+        ANTHROPIC_API_KEY="$(cat /run/secrets/anthropic_api_key)"
+        export ANTHROPIC_API_KEY
+    fi
+    if [[ -f /run/secrets/github_token ]]; then
+        GH_TOKEN="$(cat /run/secrets/github_token)"
+        export GH_TOKEN
+    fi
+}
+
+main() {
+    configure_egress_allowlist
+    load_secrets
+
+    # non-root 降格 + capability bounding set 完全 drop
+    # 降格後プロセスは NET_ADMIN / SETUID / SETGID 等を再取得できず iptables の後戻りや再度の uid 変更が物理的に不可能
+    exec setpriv \
+        --reuid=1000 \
+        --regid=1000 \
+        --clear-groups \
+        --inh-caps=-all \
+        --bounding-set=-all \
+        -- "$@"
+}
+
+main "$@"

--- a/docker/claude-sandbox/seccomp.json
+++ b/docker/claude-sandbox/seccomp.json
@@ -1,0 +1,93 @@
+{
+    "defaultAction": "SCMP_ACT_ALLOW",
+    "archMap": [
+        {
+            "architecture": "SCMP_ARCH_X86_64",
+            "subArchitectures": [
+                "SCMP_ARCH_X86",
+                "SCMP_ARCH_X32"
+            ]
+        },
+        {
+            "architecture": "SCMP_ARCH_AARCH64",
+            "subArchitectures": [
+                "SCMP_ARCH_ARM"
+            ]
+        }
+    ],
+    "syscalls": [
+        {
+            "names": [
+                "ptrace",
+                "process_vm_readv",
+                "process_vm_writev"
+            ],
+            "action": "SCMP_ACT_ERRNO",
+            "comment": "debugger / 他プロセスメモリアクセス禁止"
+        },
+        {
+            "names": [
+                "mount",
+                "umount",
+                "umount2",
+                "pivot_root",
+                "chroot",
+                "fsmount",
+                "fsopen",
+                "move_mount",
+                "open_tree"
+            ],
+            "action": "SCMP_ACT_ERRNO",
+            "comment": "ファイルシステム名前空間操作の禁止"
+        },
+        {
+            "names": [
+                "bpf"
+            ],
+            "action": "SCMP_ACT_ERRNO",
+            "comment": "eBPF プログラム操作の禁止"
+        },
+        {
+            "names": [
+                "unshare",
+                "setns"
+            ],
+            "action": "SCMP_ACT_ERRNO",
+            "comment": "名前空間の脱出や再構成を禁止（CLONE_NEWUSER/NEWNS/NEWNET 等の経路を遮断）"
+        },
+        {
+            "names": [
+                "reboot",
+                "kexec_load",
+                "kexec_file_load"
+            ],
+            "action": "SCMP_ACT_ERRNO",
+            "comment": "ホストの再起動 / カーネル入れ替え禁止"
+        },
+        {
+            "names": [
+                "swapon",
+                "swapoff"
+            ],
+            "action": "SCMP_ACT_ERRNO",
+            "comment": "swap 操作禁止"
+        },
+        {
+            "names": [
+                "init_module",
+                "finit_module",
+                "delete_module",
+                "create_module"
+            ],
+            "action": "SCMP_ACT_ERRNO",
+            "comment": "カーネルモジュール操作禁止"
+        },
+        {
+            "names": [
+                "perf_event_open"
+            ],
+            "action": "SCMP_ACT_ERRNO",
+            "comment": "perf_event は情報漏洩・権限昇格の経路になり得る"
+        }
+    ]
+}

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -48,5 +48,5 @@
 9. **resource limit**: `--memory` / `--cpus` / `--pids-limit` を必ず指定する
 10. **イメージの定期更新と脆弱性スキャン**: ベースイメージ・依存パッケージを定期的に更新し、`trivy` 等で CVE スキャンを実施する
 
-参考実装: `docker/claude-sandbox/` （Issue #266 / Phase 1-1）
+参考実装: `docker/claude-sandbox/` — コンテナ隔離を使用する場合は当該ディレクトリの `README.md` に記載された推奨 `docker run` コマンドを出発点とし、利用プロジェクトの要件に合わせてマウント・secrets 注入を調整すること（Issue #266 / Phase 1-1）
 参考判断記録: `.claude/knowledge/ciso/decisions.md` の `2026-04-11: --dangerously-skip-permissions のコンテナ隔離構想 評価`

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -43,10 +43,10 @@
 4. **.ssh / .gnupg の非マウント**: `~/.ssh` および `~/.gnupg` はマウントしない。必要な場合は操作専用の使い捨て deploy key を用いる
 5. **GitHub token の最小スコープ**: fine-grained token で対象リポジトリ・対象操作のみに制限する
 6. **read-only rootfs**: `--read-only` を有効化し、書き込み可能領域は `/workspace`（bind mount）/ `/state`（tmpfs）/ `/tmp`（tmpfs）/ `/home/$USER/.cache`（tmpfs）に限定する
-7. **非 root 実行**: UID 0 でプロセスを起動しない。entrypoint で iptables 設定後に `setpriv` で UID 1000 に降格し、同時に capability bounding set 全体を drop する（降格後の NET_ADMIN / SETUID / SETGID 等の再取得を物理的に不可能にする）
+7. **非 root 実行**: init 完了後のワークロードプロセスは UID 0 で実行しない。entrypoint は起動直後に root で iptables allowlist 設定等の特権セットアップを行った上で、`setpriv --reuid=1000 --regid=1000 --clear-groups --inh-caps=-all --bounding-set=-all` により UID 1000 へ降格し、capability bounding set 全体を drop する（降格後の NET_ADMIN / SETUID / SETGID 等の再取得を物理的に不可能にする）。`--user 1000:1000` による事前降格は iptables 設定不可となり egress allowlist が機能しないため禁止する
 8. **seccomp プロファイル**: `ptrace` / `mount` / `umount2` / `pivot_root` / `chroot` / `bpf` / `unshare(CLONE_NEW*)` / `setns` / `reboot` / `kexec_load` / `swapon` / `swapoff` / `init_module` / `perf_event_open` を拒否する
 9. **resource limit**: `--memory` / `--cpus` / `--pids-limit` を必ず指定する
 10. **イメージの定期更新と脆弱性スキャン**: ベースイメージ・依存パッケージを定期的に更新し、`trivy` 等で CVE スキャンを実施する
 
-参考実装: `docker/claude-sandbox/` — コンテナ隔離を使用する場合は当該ディレクトリの `README.md` に記載された推奨 `docker run` コマンドを出発点とし、利用プロジェクトの要件に合わせてマウント・secrets 注入を調整すること（Issue #266 / Phase 1-1）
-参考判断記録: `.claude/knowledge/ciso/decisions.md` の `2026-04-11: --dangerously-skip-permissions のコンテナ隔離構想 評価`
+参考実装: `docker/claude-sandbox/` — コンテナ隔離を使用する場合は当該ディレクトリの `README.md` に記載された推奨 `docker run` コマンドを出発点とし、利用プロジェクトの要件に合わせてマウント・secrets 注入を調整すること。entrypoint 実装は `docker/claude-sandbox/entrypoint.sh` を参照（Issue #266 / Phase 1-1）
+参考判断記録: `.claude/knowledge/cto/decisions.md` の `2026-04-11: docker/claude-sandbox/ のリポジトリトップレベル配置判断` および `2026-04-11: seccomp プロファイルを ALLOW デフォルト + 特定 syscall denial 構成で実装`

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -32,3 +32,21 @@
 ## インシデント対応
 
 （セキュリティインシデント発生時の対応手順を記載）
+
+## コンテナ隔離の最低条件
+
+`--dangerously-skip-permissions` を伴う無人実行（`full` プリセットの spike-loop / ship-parallel / autopilot 等）は以下の最低条件を全て満たしたコンテナ環境で実行しなければならない（MUST）。1 項目でも欠ける場合は NO-GO とする。
+
+1. **docker.sock を非マウント**: `/var/run/docker.sock` のマウントは絶対禁止（コンテナエスケープの直接経路になる）
+2. **egress allowlist**: `api.anthropic.com` / `api.github.com` / `github.com` のみ許可し、それ以外への外部通信を遮断する
+3. **secrets の環境変数渡し禁止**: GitHub token / Anthropic API key は Docker secrets または `/run/secrets/` への読み取り専用 bind mount で注入する。`docker run -e ANTHROPIC_API_KEY=...` のような host 側からの env 渡しは禁止
+4. **.ssh / .gnupg の非マウント**: `~/.ssh` および `~/.gnupg` はマウントしない。必要な場合は操作専用の使い捨て deploy key を用いる
+5. **GitHub token の最小スコープ**: fine-grained token で対象リポジトリ・対象操作のみに制限する
+6. **read-only rootfs**: `--read-only` を有効化し、書き込み可能領域は `/workspace`（bind mount）/ `/state`（tmpfs）/ `/tmp`（tmpfs）/ `/home/$USER/.cache`（tmpfs）に限定する
+7. **非 root 実行**: UID 0 でプロセスを起動しない。entrypoint で iptables 設定後に `setpriv` で UID 1000 に降格し、同時に capability bounding set 全体を drop する（降格後の NET_ADMIN / SETUID / SETGID 等の再取得を物理的に不可能にする）
+8. **seccomp プロファイル**: `ptrace` / `mount` / `umount2` / `pivot_root` / `chroot` / `bpf` / `unshare(CLONE_NEW*)` / `setns` / `reboot` / `kexec_load` / `swapon` / `swapoff` / `init_module` / `perf_event_open` を拒否する
+9. **resource limit**: `--memory` / `--cpus` / `--pids-limit` を必ず指定する
+10. **イメージの定期更新と脆弱性スキャン**: ベースイメージ・依存パッケージを定期的に更新し、`trivy` 等で CVE スキャンを実施する
+
+参考実装: `docker/claude-sandbox/` （Issue #266 / Phase 1-1）
+参考判断記録: `.claude/knowledge/ciso/decisions.md` の `2026-04-11: --dangerously-skip-permissions のコンテナ隔離構想 評価`

--- a/tests/test_container_sandbox.sh
+++ b/tests/test_container_sandbox.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+# test_container_sandbox.sh — docker/claude-sandbox/ の統合テスト
+# 使い方: bash tests/test_container_sandbox.sh
+# CI: GitHub Actions（ubuntu-latest のみ実行、macOS では skip）
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DOCKER_DIR="${SCRIPT_DIR}/docker/claude-sandbox"
+SECCOMP_PATH="${DOCKER_DIR}/seccomp.json"
+IMAGE_TAG="vibecorp/claude-sandbox:test-$$"
+
+# 本イメージは entrypoint.sh が root 権限で iptables を設定し setpriv で UID 1000 に降格する構成のため
+# 最低限 NET_ADMIN / SETUID / SETGID を付与する必要がある
+CAPS_ARGS=(--cap-drop ALL --cap-add NET_ADMIN --cap-add SETUID --cap-add SETGID)
+
+PASSED=0
+FAILED=0
+TOTAL=0
+
+pass() {
+    PASSED=$((PASSED + 1))
+    TOTAL=$((TOTAL + 1))
+    echo "  PASS: $1"
+}
+
+fail() {
+    FAILED=$((FAILED + 1))
+    TOTAL=$((TOTAL + 1))
+    echo "  FAIL: $1"
+}
+
+# --- Docker 未導入時は skip（macOS CI runner 等） ---
+
+if ! command -v docker >/dev/null; then
+    echo "SKIP: docker コマンドが見つからないためテストをスキップします"
+    exit 0
+fi
+
+if ! docker info >/dev/null; then
+    echo "SKIP: docker daemon が起動していないためテストをスキップします"
+    exit 0
+fi
+
+# --- クリーンアップ ---
+
+cleanup() {
+    # 終了コードに影響を与えないようサブシェルで隔離
+    (
+        set +e
+        docker rmi -f "$IMAGE_TAG" >/dev/null 2>&1
+    )
+}
+trap cleanup EXIT
+
+# ============================================
+echo "=== docker-sandbox ビルド検証 ==="
+# ============================================
+
+# ケース 1: ビルドが成功し 5 分以内に完了する
+echo "--- ビルド開始（5 分以内が受け入れ基準）---"
+BUILD_START=$(date +%s)
+if docker build -t "$IMAGE_TAG" "$DOCKER_DIR"; then
+    BUILD_END=$(date +%s)
+    BUILD_DURATION=$((BUILD_END - BUILD_START))
+    if [ "$BUILD_DURATION" -le 300 ]; then
+        pass "ビルドが 300 秒以内に完了 (${BUILD_DURATION}s)"
+    else
+        fail "ビルドが 300 秒を超過 (${BUILD_DURATION}s)"
+    fi
+else
+    fail "docker build が失敗"
+    echo ""
+    echo "=== 結果: $PASSED/$TOTAL passed, $FAILED failed ==="
+    exit 1
+fi
+
+# ============================================
+echo ""
+echo "=== 起動検証 ==="
+# ============================================
+
+# ケース 2: claude --version が正常終了する
+if docker run --rm "${CAPS_ARGS[@]}" "$IMAGE_TAG" claude --version >/dev/null; then
+    pass "claude --version が正常終了"
+else
+    fail "claude --version が失敗"
+fi
+
+# ============================================
+echo ""
+echo "=== non-root 降格検証 ==="
+# ============================================
+
+# ケース 3: id -un が claude を返す
+UN=$(docker run --rm --read-only --tmpfs /tmp --tmpfs /state --tmpfs /home/claude/.cache \
+    "${CAPS_ARGS[@]}" \
+    "$IMAGE_TAG" id -un)
+if [ "$UN" = "claude" ]; then
+    pass "降格後のユーザーが claude"
+else
+    fail "降格後のユーザーが claude でない (実際: $UN)"
+fi
+
+# ============================================
+echo ""
+echo "=== read-only rootfs 検証 ==="
+# ============================================
+
+# ケース 4: rootfs への書き込みが失敗する
+if docker run --rm --read-only --tmpfs /tmp --tmpfs /state --tmpfs /home/claude/.cache \
+    "${CAPS_ARGS[@]}" \
+    "$IMAGE_TAG" sh -c 'touch /etc/test-ro' >/dev/null 2>&1; then
+    fail "read-only rootfs なのに /etc/test-ro に書き込めた"
+else
+    pass "read-only rootfs で /etc への書き込みが失敗"
+fi
+
+# ============================================
+echo ""
+echo "=== egress allowlist 検証 ==="
+# ============================================
+
+# ケース 5: 許可外ホストへの接続が失敗する
+if docker run --rm --read-only --tmpfs /tmp --tmpfs /state --tmpfs /home/claude/.cache \
+    "${CAPS_ARGS[@]}" \
+    "$IMAGE_TAG" sh -c 'curl -fsS --max-time 5 https://example.com' >/dev/null 2>&1; then
+    fail "example.com への接続が遮断されていない"
+else
+    pass "example.com への接続が遮断されている"
+fi
+
+# ケース 6: allowlist ホストの DNS 解決が成功する
+if docker run --rm --read-only --tmpfs /tmp --tmpfs /state --tmpfs /home/claude/.cache \
+    "${CAPS_ARGS[@]}" \
+    "$IMAGE_TAG" sh -c 'getent hosts api.anthropic.com' >/dev/null 2>&1; then
+    pass "api.anthropic.com の DNS 解決が成功"
+else
+    fail "api.anthropic.com の DNS 解決が失敗"
+fi
+
+# ============================================
+echo ""
+echo "=== seccomp プロファイル検証 ==="
+# ============================================
+
+# ケース 7a: seccomp.json が JSON として妥当
+if jq empty "$SECCOMP_PATH" >/dev/null; then
+    pass "seccomp.json が妥当な JSON"
+else
+    fail "seccomp.json が妥当な JSON でない"
+fi
+
+# ケース 7b: seccomp プロファイルを適用して起動できる
+if docker run --rm --security-opt "seccomp=${SECCOMP_PATH}" \
+    "${CAPS_ARGS[@]}" \
+    "$IMAGE_TAG" claude --version >/dev/null; then
+    pass "seccomp プロファイル適用で claude --version が成功"
+else
+    fail "seccomp プロファイル適用で claude --version が失敗"
+fi
+
+# ============================================
+echo ""
+echo "=== resource limit 検証 ==="
+# ============================================
+
+# ケース 8: --memory / --pids-limit が docker inspect で反映されている
+LIMITS_NAME="vibecorp-sandbox-limits-$$"
+docker run -d --rm \
+    --memory 2g --cpus 2 --pids-limit 512 \
+    "${CAPS_ARGS[@]}" \
+    --name "$LIMITS_NAME" \
+    "$IMAGE_TAG" sleep 30 >/dev/null
+
+# インスペクトして memory / pids-limit を取得
+INSPECT=$(docker inspect "$LIMITS_NAME" --format '{{.HostConfig.Memory}} {{.HostConfig.PidsLimit}}')
+EXPECTED_MEM=$((2 * 1024 * 1024 * 1024))
+
+# クリーンアップ
+docker stop "$LIMITS_NAME" >/dev/null
+
+if [ "$INSPECT" = "${EXPECTED_MEM} 512" ]; then
+    pass "resource limit が期待値と一致 (${INSPECT})"
+else
+    fail "resource limit が期待値と不一致 (実際: ${INSPECT}, 期待: ${EXPECTED_MEM} 512)"
+fi
+
+# ============================================
+echo ""
+echo "=== 結果: $PASSED/$TOTAL passed, $FAILED failed ==="
+
+if [ "$FAILED" -gt 0 ]; then
+    exit 1
+fi

--- a/tests/test_container_sandbox.sh
+++ b/tests/test_container_sandbox.sh
@@ -165,7 +165,7 @@ echo ""
 echo "=== resource limit 検証 ==="
 # ============================================
 
-# ケース 8: --memory / --pids-limit が docker inspect で反映されている
+# ケース 8: --memory / --cpus / --pids-limit が docker inspect で反映されている
 LIMITS_NAME="vibecorp-sandbox-limits-$$"
 docker run -d --rm \
     --memory 2g --cpus 2 --pids-limit 512 \
@@ -173,17 +173,18 @@ docker run -d --rm \
     --name "$LIMITS_NAME" \
     "$IMAGE_TAG" sleep 30 >/dev/null
 
-# インスペクトして memory / pids-limit を取得
-INSPECT=$(docker inspect "$LIMITS_NAME" --format '{{.HostConfig.Memory}} {{.HostConfig.PidsLimit}}')
+# インスペクトして memory / pids-limit / nanocpus を取得
+INSPECT=$(docker inspect "$LIMITS_NAME" --format '{{.HostConfig.Memory}} {{.HostConfig.PidsLimit}} {{.HostConfig.NanoCpus}}')
 EXPECTED_MEM=$((2 * 1024 * 1024 * 1024))
+EXPECTED_CPUS_NANO=$((2 * 1000000000))
 
 # クリーンアップ
 docker stop "$LIMITS_NAME" >/dev/null
 
-if [ "$INSPECT" = "${EXPECTED_MEM} 512" ]; then
+if [ "$INSPECT" = "${EXPECTED_MEM} 512 ${EXPECTED_CPUS_NANO}" ]; then
     pass "resource limit が期待値と一致 (${INSPECT})"
 else
-    fail "resource limit が期待値と不一致 (実際: ${INSPECT}, 期待: ${EXPECTED_MEM} 512)"
+    fail "resource limit が期待値と不一致 (実際: ${INSPECT}, 期待: ${EXPECTED_MEM} 512 ${EXPECTED_CPUS_NANO})"
 fi
 
 # ============================================


### PR DESCRIPTION
close #266

## Summary

Issue #265 親 issue の Phase 1-1 として、`claude --dangerously-skip-permissions` を安全に実行するためのコンテナベースイメージと統合テストを追加する。

- `docker/claude-sandbox/` 新規作成: Dockerfile / entrypoint.sh / seccomp.json / README.md / .dockerignore
- `tests/test_container_sandbox.sh` 新規作成: ビルド時間・non-root 降格・read-only FS・egress allowlist・seccomp 適用・resource limit を検証（9 ケース、Docker 未導入環境では skip）
- `.claude/knowledge/cto/decisions.md`: `docker/claude-sandbox/` 配置判断と seccomp プロファイル構成判断（2 エントリ）
- `docs/SECURITY.md`: 「コンテナ隔離の最低条件」セクションを追記

## 設計のポイント

- **多層防御**: `--cap-drop ALL` + `--cap-add NET_ADMIN/SETUID/SETGID` + `setpriv --bounding-set=-all` で降格、iptables allowlist、seccomp（ptrace/mount/pivot_root/bpf/unshare/setns/reboot 等を ERRNO 拒否）、`--read-only` rootfs、resource limit を全て組み合わせる
- **secrets の扱い**: `docker run -e` を禁止し、`--mount type=bind ... target=/run/secrets/...,readonly` で `/run/secrets/anthropic_api_key` / `/run/secrets/github_token` をファイル経由注入。entrypoint.sh が読み取って env に展開
- **CAP_NET_ADMIN の再取得防止**: setpriv で bounding set を完全 drop し、iptables ルールの後戻りと uid 再取得を物理的に不可能にする
- **docker.sock / .ssh / .gnupg マウントの絶対禁止** を README で明示
- **base ブランチ**: `main` ではなく `feature/container-isolation`（Phase 1-1〜2-3 の完了まで feature ブランチで完成させる方針）

## Test plan

- [x] `bash tests/test_container_sandbox.sh` がローカル（Docker / OrbStack）で 9/9 passed
- [x] `jq empty docker/claude-sandbox/seccomp.json` が妥当
- [x] ビルド時間 < 5 分（計測値: 約 8 秒（キャッシュ無し初回約 2 分強））
- [x] egress allowlist: `example.com` 接続が失敗、`api.anthropic.com` DNS 解決が成功
- [x] non-root 降格: `id -un` が `claude`
- [x] read-only rootfs: `/etc/test-ro` への書き込み失敗
- [x] seccomp 適用状態で `claude --version` 動作
- [x] resource limit: `docker inspect` で `--memory 2g --pids-limit 512` 反映確認
- [x] CodeRabbit review: No findings
- [x] sync-check: CTO / CPO 並列、Minor 指摘 1 件を修正

## スコープ外（後続 Issue）

- Phase 1-2 (#267): spike-loop のコンテナ統合
- Phase 2-1 (#268): ship-parallel worktree 設計、deploy key 方式
- Phase 2-2 (#269): 全ヘッドレス実行統合
- Phase 2-3 (#270): install.sh Docker 必須チェック
- Docs Issue (#271): docs/SECURITY.md の他セクション整備

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * claude CLI を安全に実行するコンテナサンドボックスを追加（非root実行、起動時の権限低下、厳格な外向き通信制御、システムコールの制限、エントリポイントでのシークレット読み込みと実行制約、デフォルトコマンド含む）。

* **Documentation**
  * コンテナ隔離の必須運用要件、推奨実行例、禁止設定一覧、CISOチェックリスト、実装/運用ノウハウと移行注記を追加。

* **Tests**
  * サンドボックス画像のビルド・起動・セキュリティ挙動・リソース制約を検証する統合テストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->