### PR TITLE
✨ feat: `/release-epic` スキル新設 — feature→main リリース PR を自動作成できるようになった (#349)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -28,6 +28,7 @@
         "./skills/pr",
         "./skills/pr-review-fix",
         "./skills/pr-review-loop",
+        "./skills/release-epic",
         "./skills/review",
         "./skills/review-harvest",
         "./skills/review-loop",

--- a/install.sh
+++ b/install.sh
@@ -771,6 +771,8 @@ copy_managed_files() {
       rm -rf "${skills_dir}/autopilot"
       # エピック化スキルは full プリセット専用（3 者承認ゲートで CISO/CPO/SM が必須なため）
       rm -rf "${skills_dir}/plan-epic"
+      # エピックリリーススキルは full プリセット専用（エピック運用は full でのみ整備）
+      rm -rf "${skills_dir}/release-epic"
       rm -rf "${agents_dir}"
       # 隔離レイヤは full 専用。vibecorp が配置した既知ファイルのみ削除し、
       # ディレクトリが空になったら rmdir（ユーザー独自配置は rmdir 失敗で保持される）
@@ -791,6 +793,8 @@ copy_managed_files() {
       rm -rf "${skills_dir}/autopilot"
       # エピック化スキルは full プリセット専用（3 者承認ゲートで CISO/CPO/SM が必須なため）
       rm -rf "${skills_dir}/plan-epic"
+      # エピックリリーススキルは full プリセット専用（エピック運用は full でのみ整備）
+      rm -rf "${skills_dir}/release-epic"
       # plan-cost / plan-legal は full プリセット限定
       rm -f "${agents_dir}/plan-cost.md"
       rm -f "${agents_dir}/plan-legal.md"

--- a/skills/release-epic/SKILL.md
+++ b/skills/release-epic/SKILL.md
@@ -70,11 +70,12 @@ GitHub 公式の sub-issue API で子 Issue 一覧を取得する。
 ```bash
 gh api \
   -H "Accept: application/vnd.github+json" \
+  --paginate \
   "/repos/<owner>/<repo>/issues/<親番号>/sub_issues"
 ```
 
 - `<owner>/<repo>` は `gh repo view --json owner,name --jq '.owner.login + "/" + .name'` で取得
-- `--paginate` を付けて全件取得する（既定 30 件超のエピック対応）
+- `--paginate` を必ず付けて全件取得する（既定 30 件超のエピック対応）
 
 公式仕様: https://docs.github.com/en/rest/issues/sub-issues
 
@@ -104,7 +105,9 @@ git ls-remote --heads origin "feature/epic-<親番号>*"
 
 - 0 件: 中断（「ブランチが未作成」と CEO に報告）
 - 2 件以上: 中断（「複数候補があります」と CEO に列挙報告）
-- 1 件: そのブランチ名を head に採用
+- 1 件: そのブランチ名を **完全一致の文字列**（例: `feature/epic-349_release_epic`）として保持し、後段の重複確認・PR 作成で同じ値を再利用する
+
+`gh pr list --head` および `gh pr create --head` はワイルドカードをサポートしないため（[公式ドキュメント](https://cli.github.com/manual/gh_pr_list)）、ステップ 7 で確定した完全一致のブランチ名を変数として保持しておくことが必須となる。
 
 ### 8. リリースノートの生成
 
@@ -136,19 +139,22 @@ PR タイトルは `🚀 release: epic #<親番号> <親タイトル>` の形式
 ### 9. 既存 PR の重複確認
 
 同一 head（feature ブランチ）→ base（main）の open PR が既に存在しないか確認する。
+ステップ 7 で確定した完全一致のブランチ名（例: `feature/epic-349_release_epic`）を `--head` に渡す（ワイルドカードは利用不可）。
 
 ```bash
-gh pr list --base main --head "feature/epic-<親番号>_*" --state open --json number,title,url
+gh pr list --base main --head "<ステップ7で確定した完全一致のブランチ名>" --state open --json number,title,url
 ```
 
 - 既存 PR が見つかった場合は新規作成せず CEO に報告して中断する（auto-merge 機構と衝突させないため）
 
 ### 10. リリース PR の作成
 
+ステップ 7 で確定した完全一致のブランチ名を `--head` にそのまま渡す。
+
 ```bash
 gh pr create \
   --base main \
-  --head "feature/epic-<親番号>_<要約>" \
+  --head "<ステップ7で確定した完全一致のブランチ名>" \
   --title "🚀 release: epic #<親番号> <親タイトル>" \
   --body "<生成したリリースノート>"
 ```

--- a/skills/release-epic/SKILL.md
+++ b/skills/release-epic/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: release-epic
+description: >
+  親エピック Issue 配下の子 Issue が全て close されていることを確認した上で、
+  feature/epic-* → main のリリース PR を作成し、子 Issue タイトルから自動生成したリリースノートを PR 本文に記載する。
+  full プリセット専用。
+  「/release-epic」「エピックをリリースして」「feature ブランチを main にマージするPR作って」と言った時に使用。
+---
+
+# 🚀 エピックリリーススキル
+
+CEO が `/vibecorp:release-epic <親エピック Issue 番号>` を実行すると、エピック配下の子 Issue が全て完了していることを GitHub API で検証してから、`feature/epic-*` → `main` のリリース PR を作成する。子 Issue タイトルを束ねたリリースノートを PR 本文に自動生成し、親エピック Issue にリリース PR の予告リンクを貼る。
+**結果のみを簡潔に返すこと。途中経過は不要。**
+
+## 📝 本文の書き方
+
+PR タイトル・PR 本文・親 Issue へのコメントは CEO が読むため `.claude/rules/communication.md` に従って**動作主語**で書く（「〜になった／〜できるようになった」）。関数名・ファイルパスを並べるのではなく、ソフトウェアのふるまいの変化を 30 秒で掴める形にする。
+
+## 🛠️ 使用方法
+
+```bash
+/vibecorp:release-epic <親エピック Issue 番号>
+```
+
+`<親エピック Issue 番号>` が省略された場合は CEO にヒアリングする（複数エピック並走時の曖昧性を避けるため必須）。
+
+## 🧱 前提条件
+
+- **full プリセット専用**（エピック運用は full プリセットでのみ整備されているため）
+- GitHub CLI (`gh`) が認証済みであること
+- 親エピック Issue が既に存在すること（`/vibecorp:plan-epic` で起票されている前提）
+- `feature/epic-<親番号>_*` ブランチが origin に push されていること
+- リポジトリが GitHub 上にあり、sub-issue API が利用可能であること
+
+## 📋 ワークフロー
+
+### 1. プリセット確認
+
+vibecorp.yml の preset を確認する。full 以外の場合は以下を出力して終了する:
+
+```text
+/vibecorp:release-epic は full プリセット専用です。現在のプリセット: <preset>
+```
+
+```bash
+awk '/^preset:/ { print $2 }' "$CLAUDE_PROJECT_DIR/.claude/vibecorp.yml"
+```
+
+### 2. 引数検証
+
+引数が空の場合は CEO にヒアリングする。複数エピックの並走時に親 Issue を曖昧にしないよう、番号は必須引数。
+
+### 3. 親エピック Issue の取得
+
+```bash
+gh issue view <親番号> --json number,title,body,state,labels
+```
+
+- Issue が存在しない場合は中断
+- `state == "closed"` の場合は中断（既にリリース済みの可能性、CEO に確認）
+
+### 4. エピック判定
+
+タイトルに `🎯 epic:` プレフィックス、または `epic` ラベルが付与されていることを確認する。どちらも無い場合は「指定 Issue はエピックではありません」と中断する。
+
+### 5. sub-issue 一覧の取得
+
+GitHub 公式の sub-issue API で子 Issue 一覧を取得する。
+
+```bash
+gh api \
+  -H "Accept: application/vnd.github+json" \
+  "/repos/<owner>/<repo>/issues/<親番号>/sub_issues"
+```
+
+- `<owner>/<repo>` は `gh repo view --json owner,name --jq '.owner.login + "/" + .name'` で取得
+- `--paginate` を付けて全件取得する（既定 30 件超のエピック対応）
+
+公式仕様: https://docs.github.com/en/rest/issues/sub-issues
+
+子 Issue が 0 件の場合は中断する（リリース対象なし）。
+
+### 6. 未 close 子 Issue の検証
+
+子 Issue 一覧から `state == "open"` のものを抽出する。1 件でも残っていれば中断する。
+
+```text
+⚠️ 未 close の子 Issue が <n> 件あります:
+- #<番号> <タイトル>
+- #<番号> <タイトル>
+
+完了してから再実行してください。
+```
+
+全て `closed` の場合のみ次に進む。
+
+### 7. feature ブランチの存在確認
+
+`feature/epic-<親番号>_*` ブランチが origin に push されていることを確認する。Issue #346 で確立した命名規約に準拠する。
+
+```bash
+git ls-remote --heads origin "feature/epic-<親番号>*"
+```
+
+- 0 件: 中断（「ブランチが未作成」と CEO に報告）
+- 2 件以上: 中断（「複数候補があります」と CEO に列挙報告）
+- 1 件: そのブランチ名を head に採用
+
+### 8. リリースノートの生成
+
+子 Issue タイトルを束ねた PR 本文を生成する。子 Issue の絵文字プレフィックス（✨/🐛/🔄/📖/🔒/🚀 等）はそのまま流用する。
+
+```markdown
+## 🚀 エピックリリース
+
+エピック #<親番号> <親タイトル> がリリース可能になった。
+
+## 📦 含まれる変更（子 Issue ベース）
+
+- ✨ #<子1番号> <子1タイトル>
+- 🐛 #<子2番号> <子2タイトル>
+- 🔄 #<子3番号> <子3タイトル>
+
+## ✅ 完了確認
+
+- 子 Issue が全て close されていることを確認した
+- feature ブランチへのマージは GitHub の auto-merge で完結している
+
+## 🔗 関連
+
+- 親エピック Issue: #<親番号>
+```
+
+PR タイトルは `🚀 release: epic #<親番号> <親タイトル>` の形式とする。
+
+### 9. 既存 PR の重複確認
+
+同一 head（feature ブランチ）→ base（main）の open PR が既に存在しないか確認する。
+
+```bash
+gh pr list --base main --head "feature/epic-<親番号>_*" --state open --json number,title,url
+```
+
+- 既存 PR が見つかった場合は新規作成せず CEO に報告して中断する（auto-merge 機構と衝突させないため）
+
+### 10. リリース PR の作成
+
+```bash
+gh pr create \
+  --base main \
+  --head "feature/epic-<親番号>_<要約>" \
+  --title "🚀 release: epic #<親番号> <親タイトル>" \
+  --body "<生成したリリースノート>"
+```
+
+- `gh pr merge --auto` は **呼ばない**（承認フロー非介入思想）
+- マージは Branch Protection + CodeRabbit approve に委ねる
+
+### 11. 親エピック Issue の更新
+
+親エピック Issue 本文の末尾に「リリース PR を作成しました: #<PR番号>」を追記する。
+
+```bash
+gh issue edit <親番号> --body "<更新後の本文>"
+```
+
+または既存本文末尾に追記する形でコメントを残す:
+
+```bash
+gh issue comment <親番号> --body "🚀 リリース PR を作成しました: #<PR番号>"
+```
+
+本文編集とコメント追記のどちらかを選択する。本文に「## 🚀 リリース PR」セクションを追加するのが既定動作とする（後から見たときに親 Issue 単体でリリース状況が分かるため）。
+
+### 12. 結果報告
+
+```text
+## /vibecorp:release-epic 完了
+
+### 🚀 リリース PR
+- <PR URL>: <PR タイトル>
+
+### 📦 リリース対象
+- 親エピック: #<親番号> <親タイトル>
+- 子 Issue: <n> 件（全て close 済み）
+- feature ブランチ: feature/epic-<親番号>_<要約>
+- base ブランチ: main
+
+### ✅ 次のアクション
+- マージは GitHub の auto-merge（Branch Protection + CodeRabbit approve）で完結する
+- 本スキルは PR 作成のみで auto-merge は設定していない（承認フロー非介入）
+```
+
+## 🚦 介入ポイント
+
+以下の状況では CEO に報告して判断を委ねる:
+
+| 状況 | タイミング |
+|------|-----------|
+| full プリセットでない | ステップ 1 |
+| 引数が空 | ステップ 2 |
+| 親 Issue が存在しない / closed | ステップ 3 |
+| 親 Issue がエピックでない（ラベル/プレフィックスなし） | ステップ 4 |
+| sub-issue が 0 件 | ステップ 5 |
+| 未 close 子 Issue がある | ステップ 6 |
+| feature ブランチが未作成 / 複数候補 | ステップ 7 |
+| 同一 head/base の既存 PR がある | ステップ 9 |
+| gh CLI が認証されていない | 全ステップ共通 |
+
+## ⚠️ 制約
+
+- **コード変更は一切行わない** — PR 作成と Issue 更新のみ
+- **auto-merge 設定はスコープ外** — `gh pr merge --auto` は呼ばない（承認フロー非介入思想）
+- **タグ打ち・バージョニング・デプロイは扱わない** — 別 Issue で扱う
+- `--force`、`--hard`、`--no-verify` は使用しない
+- **jq では string interpolation `\(...)` を使わない** — Bash 上で `\` がエスケープ文字、`()` がサブシェルとして解釈され、意図しない展開やパースエラーを引き起こすため。必ず `+` で結合する
+- **コマンドをそのまま実行する** — `2>/dev/null`、`|| echo`、`; echo` 等のリダイレクトやフォールバックを付加しない
+- **Bash は 1 コマンド 1 呼び出しに分割する** — `cd ... && cmd | head 2>/dev/null` のように cd + パイプ + リダイレクトを含む compound command は Claude Code 本体の built-in security check（path resolution bypass 検出）で止められるため
+- 介入ポイントでは CEO の指示を待つ（自動でスキップしない）
+
+## 🔗 関連
+
+- 設計判断: `.claude/knowledge/cpo/decisions/2026-Q2.md` 2026-04-18 「Issue 親子関係・大規模リリース支援」
+- 関連 Issue: #345 (`/plan-epic` スキル新設) / #346 (`/ship` base 判定) / #347 (GHA 自動 close)
+- GitHub sub-issue API: https://docs.github.com/en/rest/issues/sub-issues
+- 自律実行不可領域: `.claude/rules/autonomous-restrictions.md`

--- a/tests/test_release_epic.sh
+++ b/tests/test_release_epic.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# test_release_epic.sh — /vibecorp:release-epic スキルの構造テスト
+# 使い方: bash tests/test_release_epic.sh
+# CI: GitHub Actions で自動実行
+
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${TESTS_DIR}/lib/test_helpers.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL_MD="${SCRIPT_DIR}/skills/release-epic/SKILL.md"
+INSTALL_SH="${SCRIPT_DIR}/install.sh"
+MARKETPLACE_JSON="${SCRIPT_DIR}/.claude-plugin/marketplace.json"
+
+# ============================================
+echo "=== /vibecorp:release-epic スキル テスト ==="
+# ============================================
+
+# --- A. SKILL.md の存在と frontmatter ---
+
+echo "--- A. SKILL.md の存在と frontmatter ---"
+
+assert_file_exists "SKILL.md が存在する" "$SKILL_MD"
+
+if [[ ! -f "$SKILL_MD" ]]; then
+  # 前提ファイル不在 → 後続テストは全て無意味なので即終了
+  exit 1
+fi
+
+assert_file_contains "frontmatter に name: release-epic がある" "$SKILL_MD" "^name: release-epic"
+assert_file_contains "frontmatter に description がある" "$SKILL_MD" "^description:"
+
+# --- B. ワークフローの必須ステップ ---
+
+echo "--- B. ワークフローの必須ステップ ---"
+
+assert_file_contains "プリセット確認ステップがある" "$SKILL_MD" "プリセット確認"
+assert_file_contains "full プリセット専用の記述がある" "$SKILL_MD" "full プリセット専用"
+assert_file_contains "親エピック Issue 取得ステップがある" "$SKILL_MD" "親エピック Issue の取得"
+assert_file_contains "エピック判定ステップがある" "$SKILL_MD" "エピック判定"
+assert_file_contains "sub-issue 一覧取得ステップがある" "$SKILL_MD" "sub-issue 一覧"
+assert_file_contains "未 close 子 Issue 検証ステップがある" "$SKILL_MD" "未 close 子 Issue"
+assert_file_contains "feature ブランチ確認ステップがある" "$SKILL_MD" "feature ブランチ"
+assert_file_contains "リリースノート生成ステップがある" "$SKILL_MD" "リリースノート"
+assert_file_contains "リリース PR 作成ステップがある" "$SKILL_MD" "リリース PR の作成"
+assert_file_contains "親 Issue 更新ステップがある" "$SKILL_MD" "親エピック Issue の更新"
+
+# --- C. GitHub API 呼び出しの記述 ---
+
+echo "--- C. GitHub API 呼び出しの記述 ---"
+
+assert_file_contains "gh issue view の使用がある" "$SKILL_MD" "gh issue view"
+assert_file_contains "sub_issues API 呼び出しがある" "$SKILL_MD" "sub_issues"
+assert_file_contains "gh api の使用がある" "$SKILL_MD" "gh api"
+assert_file_contains "gh pr create の使用がある" "$SKILL_MD" "gh pr create"
+assert_file_contains "git ls-remote によるブランチ確認がある" "$SKILL_MD" "git ls-remote"
+assert_file_contains "GitHub 公式ドキュメント URL がある" "$SKILL_MD" "docs.github.com/en/rest/issues/sub-issues"
+
+# --- D. スコープ外の明記 ---
+
+echo "--- D. スコープ外の明記 ---"
+
+assert_file_contains "auto-merge 設定スコープ外の記述がある" "$SKILL_MD" "auto-merge 設定はスコープ外"
+assert_file_contains "gh pr merge --auto を呼ばない明記がある" "$SKILL_MD" "gh pr merge --auto"
+assert_file_contains "タグ打ちスコープ外の記述がある" "$SKILL_MD" "タグ打ち"
+
+# --- E. 制約・介入ポイント ---
+
+echo "--- E. 制約・介入ポイント ---"
+
+assert_file_contains "コード変更禁止の制約がある" "$SKILL_MD" "コード変更は一切行わない"
+assert_file_contains "jq 文字列補間禁止の制約がある" "$SKILL_MD" "string interpolation"
+assert_file_contains "コマンド素直実行の制約がある" "$SKILL_MD" "コマンドをそのまま実行"
+assert_file_contains "1 コマンド 1 呼び出し制約がある" "$SKILL_MD" "1 コマンド 1 呼び出し"
+assert_file_contains "介入ポイントの記述がある" "$SKILL_MD" "介入ポイント"
+
+# --- F. install.sh のプリセット分岐 ---
+
+echo "--- F. install.sh のプリセット分岐 ---"
+
+assert_file_exists "install.sh が存在する" "$INSTALL_SH"
+
+# minimal / standard プリセットで release-epic を削除する分岐がある
+RELEASE_EPIC_DELETIONS=$(grep -c 'rm -rf "\${skills_dir}/release-epic"' "$INSTALL_SH" || true)
+if [[ "$RELEASE_EPIC_DELETIONS" -ge 2 ]]; then
+  pass "install.sh に release-epic 削除分岐が 2 箇所以上ある（minimal + standard）"
+else
+  fail "install.sh の release-epic 削除分岐が不足（${RELEASE_EPIC_DELETIONS} 件、期待: 2 件以上）"
+fi
+
+# minimal / standard 両方のブロックに release-epic 削除がある
+if awk '
+  /minimal\)/ { in_minimal=1 }
+  /standard\)/ { in_minimal=0; in_standard=1 }
+  /esac/ { in_minimal=0; in_standard=0 }
+  in_minimal && /skills_dir\}\/release-epic/ { found_minimal=1 }
+  in_standard && /skills_dir\}\/release-epic/ { found_standard=1 }
+  END { exit !(found_minimal && found_standard) }
+' "$INSTALL_SH"; then
+  pass "minimal / standard 両方のブロックに release-epic 削除がある"
+else
+  fail "minimal / standard 両方のブロックに release-epic 削除がない"
+fi
+
+# --- G. marketplace.json への登録 ---
+
+echo "--- G. marketplace.json への登録 ---"
+
+assert_file_exists "marketplace.json が存在する" "$MARKETPLACE_JSON"
+assert_file_contains "marketplace.json に release-epic が登録されている" "$MARKETPLACE_JSON" "./skills/release-epic"
+
+# --- H. 返却フォーマット ---
+
+echo "--- H. 返却フォーマット ---"
+
+assert_file_contains "結果報告フォーマットがある" "$SKILL_MD" "結果報告\|完了"
+assert_file_contains "リリース PR URL が報告に含まれる" "$SKILL_MD" "リリース PR\|PR URL"
+
+# ============================================
+print_test_summary
+# ============================================


### PR DESCRIPTION
## 🚀 概要

`/vibecorp:release-epic <親エピック Issue 番号>` で、エピック配下の全子 Issue が close されているとき、`feature/epic-*` → `main` のリリース PR が自動作成されるようになった。子 Issue タイトルを束ねたリリースノートが PR 本文に自動生成される。

## ✨ 何が変わったか

- ✅ `/vibecorp:release-epic <親番号>` で feature → main のリリース PR が作成されるようになった
- ✅ 子 Issue タイトルを束ねたリリースノートが PR 本文に自動生成されるようになった
- ✅ 未 close の子 Issue が残っている場合は中断して未完了一覧を CEO に提示するようになった
- ✅ 親エピック Issue にリリース PR の予告リンクが貼られるようになった
- ✅ minimal / standard プリセットでは install.sh で `/release-epic` スキルが除外される（full 専用）

## 🔒 スコープ外（重要）

- ⚠️ auto-merge 設定はスコープ外（`gh pr merge --auto` は呼ばない）
- ⚠️ マージは GitHub の auto-merge 機構（Branch Protection + CodeRabbit approve）に委ねる
- ⚠️ タグ打ち・バージョニング・デプロイは別 Issue で扱う

承認フロー非介入思想（2026-04-18 確立）を維持している。

## 📦 変更ファイル

- 🆕 `skills/release-epic/SKILL.md` — スキル本体
- 🆕 `tests/test_release_epic.sh` — 構造テスト（34 テストケース）
- 🔧 `install.sh` — minimal / standard プリセットで `release-epic` を除外
- 🔧 `.claude-plugin/marketplace.json` — `./skills/release-epic` を skills 配列に追加

## 🧪 テスト

```text
=== 結果: 34/34 passed, 0 failed ===
```

既存テスト（`test_plan_epic.sh`, `test_install_preset.sh`）にも影響なし。

## 🔗 関連

close https://github.com/hirokimry/vibecorp/issues/349

- decisions.md 2026-04-18「Issue 親子関係・大規模リリース支援」
- Issue #345 (`/plan-epic` スキル新設) ✅
- Issue #346 (`/ship` base 判定)
- Issue #347 (GHA 自動 close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * エピックのリリース自動化ワークフローを追加しました。親エピックの検証から子課題の集約、リリース用PRの作成・記録までをサポートします。

* **ドキュメント**
  * 新しい「release-epic」スキルの利用手順と制約を公開しました。

* **変更（インストーラ）**
  * インストール処理のクリーンアップに「release-epic」関連の削除処理を追加しました。

* **テスト**
  * リリースワークフローを検証する自動テストスクリプトを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->