### PR TITLE
🔄 refactor: コンテナ認証を gh auth token 自動取得 + ブラウザログイン方式に移行

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,18 @@ path/to/vibecorp/install.sh --name your-project
 ### full プリセット（コンテナ隔離で自律実行）
 
 ```bash
-# Anthropic API キーと GitHub トークンを環境変数に設定
+# Anthropic API キーを環境変数に設定
 export ANTHROPIC_API_KEY="sk-ant-..."
-export GITHUB_TOKEN="ghp_..."
 
 # インストール（Docker チェック + イメージビルド + シークレット配置を自動実行）
+# GitHub トークンは gh auth login 済みなら自動取得される
 path/to/vibecorp/install.sh --name your-project --preset full
 
 # Issue を自動 ship（コンテナ内で実行される）
 claude -p "/ship <Issue URL>"
 ```
 
-環境変数が未設定の場合は対話的に入力を求める。`GH_TOKEN` を設定済みの場合はそちらも利用可能。Docker 未導入の場合は `--preset standard` への案内が表示される。
+GitHub トークンは `gh auth login` 済みなら `gh auth token` から自動取得される。`GH_TOKEN` / `GITHUB_TOKEN` 環境変数での明示指定も可能。Anthropic API キーは環境変数未設定の場合に対話的に入力を求める。Docker 未導入の場合は `--preset standard` への案内が表示される。
 
 ### バージョン指定インストール
 

--- a/docker/claude-sandbox/README.md
+++ b/docker/claude-sandbox/README.md
@@ -56,6 +56,7 @@ docker run --rm \
 - `--user` は指定しない。entrypoint.sh が root で iptables 設定後、`setpriv --reuid=1000 --regid=1000 --clear-groups --inh-caps=-all --bounding-set=-all` で降格する。事前に `--user 1000:1000` を指定すると iptables の OUTPUT 書き換えが行えなくなり egress allowlist が機能しないため禁止
 - `CLAUDE_PROJECT_DIR` は Dockerfile の `ENV` で `/workspace` に設定済み
 - `docker run` には `--secret` フラグが存在しないため、`--mount type=bind ... target=/run/secrets/...,readonly` でシークレットを注入する。`docker compose` 利用時は `secrets:` セクションを使用する（後述）
+- `secrets/github_token` は `install.sh` が自動配置する。`gh auth login` 済みなら `gh auth token` から自動取得されるため、手動でのトークン配置は通常不要
 - `--network bridge` を前提とする。`--network=host` や `--network=none` では Docker 内部 DNS（`127.0.0.11:53`）前提が崩れる
 
 ### docker compose での例

--- a/install.sh
+++ b/install.sh
@@ -448,6 +448,9 @@ setup_secrets() {
     if [[ -n "$token" ]]; then
       printf '%s' "$token" > "$token_file"
       log_info "環境変数から secrets/github_token を作成"
+    elif command -v gh >/dev/null && token=$(gh auth token 2>/dev/null) && [[ -n "$token" ]]; then
+      printf '%s' "$token" > "$token_file"
+      log_info "gh auth token から secrets/github_token を作成"
     elif [[ -t 0 ]]; then
       printf '\033[33m[INPUT]\033[0m    GitHub トークンを入力してください: ' >&2
       local gh_token

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -161,9 +161,33 @@ cleanup_mock_secrets() {
   unset ANTHROPIC_API_KEY GH_TOKEN GITHUB_TOKEN 2>/dev/null || true
 }
 
+setup_mock_gh() {
+  MOCK_GH_DIR=$(mktemp -d)
+  export MOCK_GH_DIR
+  printf '#!/bin/bash\necho "$@" >> "%s/gh_calls.log"\nif [ "$1" = "auth" ] && [ "$2" = "token" ]; then echo "gho_mock_token_12345"; exit 0; fi\nexit 0\n' "$MOCK_GH_DIR" > "$MOCK_GH_DIR/gh"
+  chmod +x "$MOCK_GH_DIR/gh"
+  export PATH="$MOCK_GH_DIR:$PATH"
+}
+
+setup_mock_gh_fail() {
+  MOCK_GH_DIR=$(mktemp -d)
+  export MOCK_GH_DIR
+  printf '#!/bin/bash\necho "$@" >> "%s/gh_calls.log"\nexit 1\n' "$MOCK_GH_DIR" > "$MOCK_GH_DIR/gh"
+  chmod +x "$MOCK_GH_DIR/gh"
+  export PATH="$MOCK_GH_DIR:$PATH"
+}
+
+cleanup_mock_gh() {
+  if [ -n "${MOCK_GH_DIR:-}" ] && [ -d "$MOCK_GH_DIR" ]; then
+    rm -rf "$MOCK_GH_DIR"
+    MOCK_GH_DIR=""
+  fi
+}
+
 cleanup() {
   cleanup_mock_docker
   cleanup_mock_secrets
+  cleanup_mock_gh
   if [ -n "$TMPDIR_ROOT" ] && [ -d "$TMPDIR_ROOT" ]; then
     rm -rf "$TMPDIR_ROOT"
   fi
@@ -2752,6 +2776,7 @@ cleanup
 # S3. 環境変数未設定 + 非対話でエラー終了する
 create_test_repo
 setup_mock_docker
+setup_mock_gh_fail
 unset ANTHROPIC_API_KEY GH_TOKEN GITHUB_TOKEN 2>/dev/null
 EXIT_CODE=$(echo "" | bash "$INSTALL_SH" --name test-proj --preset full 2>/dev/null; echo $?)
 if [[ "$EXIT_CODE" -ne 0 ]]; then
@@ -2821,6 +2846,83 @@ else
   fail "S6: full プリセット完了メッセージに /ship の使い方がない"
 fi
 unset ANTHROPIC_API_KEY GH_TOKEN
+cleanup
+
+# ============================================
+echo ""
+echo "=== S7: gh auth token 自動取得テスト ==="
+# ============================================
+
+# S7a. gh auth token が成功する場合、環境変数未設定でもトークンが配置される
+create_test_repo
+setup_mock_docker
+setup_mock_gh
+unset GH_TOKEN GITHUB_TOKEN 2>/dev/null
+export ANTHROPIC_API_KEY="test-api-key"
+bash "$INSTALL_SH" --name test-proj --preset full 2>/dev/null
+if [[ -f "$TMPDIR_ROOT/secrets/github_token" ]]; then
+  content=$(cat "$TMPDIR_ROOT/secrets/github_token")
+  if [[ "$content" == "gho_mock_token_12345" ]]; then
+    pass "S7a: gh auth token から secrets/github_token が作成される"
+  else
+    fail "S7a: secrets/github_token の内容が不正: $content"
+  fi
+else
+  fail "S7a: secrets/github_token が作成されていない"
+fi
+unset ANTHROPIC_API_KEY
+cleanup
+
+# S7b. gh auth token が失敗し gh も使えない場合、非対話でエラー終了する
+create_test_repo
+setup_mock_docker
+setup_mock_gh_fail
+unset GH_TOKEN GITHUB_TOKEN 2>/dev/null
+export ANTHROPIC_API_KEY="test-api-key"
+EXIT_CODE=$(echo "" | bash "$INSTALL_SH" --name test-proj --preset full 2>/dev/null; echo $?)
+if [[ "$EXIT_CODE" -ne 0 ]]; then
+  pass "S7b: gh auth token 失敗 + 非対話でエラー終了する"
+else
+  fail "S7b: gh auth token 失敗 + 非対話でもエラーにならなかった"
+fi
+unset ANTHROPIC_API_KEY
+cleanup
+
+# S7c. 環境変数が設定済みの場合、gh auth token は呼ばれない
+create_test_repo
+setup_mock_docker
+setup_mock_gh
+export ANTHROPIC_API_KEY="test-api-key"
+export GH_TOKEN="env-token-value"
+bash "$INSTALL_SH" --name test-proj --preset full 2>/dev/null
+content=$(cat "$TMPDIR_ROOT/secrets/github_token")
+if [[ "$content" == "env-token-value" ]]; then
+  if [[ -f "$MOCK_GH_DIR/gh_calls.log" ]] && grep -q "auth token" "$MOCK_GH_DIR/gh_calls.log"; then
+    fail "S7c: 環境変数設定済みなのに gh auth token が呼ばれた"
+  else
+    pass "S7c: 環境変数が優先され gh auth token は呼ばれない"
+  fi
+else
+  fail "S7c: secrets/github_token の内容が環境変数と一致しない: $content"
+fi
+unset ANTHROPIC_API_KEY GH_TOKEN
+cleanup
+
+# S7d. gh コマンドが PATH にない場合でも非対話でエラー終了する
+create_test_repo
+setup_mock_docker
+unset GH_TOKEN GITHUB_TOKEN 2>/dev/null
+export ANTHROPIC_API_KEY="test-api-key"
+SAVED_PATH="$PATH"
+export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v -E '(gh|homebrew|linuxbrew)' | tr '\n' ':')
+EXIT_CODE=$(echo "" | bash "$INSTALL_SH" --name test-proj --preset full 2>/dev/null; echo $?)
+export PATH="$SAVED_PATH"
+if [[ "$EXIT_CODE" -ne 0 ]]; then
+  pass "S7d: gh が PATH にない場合 + 非対話でエラー終了する"
+else
+  fail "S7d: gh が PATH にない場合でもエラーにならなかった"
+fi
+unset ANTHROPIC_API_KEY
 cleanup
 
 # ============================================


### PR DESCRIPTION
## Summary

- `install.sh` の `setup_secrets()` に `gh auth token` 自動取得フォールバックを追加
- GitHub トークンの取得優先順位: 既存ファイル → 環境変数 → `gh auth token` → 対話入力
- README のクイックスタートから `GITHUB_TOKEN` 手動設定を削除し、`gh auth login` による自動取得を案内

## Test plan

- [x] S7a: `gh auth token` から `secrets/github_token` が作成される
- [x] S7b: `gh auth token` 失敗 + 非対話でエラー終了する
- [x] S7c: 環境変数が優先され `gh auth token` は呼ばれない
- [x] S7d: `gh` が PATH にない場合 + 非対話でエラー終了する
- [x] 既存テスト 352/352 全パス

close https://github.com/hirokimry/vibecorp/issues/281

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * GitHub トークン設定手順を更新。`gh` コマンドの認証済み状態から自動取得が可能になった点を記載
  * 環境変数での明示指定やインタラクティブ入力についての説明を追加

* **New Features**
  * GitHub トークンの自動取得機能を実装。既存の認証情報から自動プロビジョニング可能に

* **Tests**
  * 自動取得機能に関する検証テストを拡充

<!-- end of auto-generated comment: release notes by coderabbit.ai -->