### PR TITLE
fix(install): プレースホルダー検出を 3 変数限定に精緻化

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -616,7 +616,9 @@ copy_managed_files() {
   local placeholder_errors=0
   for dir in "${target_dirs[@]}"; do
     while IFS= read -r f; do
-      if grep -q '{{' "$f" 2>/dev/null; then
+      # vibecorp が管理する 3 つのプレースホルダーのみを対象にする
+      # （docker inspect の {{.State.Status}} 等、テンプレート構文を含む正当なコンテンツを誤検知しないため）
+      if grep -q '{{PROJECT_NAME}}\|{{PRESET}}\|{{LANGUAGE}}' "$f" 2>/dev/null; then
         local tmp
         tmp="$(mktemp "$(dirname "$f")/.${f##*/}.XXXXXX")"
         if sed \
@@ -630,8 +632,8 @@ copy_managed_files() {
           rm -f "$tmp"
           placeholder_errors=$((placeholder_errors + 1))
         fi
-        # 置換後も未解決のプレースホルダーが残っていないか検証
-        if grep -q '{{' "$f" 2>/dev/null; then
+        # 置換後も vibecorp プレースホルダーが残っていないか検証
+        if grep -q '{{PROJECT_NAME}}\|{{PRESET}}\|{{LANGUAGE}}' "$f" 2>/dev/null; then
           log_error "未解決のプレースホルダーが残っています: $f"
           placeholder_errors=$((placeholder_errors + 1))
         fi

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -2480,16 +2480,16 @@ create_test_repo
 bash "$INSTALL_SH" --name test-proj --preset full --language ja 2>/dev/null
 R="$TMPDIR_ROOT"
 
-# hooks 内の全ファイルにプレースホルダーが残っていないこと
-REMAINING=$(grep -rl '{{' "$R/.claude/hooks/" 2>/dev/null || true)
+# hooks 内の全ファイルに vibecorp プレースホルダーが残っていないこと
+REMAINING=$(grep -rl '{{PROJECT_NAME}}\|{{PRESET}}\|{{LANGUAGE}}' "$R/.claude/hooks/" 2>/dev/null || true)
 if [ -z "$REMAINING" ]; then
   pass "AI1: hooks 内にプレースホルダーが残っていない"
 else
   fail "AI1: hooks 内にプレースホルダーが残っている: $REMAINING"
 fi
 
-# skills 内の全ファイルにプレースホルダーが残っていないこと
-REMAINING=$(grep -rl '{{' "$R/.claude/skills/" 2>/dev/null || true)
+# skills 内の全ファイルに vibecorp プレースホルダーが残っていないこと
+REMAINING=$(grep -rl '{{PROJECT_NAME}}\|{{PRESET}}\|{{LANGUAGE}}' "$R/.claude/skills/" 2>/dev/null || true)
 if [ -z "$REMAINING" ]; then
   pass "AI1: skills 内にプレースホルダーが残っていない"
 else
@@ -2497,24 +2497,52 @@ else
 fi
 cleanup
 
-# AI2. sed 置換が失敗した場合にエラーメッセージが出力される
+# AI2. --update 時に vibecorp プレースホルダーが正常に置換されること
 create_test_repo
 bash "$INSTALL_SH" --name test-proj 2>/dev/null
 R="$TMPDIR_ROOT"
 
-# 未知のプレースホルダーを含むファイルを hooks に配置して --update で再実行
+# vibecorp プレースホルダーを含むファイルを hooks に配置して --update で再実行
 echo '#!/bin/bash
-# {{UNKNOWN_PLACEHOLDER}} テスト' > "$R/.claude/hooks/test-placeholder.sh"
+# {{PROJECT_NAME}} テスト' > "$R/.claude/hooks/test-placeholder.sh"
 chmod +x "$R/.claude/hooks/test-placeholder.sh"
 
-STDERR_OUTPUT=$(bash "$INSTALL_SH" --update 2>&1 >/dev/null) || true
-if echo "$STDERR_OUTPUT" | grep -q "未解決のプレースホルダーが残っています"; then
-  pass "AI2: 未解決プレースホルダー検出時にエラーメッセージが出力される"
+bash "$INSTALL_SH" --update 2>/dev/null
+REMAINING=$(grep -l '{{PROJECT_NAME}}' "$R/.claude/hooks/test-placeholder.sh" 2>/dev/null || true)
+if [ -z "$REMAINING" ]; then
+  pass "AI2: --update でプレースホルダーが正常に置換される"
 else
-  fail "AI2: 未解決プレースホルダー検出時にエラーメッセージが出力される"
+  fail "AI2: --update でプレースホルダーが残っている"
 fi
 # クリーンアップ
 rm -f "$R/.claude/hooks/test-placeholder.sh"
+cleanup
+
+# AI2b. 未知のテンプレート構文（docker inspect 等）は誤検知しない
+create_test_repo
+bash "$INSTALL_SH" --name test-proj 2>/dev/null
+R="$TMPDIR_ROOT"
+
+# docker inspect の Go テンプレート構文を含むファイルを配置
+echo '#!/bin/bash
+# docker inspect --format "{{.State.Status}}" container
+# {{.HostConfig.Memory}} / {{.State.ExitCode}}' > "$R/.claude/hooks/test-docker-template.sh"
+chmod +x "$R/.claude/hooks/test-docker-template.sh"
+
+STDERR_OUTPUT=$(bash "$INSTALL_SH" --update 2>&1 >/dev/null) || true
+if echo "$STDERR_OUTPUT" | grep -q "未解決のプレースホルダーが残っています"; then
+  fail "AI2b: 未知のテンプレート構文が誤検知された"
+else
+  pass "AI2b: 未知のテンプレート構文を誤検知しない"
+fi
+# ファイル内容が書き換えられていないこと
+if grep -q '{{.State.Status}}' "$R/.claude/hooks/test-docker-template.sh"; then
+  pass "AI2b: 未知のテンプレート構文を保持する"
+else
+  fail "AI2b: 未知のテンプレート構文が書き換えられた"
+fi
+# クリーンアップ
+rm -f "$R/.claude/hooks/test-docker-template.sh"
 cleanup
 
 # AI3. sed 失敗時に .tmp ファイルが残らない


### PR DESCRIPTION
## Summary

`install.sh` のプレースホルダー検出 `grep -q '{{'` が、vibecorp が管理する 3 変数（`PROJECT_NAME` / `PRESET` / `LANGUAGE`）以外の正当なテンプレート構文（例: `docker inspect --format '{{.State.Status}}'`）も誤検知し、インストールを失敗させる問題を修正。

## 変更内容

- `install.sh`: プレースホルダー検出 / 残存検証の `grep` を `{{PROJECT_NAME}}\|{{PRESET}}\|{{LANGUAGE}}` 限定に
- `tests/test_install.sh` AI1 / AI2: 検出パターンを 3 変数限定に追随
- `tests/test_install.sh` AI2b: docker inspect Go テンプレート構文を誤検知しない回帰テスト追加

## 背景

Issue #294 の作業計画 PR 1（最優先・bugfix）。PR #278 (feature/container-isolation) の差分からコンテナ隔離方式と独立した改善を抽出したもの。

## Test plan

- [x] `bash tests/test_install.sh` → 334/334 passed（AI2b 追加後）
- [x] 3 変数以外の `{{...}}` を含むファイルがインストール中に誤検知されないこと（AI2b で検証）
- [ ] CI（test-matrix macos / ubuntu）通過

close #294 の PR 1 として作業計画に基づく（Issue 全体は残りの PR 2〜5 + ブランチ close 完了まで open）。

Refs: #294, #278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * プレースホルダー検出をより正確に制御し、特定のテンプレート変数のみを対象とするように改善しました。
  * テンプレート処理時の検証ロジックを強化し、不要な置換エラーを削減しました。

* **テスト**
  * テンプレート置換機能のテストケースを追加し、様々なシナリオでの動作を確認するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->