### PR TITLE
✨ feat: claude 起動時に --plugin-dir を手入力しなくてよくなった

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,12 @@
+{
+  "name": "vibecorp",
+  "owner": {
+    "name": "hirokimry"
+  },
+  "plugins": [
+    {
+      "name": "vibecorp",
+      "source": "."
+    }
+  ]
+}

--- a/install.sh
+++ b/install.sh
@@ -1423,8 +1423,13 @@ generate_settings_json() {
 
     local new_hooks
     new_hooks=$(echo "$new_settings" | jq '.hooks.PreToolUse')
+    local new_marketplaces
+    new_marketplaces=$(echo "$new_settings" | jq '.extraKnownMarketplaces // {}')
+    local new_enabled_plugins
+    new_enabled_plugins=$(echo "$new_settings" | jq '.enabledPlugins // {}')
 
-    jq --argjson new "$new_hooks" --argjson managed "$managed_hooks_json" '
+    jq --argjson new "$new_hooks" --argjson managed "$managed_hooks_json" \
+       --argjson new_mkts "$new_marketplaces" --argjson new_plugins "$new_enabled_plugins" '
       def is_managed_hook:
         (.command | split("/") | last) as $basename |
         any($managed[]; . == $basename);
@@ -1438,8 +1443,12 @@ generate_settings_json() {
         | group_by(.matcher)
         | map({matcher: .[0].matcher, hooks: ([.[].hooks[]] | unique_by(.command))})
       )
+      # extraKnownMarketplaces / enabledPlugins はテンプレート値で既存をオーバーレイする
+      # （vibecorp 自身のエントリだけを上書きし、ユーザー追加分は保持される）
+      | .extraKnownMarketplaces = ((.extraKnownMarketplaces // {}) + $new_mkts)
+      | .enabledPlugins = ((.enabledPlugins // {}) + $new_plugins)
     ' "$settings" > "${settings}.tmp" && mv "${settings}.tmp" "$settings"
-    log_info "settings.json をマージ（ユーザーフック保持）"
+    log_info "settings.json をマージ（ユーザーフック・marketplace 保持）"
   fi
 }
 

--- a/templates/claude/settings.json
+++ b/templates/claude/settings.json
@@ -1,4 +1,15 @@
 {
+  "extraKnownMarketplaces": {
+    "vibecorp": {
+      "source": {
+        "source": "github",
+        "repo": "hirokimry/vibecorp"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "vibecorp@vibecorp": true
+  },
   "permissions": {
     "allow": [
       "Write(.claude/knowledge/**)",

--- a/templates/settings.json.tpl
+++ b/templates/settings.json.tpl
@@ -1,4 +1,15 @@
 {
+  "extraKnownMarketplaces": {
+    "vibecorp": {
+      "source": {
+        "source": "github",
+        "repo": "hirokimry/vibecorp"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "vibecorp@vibecorp": true
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/tests/test_plugin_autoload.sh
+++ b/tests/test_plugin_autoload.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# test_plugin_autoload.sh — Plugin Marketplace 自動ロード設定の検証 (#405)
+#
+# 検証対象:
+#   - .claude-plugin/marketplace.json が vibecorp ルートに存在し、構造が正しい
+#   - templates/settings.json.tpl と templates/claude/settings.json に
+#     extraKnownMarketplaces / enabledPlugins が含まれる
+#   - install.sh の generate_settings_json() マージロジックで既存の
+#     extraKnownMarketplaces / enabledPlugins が壊れない
+#
+# 目的:
+#   `claude --plugin-dir .` を手入力せずに /vibecorp:* スキルが解決される
+#   状態を継続的に保証する（#405）。
+#
+# 使い方: bash tests/test_plugin_autoload.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MARKETPLACE="${REPO_ROOT}/.claude-plugin/marketplace.json"
+TPL="${REPO_ROOT}/templates/settings.json.tpl"
+CLAUDE_SETTINGS="${REPO_ROOT}/templates/claude/settings.json"
+INSTALL_SH="${REPO_ROOT}/install.sh"
+
+PASSED=0
+FAILED=0
+TOTAL=0
+
+pass() {
+  PASSED=$((PASSED + 1))
+  TOTAL=$((TOTAL + 1))
+  echo "  PASS: $1"
+}
+
+fail() {
+  FAILED=$((FAILED + 1))
+  TOTAL=$((TOTAL + 1))
+  echo "  FAIL: $1"
+}
+
+echo "=== Plugin Marketplace 自動ロード検証 (#405) ==="
+
+# --- A. .claude-plugin/marketplace.json の存在と構造 ---
+
+if [[ -f "$MARKETPLACE" ]]; then
+  pass ".claude-plugin/marketplace.json が存在する"
+else
+  fail ".claude-plugin/marketplace.json が存在しない"
+  exit 1
+fi
+
+if jq . "$MARKETPLACE" >/dev/null 2>&1; then
+  pass "marketplace.json の JSON 構文が妥当"
+else
+  fail "marketplace.json の JSON 構文エラー"
+  exit 1
+fi
+
+mkt_name=$(jq -r '.name' "$MARKETPLACE")
+if [[ "$mkt_name" == "vibecorp" ]]; then
+  pass "marketplace.json の name が \"vibecorp\""
+else
+  fail "marketplace.json の name が期待値と異なる: $mkt_name"
+fi
+
+plugin_count=$(jq '.plugins | length' "$MARKETPLACE")
+if [[ "$plugin_count" -ge 1 ]]; then
+  pass "marketplace.json に plugins エントリが存在する（${plugin_count} 件）"
+else
+  fail "marketplace.json に plugins エントリが存在しない"
+fi
+
+plugin_name=$(jq -r '.plugins[0].name' "$MARKETPLACE")
+if [[ "$plugin_name" == "vibecorp" ]]; then
+  pass "marketplace.json の最初の plugin name が \"vibecorp\""
+else
+  fail "marketplace.json の最初の plugin name が期待値と異なる: $plugin_name"
+fi
+
+plugin_source=$(jq -r '.plugins[0].source' "$MARKETPLACE")
+if [[ "$plugin_source" == "." ]]; then
+  pass "marketplace.json の plugin source が \".\"（リポジトリルート）"
+else
+  fail "marketplace.json の plugin source が期待値と異なる: $plugin_source"
+fi
+
+# --- B. templates/settings.json.tpl の extraKnownMarketplaces / enabledPlugins ---
+
+if jq -e '.extraKnownMarketplaces.vibecorp.source.repo == "hirokimry/vibecorp"' "$TPL" >/dev/null 2>&1; then
+  pass "templates/settings.json.tpl に extraKnownMarketplaces.vibecorp が登録されている"
+else
+  fail "templates/settings.json.tpl の extraKnownMarketplaces.vibecorp が期待値と異なる"
+fi
+
+if jq -e '.enabledPlugins["vibecorp@vibecorp"] == true' "$TPL" >/dev/null 2>&1; then
+  pass "templates/settings.json.tpl に enabledPlugins[\"vibecorp@vibecorp\"] が true で登録されている"
+else
+  fail "templates/settings.json.tpl の enabledPlugins[\"vibecorp@vibecorp\"] が期待値と異なる"
+fi
+
+# --- C. templates/claude/settings.json も同等の設定を持つ ---
+
+if jq -e '.extraKnownMarketplaces.vibecorp.source.repo == "hirokimry/vibecorp"' "$CLAUDE_SETTINGS" >/dev/null 2>&1; then
+  pass "templates/claude/settings.json に extraKnownMarketplaces.vibecorp が登録されている"
+else
+  fail "templates/claude/settings.json の extraKnownMarketplaces.vibecorp が期待値と異なる"
+fi
+
+if jq -e '.enabledPlugins["vibecorp@vibecorp"] == true' "$CLAUDE_SETTINGS" >/dev/null 2>&1; then
+  pass "templates/claude/settings.json に enabledPlugins[\"vibecorp@vibecorp\"] が登録されている"
+else
+  fail "templates/claude/settings.json の enabledPlugins[\"vibecorp@vibecorp\"] が期待値と異なる"
+fi
+
+# --- D. install.sh の マージロジックがユーザー追加 marketplace を壊さないことの構文検証 ---
+# install.sh 内の jq フィルタが extraKnownMarketplaces / enabledPlugins を保持する記述を含むこと
+
+if grep -q "extraKnownMarketplaces" "$INSTALL_SH"; then
+  pass "install.sh に extraKnownMarketplaces のマージロジックが含まれる"
+else
+  fail "install.sh に extraKnownMarketplaces のマージロジックが無い"
+fi
+
+if grep -q "enabledPlugins" "$INSTALL_SH"; then
+  pass "install.sh に enabledPlugins のマージロジックが含まれる"
+else
+  fail "install.sh に enabledPlugins のマージロジックが無い"
+fi
+
+# 既存値を保持するパターン (.foo // {}) + $new で記述されていることを確認
+if grep -qF '.extraKnownMarketplaces // {}' "$INSTALL_SH" && grep -qF '.enabledPlugins // {}' "$INSTALL_SH"; then
+  pass "install.sh が既存の extraKnownMarketplaces / enabledPlugins をオーバーレイで保持する"
+else
+  fail "install.sh の既存値保持パターンが見つからない（ユーザーカスタムが上書きされる懸念）"
+fi
+
+# install.sh 構文
+if bash -n "$INSTALL_SH" 2>/dev/null; then
+  pass "install.sh の構文が妥当"
+else
+  fail "install.sh に構文エラーがある"
+fi
+
+echo ""
+echo "=== 結果 ==="
+echo "Total : $TOTAL"
+echo "Passed: $PASSED"
+echo "Failed: $FAILED"
+
+if [[ "$FAILED" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
close https://github.com/hirokimry/vibecorp/issues/405

## ✅ このPRで何が変わるか

✅ 導入先プロジェクトで素の \`claude\` を起動するだけで \`/vibecorp:*\` スキルが認識されるようになった（\`--plugin-dir .\` を毎回手入力しなくてよくなった）
✅ \`install.sh\` が \`settings.json\` に GitHub 経由のマーケットプレイス登録を書き込むため、clone した全員に自動適用される
✅ \`--update\` 実行時もユーザーが追加したカスタム \`extraKnownMarketplaces\` / \`enabledPlugins\` を壊さず vibecorp エントリだけ最新化する

## 🎯 背景

Claude Code はローカルプラグインを自動検出しないため、起動のたび \`--plugin-dir .\` を渡さないと \`/vibecorp:*\` スキルが使えなかった。\`enabledPlugins\` 単体・\`extraKnownMarketplaces + 相対パス\` はいずれも不可（後者は #23978 のバグ）。\`extraKnownMarketplaces + GitHub ソース\` 方式が機能するため、これを採用。

## 🔄 変更点

### vibecorp リポジトリ側

- ✨ \`.claude-plugin/marketplace.json\` を新規作成
  - \`name: vibecorp\` / \`plugins[0]: { name: vibecorp, source: "." }\`

### 導入先に配布される settings

- ✨ \`templates/settings.json.tpl\` に \`extraKnownMarketplaces.vibecorp\`（github source: \`hirokimry/vibecorp\`）と \`enabledPlugins["vibecorp@vibecorp"] = true\` を追加
- ✨ \`templates/claude/settings.json\` も同等に更新

### install.sh

- 🔄 \`generate_settings_json()\` のマージロジックに \`extraKnownMarketplaces\` と \`enabledPlugins\` のオーバーレイを追加。既存値を保持しつつ vibecorp エントリのみ更新する形（\`(.foo // {}) + \$new\` パターン）

### tests

- 🧪 \`tests/test_plugin_autoload.sh\` を追加（\`marketplace.json\` の構造、両 settings テンプレートの設定、install.sh のマージロジック検証）

## ✅ 確認

- ✅ \`bash tests/test_plugin_autoload.sh\` 通過（14/14）
- ✅ \`bash tests/test_settings_json_hooks_exist.sh\` 通過（6/6）
- ✅ \`bash tests/test_install_args.sh\` 通過（45/45）
- ✅ \`bash tests/test_install_update.sh\` 通過（60/60）

## 検証残（実機）

実装計画には「実機での \`--plugin-dir\` 不要動作確認」が含まれるが、それは導入先での起動を伴うため本PRの範囲外。マージ後にユーザー側で導入先プロジェクトの \`install.sh --update\` 実行 → \`claude\` 起動で \`/vibecorp:*\` がそのまま解決されるかを確認する。

## 関連

- Claude Code Plugin Marketplace: <https://code.claude.com/docs/en/plugin-marketplaces>
- \`extraKnownMarketplaces\` 相対パスバグ: <https://github.com/anthropics/claude-code/issues/23978>

🤖 Generated with [Claude Code](https://claude.com/claude-code)