### PR TITLE
✨ feat: /diagnose がスピード/UX ボトルネックを検出するようになった (#355)

### DIFF
--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -13,6 +13,8 @@ description: >
 コードベースを自律的に診断し、改善点を発見してフィルタリング後に GitHub Issue として起票する。
 **実装は行わない。起票と実装を分離することで暴走を防止する。**
 
+**スピード/UX 観点はモデル指定・コスト最適化には一切踏み込まない**。モデル指定の変更提案（Opus → Sonnet 等）・エージェント削減・合議制回数削減・並列度自体の削減・`max_issues_per_run` 等のコスト上限値の変更は CFO 管轄（Issue #354 系）に閉じ込め、品質劣化ルートを遮断する。スピード/UX 観点は逐次処理の並列化余地・同期待ちボトルネック・フック実行時間の肥大化・スキル間の冗長な再実行のみを対象とする。
+
 ## 使用方法
 
 ```bash
@@ -92,6 +94,17 @@ CTO エージェントに以下を依頼する:
 - テストカバレッジの不足
 - エラーハンドリングの改善余地
 - パフォーマンスボトルネック
+- スピード/UX（ユーザー待ち時間の短縮）:
+  - 並列化可能な逐次処理（独立したエージェント呼び出し・スキル呼び出し・テストが直列に並んでいる箇所）
+  - 同期待ちが長いフェーズ（CI 待ち・レビュー待ち等の構造的ボトルネック）
+  - フック実行時間の肥大化（PreToolUse / PostToolUse フックが 1 処理あたり閾値を超える）
+  - スキル間の冗長な再実行（同じチェック・同じ走査が複数スキルで重複実行されている）
+
+**スピード/UX 観点で出してはいけない提案（CFO 管轄に閉じ込める）**:
+- モデル指定の変更提案（Opus → Sonnet 等）は出さない
+- エージェント削減・合議制回数削減は出さない
+- 並列度自体の削減は出さない
+- `max_issues_per_run` / `max_issues_per_day` 等のコスト上限値の変更は出さない
 ```
 
 `--scope` が指定されている場合はそのディレクトリに限定して分析する。
@@ -150,8 +163,8 @@ SM エージェントに残った候補を渡し、`rules/autonomous-restriction
 不可領域:
 1. 認証（hooks/*auth*, hooks/*permission*, settings.json の permissions, gh auth, ANTHROPIC_API_KEY 扱い）
 2. 暗号（encrypt/decrypt/secret/credential/token を扱うコード）
-3. 課金構造（docs/cost-analysis.md, max_issues_per_day 等のコスト上限, claude -p / npx / bunx で LLM を呼ぶ箇所）
-4. ガードレール（protect-files.sh, diagnose-guard.sh, forbidden_targets, diagnose-active スタンプの制御）
+3. 課金構造（docs/cost-analysis.md, max_issues_per_day 等のコスト上限, claude -p / npx / bunx で LLM を呼ぶ箇所、**モデル指定の変更（Opus → Sonnet 等）**）
+4. ガードレール（protect-files.sh, diagnose-guard.sh, forbidden_targets, diagnose-active スタンプの制御、**エージェント削減・合議制回数削減・並列度自体の削減**）
 5. MVV（MVV.md 自体の変更）
 
 該当する候補には「除外」と判定し、理由として該当領域名を付記してください。

--- a/tests/test_diagnose_speed_ux.sh
+++ b/tests/test_diagnose_speed_ux.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# test_diagnose_speed_ux.sh — /vibecorp:diagnose のスピード/UX 観点（Issue #355）
+# 使い方: bash tests/test_diagnose_speed_ux.sh
+# CI: GitHub Actions で自動実行
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL_MD="${SCRIPT_DIR}/skills/diagnose/SKILL.md"
+PASSED=0
+FAILED=0
+TOTAL=0
+
+# --- ヘルパー ---
+
+pass() {
+  PASSED=$((PASSED + 1))
+  TOTAL=$((TOTAL + 1))
+  echo "  PASS: $1"
+}
+
+fail() {
+  FAILED=$((FAILED + 1))
+  TOTAL=$((TOTAL + 1))
+  echo "  FAIL: $1"
+}
+
+assert_file_contains() {
+  local desc="$1"
+  local path="$2"
+  local pattern="$3"
+  if grep -q -- "$pattern" "$path"; then
+    pass "$desc"
+  else
+    fail "$desc (パターン '$pattern' がファイルに含まれない: $path)"
+  fi
+}
+
+# ============================================
+echo "=== /vibecorp:diagnose スピード/UX 観点 テスト（Issue #355） ==="
+# ============================================
+
+# 前提ファイル不在は後続テストを無意味にするため早期終了する（rules/testing.md 準拠）
+if [[ ! -f "$SKILL_MD" ]]; then
+  fail "SKILL.md が存在しない: $SKILL_MD"
+  exit 1
+fi
+pass "SKILL.md が存在する"
+
+# --- 受入基準: SKILL.md 上部に「モデル指定・コスト最適化に踏み込まない」旨の明記 ---
+
+echo "--- 上部明記（受入基準3） ---"
+
+assert_file_contains "上部に「モデル指定・コスト最適化には一切踏み込まない」旨が記載されている" \
+  "$SKILL_MD" "モデル指定・コスト最適化には一切踏み込まない"
+
+# --- 受入基準: ステップ4a/4b（CTO 分析）にスピード/UX 観点のチェックリスト ---
+
+echo "--- CTO 分析プロンプトのスピード/UX チェックリスト（受入基準1） ---"
+
+assert_file_contains "CTO 分析プロンプトに「スピード/UX」見出しがある" \
+  "$SKILL_MD" "スピード/UX"
+
+assert_file_contains "観点: 並列化可能な逐次処理" \
+  "$SKILL_MD" "並列化可能な逐次処理"
+
+assert_file_contains "観点: 同期待ちが長いフェーズ" \
+  "$SKILL_MD" "同期待ちが長いフェーズ"
+
+assert_file_contains "観点: フック実行時間の肥大化" \
+  "$SKILL_MD" "フック実行時間の肥大化"
+
+assert_file_contains "観点: スキル間の冗長な再実行" \
+  "$SKILL_MD" "スキル間の冗長な再実行"
+
+# --- CTO 分析プロンプトの禁止事項（CFO 管轄に閉じ込める） ---
+
+echo "--- CTO 分析プロンプトの禁止事項 ---"
+
+assert_file_contains "禁止: モデル指定の変更提案" \
+  "$SKILL_MD" "モデル指定の変更提案（Opus → Sonnet 等）は出さない"
+
+assert_file_contains "禁止: エージェント削減・合議制回数削減" \
+  "$SKILL_MD" "エージェント削減・合議制回数削減は出さない"
+
+assert_file_contains "禁止: 並列度自体の削減" \
+  "$SKILL_MD" "並列度自体の削減は出さない"
+
+assert_file_contains "禁止: max_issues_per_run コスト上限値の変更" \
+  "$SKILL_MD" "max_issues_per_run"
+
+# --- 受入基準: SM フィルタ（ステップ6b）でモデル指定変更・エージェント削減が除外される ---
+
+echo "--- SM フィルタプロンプトの追加除外項目（受入基準2） ---"
+
+# §3 課金構造に「モデル指定の変更」が明示されていることを確認
+assert_file_contains "SM フィルタ §3 課金構造に「モデル指定の変更」が明示されている" \
+  "$SKILL_MD" "モデル指定の変更（Opus → Sonnet 等）"
+
+# §4 ガードレールに「エージェント削減・合議制回数削減・並列度自体の削減」が明示されていることを確認
+assert_file_contains "SM フィルタ §4 ガードレールに「エージェント削減・合議制回数削減・並列度自体の削減」が明示されている" \
+  "$SKILL_MD" "エージェント削減・合議制回数削減・並列度自体の削減"
+
+# モデル指定変更の候補が SM フィルタの不可領域記述に到達するための前提（ステップ6bプロンプトが課金構造を列挙していること）
+assert_file_contains "SM フィルタプロンプトに不可領域 3. 課金構造の記述がある" \
+  "$SKILL_MD" "3. 課金構造"
+
+assert_file_contains "SM フィルタプロンプトに不可領域 4. ガードレールの記述がある" \
+  "$SKILL_MD" "4. ガードレール"
+
+# ============================================
+echo ""
+echo "=== 結果: $PASSED/$TOTAL passed, $FAILED failed ==="
+
+if [ "$FAILED" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## ✨ 何が変わるか

`/vibecorp:diagnose` がコードベースを診断する際、**スピード/UX ボトルネック**も発見対象になった。

- 並列化可能な逐次処理（独立した処理が直列に並んでいる箇所）
- 同期待ちが長いフェーズ（CI 待ち・レビュー待ち等）
- フック実行時間の肥大化（PreToolUse / PostToolUse が閾値超過）
- スキル間の冗長な再実行（同じチェックが複数スキルで重複）

これにより、新規エージェント・フックが逐次処理を増やしてもユーザー待ち時間の悪化に気付けるようになった。

## 🔒 やらないことの明示（二重遮断）

スピード/UX 観点は**モデル指定・コスト最適化には一切踏み込まない**。以下は CFO 管轄（Issue #354 系）に閉じ込め、品質劣化ルートを遮断する。

- ❌ モデル指定の変更提案（Opus → Sonnet 等）
- ❌ エージェント削減・合議制回数削減
- ❌ 並列度自体の削減
- ❌ `max_issues_per_run` 等のコスト上限変更

二重遮断の構造:

| 層 | 遮断方法 |
|---|---|
| 観点段階 | CTO 分析プロンプトに「禁止事項」として明示。最初から候補に含めない |
| フィルタ段階 | SM フィルタの不可領域 §3 課金構造に「モデル指定の変更」を、§4 ガードレールに「エージェント削減・合議制回数削減・並列度自体の削減」を追加 |

## 📝 変更ファイル

| ファイル | 変更 |
|---|---|
| `skills/diagnose/SKILL.md` | 上部冒頭に「モデル指定・コスト最適化に踏み込まない」旨を明記 / 4b CTO 分析プロンプトにスピード/UX 観点 + 禁止事項追加 / 6b SM フィルタプロンプトの不可領域 §3 / §4 を補強 |
| `tests/test_diagnose_speed_ux.sh` | 新規。受入基準を満たす 15 アサーション |

`autonomous-restrictions.md` は変更していない（§4 ガードレール抵触リスク回避。SKILL 側の二重遮断で同等効果）。

## 🧪 テスト

- `tests/test_diagnose_speed_ux.sh`（新規）: 15/15 passed
- `tests/test_diagnose.sh`（既存）: 26/26 passed（回帰なし）

## ✅ 受入基準

- [x] `/diagnose` のステップ4b（CTO による分析）に「スピード/UX 観点」のチェックリストを明示的に追加
- [x] ステップ6b（SM フィルタ）で「モデル指定変更」「エージェント削減」が候補に残っていた場合、必ず除外されることをテストで確認
- [x] `/diagnose` の説明文（SKILL.md 上部）に「スピード観点はモデル指定・コストに踏み込まない」旨を明記
- [x] テストを `tests/` 配下に追加（`rules/testing.md` 準拠）

Close #355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * スピード/UX改善提案の対象範囲を明確化し、並列化余地・同期待ち・フック時間肥大化・スキル間冗長再実行に限定

* **Tests**
  * ドキュメント記載内容の準拠状況を検証する自動テストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->