### PR TITLE
🐛 fix: marketplace 経由のプラグイン自動ロードが動作しない（#405 修正漏れ）

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,34 @@
     {
       "name": "vibecorp",
       "description": "vibecorp スキル・エージェント・フック一式",
-      "source": "./"
+      "source": "./",
+      "skills": [
+        "./skills/approve-audit",
+        "./skills/audit-cost",
+        "./skills/audit-security",
+        "./skills/autopilot",
+        "./skills/branch",
+        "./skills/commit",
+        "./skills/context7",
+        "./skills/diagnose",
+        "./skills/harvest-all",
+        "./skills/issue",
+        "./skills/knowledge-pr",
+        "./skills/plan",
+        "./skills/plan-review-loop",
+        "./skills/pr",
+        "./skills/pr-review-fix",
+        "./skills/pr-review-loop",
+        "./skills/review",
+        "./skills/review-harvest",
+        "./skills/review-loop",
+        "./skills/session-harvest",
+        "./skills/ship",
+        "./skills/ship-parallel",
+        "./skills/sync-check",
+        "./skills/sync-edit",
+        "./skills/worktree"
+      ]
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,12 +1,15 @@
 {
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "vibecorp",
+  "description": "AI エージェントチームによる再現可能なプロダクト開発フレームワーク",
   "owner": {
     "name": "hirokimry"
   },
   "plugins": [
     {
       "name": "vibecorp",
-      "source": "."
+      "description": "vibecorp スキル・エージェント・フック一式",
+      "source": "./"
     }
   ]
 }

--- a/.claude/knowledge/cpo/decisions-index.md
+++ b/.claude/knowledge/cpo/decisions-index.md
@@ -5,6 +5,8 @@
 
 ## エントリ
 
+- 2026-04-26 — marketplace 経由プラグイン自動ロード修正 Issue を OK と判定（install.sh の一括セットアップ完結とmarketplace.json公式準拠）
+
 - 2026-04-20 — Issue #361 README.md の不整合修正を実施（/issue の CPO 単独→3者ゲート、/autopilot のラベル縛り撤廃を反映）
 - 2026-04-18 — .claude/.gitignore テンプレート配布化 + 配布系アーキテクチャ再設計 Issue を OK と判定
 - 2026-04-18 — 配布バグ軽量修正5件（Issue #360 抜粋）を OK と判定

--- a/.claude/knowledge/sm/decisions-index.md
+++ b/.claude/knowledge/sm/decisions-index.md
@@ -5,6 +5,7 @@
 
 ## エントリ
 
+- 2026-04-25 — 並列 ship 判定（16件）— #398/#247/#339 を除外、#253 を保留。残り install.sh 競合グループ・pr-review 競合等を直列チェーンに分類
 - 2026-04-25 — Issue #358 Plugin 名前空間 Phase 2 完了確認 — 全26スキル plugin 化、templates/claude/skills/ 廃止、install.sh スタブ自動生成移行
 - 2026-04-24 — Issue #352 sync-check 整合性修正 — docs/ai-organization.md に Plugin 名前空間移行検討状況を追記
 - 2026-04-23 — diagnose デフォルト値・forbidden_targets 設定整合確認 — vibecorp.yml diagnose セクション全設定値が不可領域 5 分類と整合。docs/cost-analysis.md が上限ガードレールの Source of Truth として確立

--- a/.claude/knowledge/sm/decisions/2026-Q2.md
+++ b/.claude/knowledge/sm/decisions/2026-Q2.md
@@ -253,3 +253,58 @@ sync-check により Phase 2 の整合性を確認。
 ### 結論
 
 Phase 2 完了。整合性に問題なし。
+
+
+## 2026-04-25 — 並列 ship 判定（Issue #405, #398, #356, #343, #324, #295, #247, #246, #245, #243, #242, #241, #253, #357, #339, #362）
+
+### 対象
+
+並列 ship 実行可否の判定依頼。対象 Issue 16件。
+
+### 判断内容
+
+#### autonomous-restrictions.md 抵触チェック
+
+| Issue | 変更対象 | 不可領域 | 判定 |
+|-------|---------|---------|------|
+| #405 | `.claude-plugin/marketplace.json`（新規）、`install.sh` の `generate_settings_json()` | — | 通過 |
+| #398 | `settings.json.tpl` / `settings.json` の `permissions.allow` | §1 認証（permissions セクション変更） | **除外** |
+| #356 | `skills/pr-review-loop/SKILL.md`, `skills/pr-review-fix/SKILL.md` | — | 通過 |
+| #343 | `skills/spike-loop/` 削除, `install.sh` 参照除去 | — | 通過 |
+| #324 | `skills/diagnose/SKILL.md` | — | 通過 |
+| #295 | `skills/pr-review-loop/SKILL.md`, `skills/pr-review-fix/SKILL.md` | — | 通過 |
+| #247 | `skills/diagnose/SKILL.md` の `max_issues_per_run` デフォルト値変更 | §3 課金構造（`max_issues_per_run` はコスト関連上限） | **除外** |
+| #246 | 複数 SKILL.md のテキスト置換（kaizen→diagnose） | — | 通過 |
+| #245 | `templates/docs/team-permissions.md` → `team-permissions.md.tpl` リネーム、`install.sh` コピー処理 | — | 通過 |
+| #243 | `install.sh` の `merge_or_overwrite()` trap 修正 | — | 通過 |
+| #242 | `install.sh` のコピー処理追加 | — | 通過 |
+| #241 | `templates/` の設定ファイル構造変更（settings.json.tpl 二重管理解消） | — | 通過 |
+| #253 | 新規 hook or スクリプト（ゾンビエージェント自動kill） | §4 ガードレール（hook 新規追加は自律実行制御のガードレールに隣接） | **保留（情報不足）** |
+| #357 | `skills/pr-review-fix/` → `skills/pr-fix/` 等リネーム | — | 通過 |
+| #339 | `install.sh` に ANTHROPIC_API_KEY 警告ロジック追加 | §1 認証・§3 課金（ANTHROPIC_API_KEY の扱いに関わる変更） | **除外** |
+| #362 | `docs/design-philosophy.md` のみ | — | 通過 |
+
+#### ファイル競合マトリクス（通過 Issue のみ）
+
+install.sh を変更する Issue: #405, #343, #245, #243, #242, #241
+skills/pr-review-loop/SKILL.md + skills/pr-review-fix/SKILL.md: #356, #295
+skills/diagnose/SKILL.md: #324, #246（diagnoseを含む複数ファイル）
+skills/spike-loop/（削除）: #343 のみ
+skills/pr-review-fix/ リネーム: #357 と #356/#295 が競合
+
+#### 並列グループ・直列チェーン
+
+- install.sh 変更グループ（#405, #343, #245, #243, #242, #241）は相互競合→直列
+- #356 と #295 は同一ファイル（pr-review-loop + pr-review-fix の SKILL.md）→ 直列
+- #357（リネーム）は #356/#295 の変更先ファイル名を変えるため→ #356/#295 より先に実施か後に実施かを確定させる必要あり
+- #324 と #246 は skills/diagnose/SKILL.md で競合 → 直列
+- #362 は docs/ のみ → 全 Issue と並列可能
+
+### 結論
+
+詳細は本レポート本文参照。
+
+### 変更ファイル
+
+- `.claude/knowledge/sm/decisions/2026-Q2.md`（本エントリ追記）
+- `.claude/knowledge/sm/decisions-index.md`（インデックス追記）

--- a/tests/test_plugin_autoload.sh
+++ b/tests/test_plugin_autoload.sh
@@ -85,10 +85,45 @@ else
 fi
 
 plugin_source=$(jq -r '.plugins[0].source' "$MARKETPLACE")
-if [[ "$plugin_source" == "." ]]; then
-  pass "marketplace.json の plugin source が \".\"（リポジトリルート）"
+if [[ "$plugin_source" == "./" ]]; then
+  pass "marketplace.json の plugin source が \"./\"（リポジトリルート）"
 else
   fail "marketplace.json の plugin source が期待値と異なる: $plugin_source"
+fi
+
+schema_val=$(jq -r '.["$schema"] // ""' "$MARKETPLACE")
+if [[ "$schema_val" == "https://anthropic.com/claude-code/marketplace.schema.json" ]]; then
+  pass "marketplace.json の \$schema が公式 URL"
+else
+  fail "marketplace.json の \$schema が期待値と異なる: $schema_val"
+fi
+
+mkt_desc=$(jq -r '.description // ""' "$MARKETPLACE")
+if [[ -n "$mkt_desc" ]]; then
+  pass "marketplace.json に description が存在する"
+else
+  fail "marketplace.json に description が存在しない"
+fi
+
+plugin_desc=$(jq -r '.plugins[0].description // ""' "$MARKETPLACE")
+if [[ -n "$plugin_desc" ]]; then
+  pass "marketplace.json の plugin に description が存在する"
+else
+  fail "marketplace.json の plugin に description が存在しない"
+fi
+
+skills_count=$(jq '.plugins[0].skills | length' "$MARKETPLACE")
+if [[ "$skills_count" -ge 1 ]]; then
+  pass "marketplace.json の plugin に skills 配列が存在する（${skills_count} 件）"
+else
+  fail "marketplace.json の plugin に skills 配列が存在しない、または空"
+fi
+
+skills_dir_count=$(find "${REPO_ROOT}/skills" -maxdepth 1 -mindepth 1 -type d | wc -l | tr -d ' ')
+if [[ "$skills_count" -eq "$skills_dir_count" ]]; then
+  pass "skills 配列の件数（${skills_count}）が skills/ ディレクトリ数と一致"
+else
+  fail "skills 配列の件数（${skills_count}）が skills/ ディレクトリ数（${skills_dir_count}）と不一致"
 fi
 
 # --- B. templates/settings.json.tpl の extraKnownMarketplaces / enabledPlugins ---


### PR DESCRIPTION
## Summary

- marketplace.json の `source` を `"."` → `"./"` に修正（Claude Code スキーマバリデーション通過）
- `$schema`, `description` を追加（公式マーケットプレイス準拠）
- 全25スキルの `skills` 配列を追加（Claude Code がスキルを発見できるようになった）
- テストを15項目→20項目に強化（`$schema` URL一致・`description` 存在・`skills` 件数一致）

close https://github.com/hirokimry/vibecorp/issues/421

## Test plan

- [x] `bash tests/test_plugin_autoload.sh` 全20項目パス
- [ ] 導入先で `rm -rf ~/.claude/plugins/marketplaces/hirokimry-vibecorp`
- [ ] `/plugin marketplace add hirokimry/vibecorp` がエラーなく完了
- [ ] `/plugin install vibecorp@vibecorp --scope project` が成功
- [ ] `--plugin-dir` なしで `/vibecorp:help` が解決される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * マーケットプレイスマニフェストにスキーマ宣言、パッケージ／プラグイン説明、および利用可能なスキル一覧を追加しました。

* **Tests**
  * マニフェストの構造と内容を検証するテストを強化し、ソース参照の形式とスキル一覧の整合性をチェックするようにしました。

* **Chores**
  * 判断記録の目次と最新の決定記録を追記・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->