### PR TITLE
🔒 fix: C*O subagent が Bash 経由で knowledge を直書きできないようになった

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,6 +32,10 @@
           },
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/protect-knowledge-bash-writes.sh"
+          },
+          {
+            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/protect-branch.sh"
           },
           {
@@ -62,6 +66,10 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/role-gate.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/protect-knowledge-direct-writes.sh"
           },
           {
             "type": "command",

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -48,7 +48,26 @@ docs/（Source of Truth・仕様書群）
 設計方針:
 - **永続データ（判断・監査）は `.claude/knowledge/` 配下** に置き、index + 四半期アーカイブの 2 段構成で肥大化を防ぐ
 - **揮発データは XDG_CACHE_HOME 配下** に置き、git 履歴に永続化しない（Issue #335 で CISO の `decisions.md` が肥大化した教訓）
-- `.claude/knowledge/{role}/decisions/` および `{role}/audit-log/` への作業ブランチ直書きは `protect-knowledge-direct-writes.sh` フックで deny される（buffer worktree 経由のみ許可、fail-secure）
+- `.claude/knowledge/{role}/decisions/` および `{role}/audit-log/` への作業ブランチ直書きは **2 層のフック**で deny される（buffer worktree 経由のみ許可、fail-secure）
+
+### fail-secure 多層防御（Issue #448 で確立）
+
+`.claude/knowledge/` の保護は **Edit/Write 層** と **Bash 層** の 2 層で実装する。
+
+| 層 | フック | matcher | 担当 |
+|---|---|---|---|
+| Edit/Write 層 | `protect-knowledge-direct-writes.sh` | `Edit\|Write\|MultiEdit` | Edit/Write/MultiEdit ツール経由の書込みを deny |
+| Bash 層 | `protect-knowledge-bash-writes.sh` | `Bash` | `>`, `>>`, `tee`, `cp`, `mv`, `sed -i`, `awk -i inplace` 等の Bash 経由書込みを deny |
+
+両層で `audit-log/` `decisions/` への直書きを deny し、buffer worktree 経由でのみ許可する。
+
+**設計原則**:
+- C*O 6 エージェント（cfo/cto/cpo/ciso/clo/sm）には `Edit, Write, MultiEdit` を tools として宣言し、Edit/Write 経由の書込みを誘導する
+- agent 定義の書込みセクションで「Bash redirect 禁止」を明文化する
+- それでも Bash redirect を試みた場合は Bash 層で fail-secure deny される
+- 共通のパス正規化ヘルパー `lib/path_normalize.sh` を両フックから source して DRY を維持する
+
+**なぜ 2 層必要か**: 当初は Edit/Write 層のみで設計したが、エージェントが Bash redirect を選んだ場合に hook を素通りする経路が判明（Issue #448）。多層防御により agent の tool 選択に依存せず保護を維持する。
 
 ### skills 内のステップにするもの
 

--- a/templates/claude/agents/cfo.md
+++ b/templates/claude/agents/cfo.md
@@ -4,7 +4,7 @@ description: >
   CFO（最高財務責任者）エージェント。コスト分析・API利用量管理・予算管理の番人。
   経理チームの合議結果をメタレビューし、コスト最適化を判断する。
   「コスト確認」「API利用量は？」「予算分析」と言った時に使用。
-tools: Read, Write, Bash, Grep, Glob
+tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob
 model: sonnet
 ---
 
@@ -123,6 +123,14 @@ fi
 ```
 
 #### 書込み（BUFFER_DIR が空でなければ実行）
+
+**書込みは Edit/Write/MultiEdit tool で行う。Bash redirect で knowledge 配下に書き込まない。**
+
+理由（Issue #448）:
+- `protect-knowledge-direct-writes.sh` フックは Edit/Write/MultiEdit matcher のみ監視する
+- Bash redirect (`>`, `>>`, `tee`, `cat <<EOF >`, `cp`, `mv`, `sed -i`, `awk -i inplace`) で書き込むと Bash 層の `protect-knowledge-bash-writes.sh` でも deny される
+- buffer 経由でない直書きは fail-secure で物理的に拒否される
+- Edit/Write を使うことで hook の deny を確実に検出でき、buffer 経由フォールバックが正しく動作する
 
 判断を以下の 2 箇所に記録する:
 

--- a/templates/claude/agents/ciso.md
+++ b/templates/claude/agents/ciso.md
@@ -4,7 +4,7 @@ description: >
   CISO（最高情報セキュリティ責任者）エージェント。セキュリティの番人。
   セキュリティチームの合議結果をメタレビューし、脆弱性・データ保護・認証設計を判断する。
   「セキュリティ確認」「脆弱性ない？」「セキュリティ監査」と言った時に使用。
-tools: Read, Bash, Grep, Glob
+tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob
 model: sonnet
 ---
 
@@ -127,6 +127,14 @@ fi
 ```
 
 #### 書込み（BUFFER_DIR が空でなければ実行）
+
+**書込みは Edit/Write/MultiEdit tool で行う。Bash redirect で knowledge 配下に書き込まない。**
+
+理由（Issue #448）:
+- `protect-knowledge-direct-writes.sh` フックは Edit/Write/MultiEdit matcher のみ監視する
+- Bash redirect (`>`, `>>`, `tee`, `cat <<EOF >`, `cp`, `mv`, `sed -i`, `awk -i inplace`) で書き込むと Bash 層の `protect-knowledge-bash-writes.sh` でも deny される
+- buffer 経由でない直書きは fail-secure で物理的に拒否される
+- Edit/Write を使うことで hook の deny を確実に検出でき、buffer 経由フォールバックが正しく動作する
 
 判断を以下の 2 箇所に記録する:
 

--- a/templates/claude/agents/clo.md
+++ b/templates/claude/agents/clo.md
@@ -4,7 +4,7 @@ description: >
   CLO（最高法務責任者）エージェント。法務・コンプライアンスの番人。
   法務チームの合議結果をメタレビューし、ライセンス・規約・コンプライアンスを判断する。
   「法務確認」「ライセンス大丈夫？」「コンプライアンスチェック」と言った時に使用。
-tools: Read, Bash, Grep, Glob
+tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob
 model: sonnet
 ---
 
@@ -117,6 +117,14 @@ fi
 ```
 
 #### 書込み（BUFFER_DIR が空でなければ実行）
+
+**書込みは Edit/Write/MultiEdit tool で行う。Bash redirect で knowledge 配下に書き込まない。**
+
+理由（Issue #448）:
+- `protect-knowledge-direct-writes.sh` フックは Edit/Write/MultiEdit matcher のみ監視する
+- Bash redirect (`>`, `>>`, `tee`, `cat <<EOF >`, `cp`, `mv`, `sed -i`, `awk -i inplace`) で書き込むと Bash 層の `protect-knowledge-bash-writes.sh` でも deny される
+- buffer 経由でない直書きは fail-secure で物理的に拒否される
+- Edit/Write を使うことで hook の deny を確実に検出でき、buffer 経由フォールバックが正しく動作する
 
 判断を以下の 2 箇所に記録する:
 

--- a/templates/claude/agents/cpo.md
+++ b/templates/claude/agents/cpo.md
@@ -4,7 +4,7 @@ description: >
   CPO（プロダクト責任者）エージェント。プロダクト方針・仕様の番人。
   仕様の一貫性チェック、新機能の評価、プロダクト方針とコード変更の整合性を判断する。
   「仕様確認」「この機能どう思う」「プロダクトレビュー」と言った時に使用。
-tools: Read, Bash, Grep, Glob
+tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob
 model: sonnet
 ---
 
@@ -107,6 +107,14 @@ fi
 ```
 
 #### 書込み（BUFFER_DIR が空でなければ実行）
+
+**書込みは Edit/Write/MultiEdit tool で行う。Bash redirect で knowledge 配下に書き込まない。**
+
+理由（Issue #448）:
+- `protect-knowledge-direct-writes.sh` フックは Edit/Write/MultiEdit matcher のみ監視する
+- Bash redirect (`>`, `>>`, `tee`, `cat <<EOF >`, `cp`, `mv`, `sed -i`, `awk -i inplace`) で書き込むと Bash 層の `protect-knowledge-bash-writes.sh` でも deny される
+- buffer 経由でない直書きは fail-secure で物理的に拒否される
+- Edit/Write を使うことで hook の deny を確実に検出でき、buffer 経由フォールバックが正しく動作する
 
 判断を以下の 2 箇所に記録する:
 

--- a/templates/claude/agents/cto.md
+++ b/templates/claude/agents/cto.md
@@ -4,7 +4,7 @@ description: >
   CTO（技術責任者）エージェント。コード品質・アーキテクチャ・技術的負債の番人。
   コードレビュー、技術スタック判断、依存パッケージ管理を行う。
   「コードレビューして」「技術的にどう？」「アーキテクチャ確認」と言った時に使用。
-tools: Read, Bash, Grep, Glob
+tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob
 model: sonnet
 ---
 
@@ -130,6 +130,14 @@ fi
 ```
 
 #### 書込み（BUFFER_DIR が空でなければ実行）
+
+**書込みは Edit/Write/MultiEdit tool で行う。Bash redirect で knowledge 配下に書き込まない。**
+
+理由（Issue #448）:
+- `protect-knowledge-direct-writes.sh` フックは Edit/Write/MultiEdit matcher のみ監視する
+- Bash redirect (`>`, `>>`, `tee`, `cat <<EOF >`, `cp`, `mv`, `sed -i`, `awk -i inplace`) で書き込むと Bash 層の `protect-knowledge-bash-writes.sh` でも deny される
+- buffer 経由でない直書きは fail-secure で物理的に拒否される
+- Edit/Write を使うことで hook の deny を確実に検出でき、buffer 経由フォールバックが正しく動作する
 
 判断を以下の 2 箇所に記録する:
 

--- a/templates/claude/agents/sm.md
+++ b/templates/claude/agents/sm.md
@@ -4,7 +4,7 @@ description: >
   SM（Scrum Master）エージェント。プロセス管理の専門家として組織全体を見渡す。
   進捗報告・エージェント間調整・次タスク提案・ブロッカー検出・並列実行判定を行う。
   「状況報告」「次やること」「並列判定して」「タスク整理して」と言った時に使用。
-tools: Read, Bash, Grep, Glob
+tools: Read, Edit, Write, MultiEdit, Bash, Grep, Glob
 model: sonnet
 ---
 
@@ -140,6 +140,14 @@ fi
 ```
 
 #### 書込み（BUFFER_DIR が空でなければ実行）
+
+**書込みは Edit/Write/MultiEdit tool で行う。Bash redirect で knowledge 配下に書き込まない。**
+
+理由（Issue #448）:
+- `protect-knowledge-direct-writes.sh` フックは Edit/Write/MultiEdit matcher のみ監視する
+- Bash redirect (`>`, `>>`, `tee`, `cat <<EOF >`, `cp`, `mv`, `sed -i`, `awk -i inplace`) で書き込むと Bash 層の `protect-knowledge-bash-writes.sh` でも deny される
+- buffer 経由でない直書きは fail-secure で物理的に拒否される
+- Edit/Write を使うことで hook の deny を確実に検出でき、buffer 経由フォールバックが正しく動作する
 
 判断を以下の 2 箇所に記録する:
 

--- a/templates/claude/hooks/protect-knowledge-bash-writes.sh
+++ b/templates/claude/hooks/protect-knowledge-bash-writes.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# protect-knowledge-bash-writes.sh — Bash 経由の knowledge 直書きを deny する
+# Issue #448: Edit/Write hook で deny する protect-knowledge-direct-writes.sh と対をなす多層防御の Bash 層
+#
+# 設計:
+#   順序: コマンド正規化（環境変数除去、ラッパー除去、bash -c 展開）
+#         → 検出パターン照合 + パス抽出
+#         → buffer 経由判定（既存 hook の 3 段ガード踏襲）
+#         → deny 出力
+#
+# 既知ギャップ（明示的に Edit/Write 層 + agent 定義の Edit/Write 強制でカバー）:
+#   - bash -c $'...' 形式（$''quote）
+#   - shell function 経由
+#   - eval "..." 経由
+
+set -euo pipefail
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${HOOK_DIR}/../lib/common.sh"
+# shellcheck source=../lib/knowledge_buffer.sh
+source "${HOOK_DIR}/../lib/knowledge_buffer.sh"
+# shellcheck source=../lib/path_normalize.sh
+source "${HOOK_DIR}/../lib/path_normalize.sh"
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# === 1. コマンド正規化 ===
+
+cmd_normalized="$COMMAND"
+
+# 1a) 複数の環境変数プレフィックス除去（while ループで全て剥がす）
+while [[ "$cmd_normalized" =~ ^[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+ ]]; do
+  cmd_normalized="${cmd_normalized#*[[:space:]]}"
+done
+
+# 1b) ラッパーコマンド（env / command）の除去
+# `env -i` / `env --ignore-environment` 等のフラグも一緒に剥がす
+while true; do
+  case "$cmd_normalized" in
+    "env "*)
+      rest="${cmd_normalized#env }"
+      # env のフラグを剥がす（次の非フラグ引数まで）
+      while [[ "$rest" =~ ^-[^[:space:]]*[[:space:]] ]]; do
+        rest="${rest#*[[:space:]]}"
+      done
+      cmd_normalized="$rest"
+      ;;
+    "command "*)
+      cmd_normalized="${cmd_normalized#command }"
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+# 1c) `bash -c "..."` / `sh -c "..."` 内のコマンドを展開
+case "$cmd_normalized" in
+  "bash -c \""*"\""|"bash -c '"*"'"|"sh -c \""*"\""|"sh -c '"*"'")
+    inner=$(printf '%s' "$cmd_normalized" | sed -E "s/^(bash|sh) -c [\"'](.*)[\"']\$/\\2/")
+    if [ -n "$inner" ] && [ "$inner" != "$cmd_normalized" ]; then
+      cmd_normalized="$inner"
+    fi
+    ;;
+esac
+
+# === 2. 検出パターン照合 + パス抽出 ===
+
+is_deny_target=0
+detected_path=""
+
+for forbidden in 'decisions/' 'audit-log/'; do
+  # 2a) 出力リダイレクト（> / >>）
+  # 複合コマンド `cmd1 && cmd2 > file` も対象
+  if [[ "$cmd_normalized" =~ (\>{1,2})[[:space:]]*[\'\"]?([^[:space:]\'\"\;]*\.claude/knowledge/[^/]+/${forbidden}[^[:space:]\'\"\;]*) ]]; then
+    detected_path="${BASH_REMATCH[2]}"
+    is_deny_target=1
+    break
+  fi
+  # 2b) tee / tee -a
+  if [[ "$cmd_normalized" =~ tee[[:space:]]+(-a[[:space:]]+)?[\'\"]?([^[:space:]\'\"\;]*\.claude/knowledge/[^/]+/${forbidden}[^[:space:]\'\"\;]*) ]]; then
+    detected_path="${BASH_REMATCH[2]}"
+    is_deny_target=1
+    break
+  fi
+  # 2c) cp / mv の宛先
+  if [[ "$cmd_normalized" =~ (cp|mv)[[:space:]]+[^\|\;\&]+[[:space:]]+[\'\"]?([^[:space:]\'\"\;]*\.claude/knowledge/[^/]+/${forbidden}[^[:space:]\'\"\;]*) ]]; then
+    detected_path="${BASH_REMATCH[2]}"
+    is_deny_target=1
+    break
+  fi
+  # 2d) GNU sed -i / BSD sed -i '' / awk -i inplace
+  if [[ "$cmd_normalized" =~ (sed[[:space:]]+-i([[:space:]]+\'\')?|awk[[:space:]]+-i[[:space:]]+inplace)[[:space:]]+[^\|\;\&]*[\'\"]?([^[:space:]\'\"\;]*\.claude/knowledge/[^/]+/${forbidden}[^[:space:]\'\"\;]*) ]]; then
+    detected_path="${BASH_REMATCH[3]}"
+    is_deny_target=1
+    break
+  fi
+done
+
+if [ "$is_deny_target" -eq 0 ]; then
+  exit 0
+fi
+
+# === 3. buffer 経由判定（既存 hook の 3 段ガード踏襲） ===
+
+buffer_dir="$(knowledge_buffer_worktree_dir 2>/dev/null || true)"
+abs_detected_path="$(_pkw_normalize_path "$detected_path" 2>/dev/null || echo "")"
+
+if [ -n "$buffer_dir" ] && [ -n "$abs_detected_path" ]; then
+  abs_buffer_dir="$(_pkw_normalize_path "$buffer_dir" 2>/dev/null || echo "")"
+  expected_prefix="$(vibecorp_cache_root)/vibecorp/buffer-worktree/"
+  if [ -n "$abs_buffer_dir" ] && [[ "$abs_buffer_dir" == "$expected_prefix"* ]] && [[ "$abs_detected_path" == "${abs_buffer_dir}/"* ]]; then
+    exit 0
+  fi
+fi
+
+# === 4. deny 出力 ===
+
+buffer_label="${buffer_dir:-（未取得・knowledge_buffer_ensure を実行してください）}"
+
+jq -n \
+  --arg detected "$detected_path" \
+  --arg buffer "$buffer_label" \
+  '{
+    "hookSpecificOutput": {
+      "hookEventName": "PreToolUse",
+      "permissionDecision": "deny",
+      "permissionDecisionReason": ("検出パス: " + $detected + "\n\n.claude/knowledge/{role}/decisions/ や {role}/audit-log/ への Bash 経由直書きは禁止です（>, >>, tee, cp, mv, sed -i, awk -i inplace を含む）。\n\n復旧手順:\n1. . .claude/lib/knowledge_buffer.sh\n2. knowledge_buffer_ensure\n3. BUFFER_DIR=" + $buffer + "\n4. コマンドの宛先を ${BUFFER_DIR}/.claude/knowledge/... に置き換えて再実行\n\n書込みは Bash redirect ではなく Edit/Write/MultiEdit ツールを使うことを推奨します（hook が deny を確実に検出できます）。")
+    }
+  }'
+exit 0

--- a/templates/claude/hooks/protect-knowledge-direct-writes.sh
+++ b/templates/claude/hooks/protect-knowledge-direct-writes.sh
@@ -17,6 +17,9 @@ HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "${HOOK_DIR}/../lib/common.sh"
 # shellcheck source=../lib/knowledge_buffer.sh
 source "${HOOK_DIR}/../lib/knowledge_buffer.sh"
+# shellcheck source=../lib/path_normalize.sh
+# パス正規化ヘルパー _pkw_normalize_path を共通 lib から取得（Issue #448）
+source "${HOOK_DIR}/../lib/path_normalize.sh"
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
@@ -24,21 +27,6 @@ FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
-
-# realpath -m が macOS BSD で利用不能な場合の Python フォールバック
-# Python コード内に変数展開を埋め込まず、引数渡しでインジェクション回避
-_pkw_normalize_path() {
-  local p="$1"
-  if command -v realpath >/dev/null 2>&1 && realpath -m / >/dev/null 2>&1; then
-    realpath -m -- "$p"
-  elif command -v python3 >/dev/null 2>&1; then
-    # 引数渡しでインジェクション回避（変数展開を Python コードに埋め込まない）
-    # `--` は使わない（python3 -c は -c の値で「コード」を受け、それ以降の引数は sys.argv[1:] に入る）
-    python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$p"
-  else
-    return 1
-  fi
-}
 
 # パス正規化（パストラバーサル / シンボリックリンク対策）
 abs_file_path="$(_pkw_normalize_path "$FILE_PATH" 2>/dev/null || echo "")"

--- a/templates/claude/lib/path_normalize.sh
+++ b/templates/claude/lib/path_normalize.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# path_normalize.sh — protect-knowledge-direct-writes.sh と protect-knowledge-bash-writes.sh が
+# 共通で使うパス正規化ヘルパー（DRY 化、Issue #448）
+#
+# 使い方: source "${HOOK_DIR}/../lib/path_normalize.sh"
+#
+# - realpath -m が使える環境では realpath を優先
+# - macOS BSD 等で利用不能な場合は Python フォールバック
+# - Python コード内に変数展開を埋め込まず引数渡しでインジェクション回避
+
+_pkw_normalize_path() {
+  local p="$1"
+  if command -v realpath >/dev/null 2>&1 && realpath -m / >/dev/null 2>&1; then
+    realpath -m -- "$p"
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$p"
+  else
+    return 1
+  fi
+}

--- a/templates/claude/settings.json
+++ b/templates/claude/settings.json
@@ -72,6 +72,10 @@
           },
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/protect-knowledge-bash-writes.sh"
+          },
+          {
+            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/sync-gate.sh"
           },
           {

--- a/templates/settings.json.tpl
+++ b/templates/settings.json.tpl
@@ -72,6 +72,10 @@
           },
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/protect-knowledge-bash-writes.sh"
+          },
+          {
+            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/sync-gate.sh"
           },
           {

--- a/tests/test_co_decisions_buffer.sh
+++ b/tests/test_co_decisions_buffer.sh
@@ -68,4 +68,52 @@ for role in cfo cto cpo ciso clo sm; do
   fi
 done
 
+# --- Issue #448: C*O 6 ロールに Edit/Write/MultiEdit が tools として宣言されている ---
+echo ""
+echo "--- Issue #448: tools フィールド検証 ---"
+
+for role in cfo cto cpo ciso clo sm; do
+  agent_file="${AGENTS_DIR}/${role}.md"
+  if [ ! -f "$agent_file" ]; then
+    fail "${role}: agent file が存在しない"
+    continue
+  fi
+  tools_line="$(grep '^tools:' "$agent_file" || echo "")"
+  if [ -z "$tools_line" ]; then
+    fail "${role}: tools フィールドがない"
+    continue
+  fi
+  if echo "$tools_line" | grep -qE '\bEdit\b'; then
+    pass "${role}: tools に Edit が含まれる"
+  else
+    fail "${role}: tools に Edit が含まれない（${tools_line}）"
+  fi
+  if echo "$tools_line" | grep -qE '\bWrite\b'; then
+    pass "${role}: tools に Write が含まれる"
+  else
+    fail "${role}: tools に Write が含まれない（${tools_line}）"
+  fi
+  if echo "$tools_line" | grep -qE '\bMultiEdit\b'; then
+    pass "${role}: tools に MultiEdit が含まれる"
+  else
+    fail "${role}: tools に MultiEdit が含まれない（${tools_line}）"
+  fi
+done
+
+# --- Issue #448: Bash redirect 禁止が agent 定義に明文化 ---
+echo ""
+echo "--- Issue #448: Bash redirect 禁止の明文化 ---"
+
+for role in cfo cto cpo ciso clo sm; do
+  agent_file="${AGENTS_DIR}/${role}.md"
+  if [ ! -f "$agent_file" ]; then
+    continue
+  fi
+  if grep -q "Bash redirect で knowledge 配下に書き込まない" "$agent_file"; then
+    pass "${role}: Bash redirect 禁止記述あり"
+  else
+    fail "${role}: Bash redirect 禁止記述がない"
+  fi
+done
+
 print_test_summary

--- a/tests/test_protect_knowledge_bash_writes.sh
+++ b/tests/test_protect_knowledge_bash_writes.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+# test_protect_knowledge_bash_writes.sh — Issue #448: Bash 経由の knowledge 直書きを deny する hook の検証
+# 使い方: bash tests/test_protect_knowledge_bash_writes.sh
+
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${TESTS_DIR}/lib/test_helpers.sh"
+
+PROJECT_DIR="$(cd "${TESTS_DIR}/.." && pwd)"
+HOOK_FILE="${PROJECT_DIR}/templates/claude/hooks/protect-knowledge-bash-writes.sh"
+
+TMPDIR_ROOT="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMPDIR_ROOT" || true
+}
+trap cleanup EXIT
+
+echo "=== Issue #448: protect-knowledge-bash-writes.sh テスト ==="
+
+# --- テスト1: ファイル存在 ---
+echo ""
+echo "--- テスト1: ファイル存在 ---"
+
+if [[ -f "$HOOK_FILE" ]]; then
+  pass "hook ファイルが存在する"
+else
+  fail "hook ファイルが存在しない"
+  exit 1
+fi
+assert_file_executable "hook が実行可能" "$HOOK_FILE"
+
+# 共通: hook 実行ヘルパー
+run_hook() {
+  local cmd="$1"
+  local input
+  input=$(jq -n --arg c "$cmd" '{tool_input: {command: $c}}')
+  echo "$input" | bash "$HOOK_FILE" 2>/dev/null
+}
+
+assert_deny() {
+  local desc="$1"
+  local cmd="$2"
+  local result
+  result=$(run_hook "$cmd")
+  if [[ "$result" == *'"permissionDecision":'*'"deny"'* ]]; then
+    pass "$desc"
+  else
+    fail "$desc: $result"
+  fi
+}
+
+assert_pass() {
+  local desc="$1"
+  local cmd="$2"
+  local result
+  result=$(run_hook "$cmd")
+  if [ -z "$result" ]; then
+    pass "$desc"
+  else
+    fail "$desc: $result"
+  fi
+}
+
+# --- テスト2: command が空 → 関与せず通す ---
+echo ""
+echo "--- テスト2: command 空・欠落 ---"
+
+result_empty=$(echo '{"tool_input":{"command":""}}' | bash "$HOOK_FILE" 2>/dev/null || true)
+if [ -z "$result_empty" ]; then
+  pass "command 空 → 通過"
+else
+  fail "command 空 → 出力あり: $result_empty"
+fi
+
+result_missing=$(echo '{"tool_input":{}}' | bash "$HOOK_FILE" 2>/dev/null || true)
+if [ -z "$result_missing" ]; then
+  pass "command 欠落 → 通過"
+else
+  fail "command 欠落 → 出力あり: $result_missing"
+fi
+
+# --- テスト3: 出力リダイレクト > / >> → deny ---
+echo ""
+echo "--- テスト3: 出力リダイレクト ---"
+
+assert_deny "> redirect → deny" "echo foo > .claude/knowledge/cfo/decisions/2026-Q2.md"
+assert_deny ">> redirect → deny" "echo foo >> .claude/knowledge/cfo/decisions/2026-Q2.md"
+assert_deny ">> redirect (audit-log) → deny" "echo foo >> .claude/knowledge/accounting/audit-log/2026-Q2.md"
+assert_deny "> redirect (security) → deny" "echo foo > .claude/knowledge/security/audit-log/2026-Q2.md"
+
+# --- テスト4: tee / tee -a → deny ---
+echo ""
+echo "--- テスト4: tee ---"
+
+assert_deny "tee → deny" "echo foo | tee .claude/knowledge/cfo/decisions/2026-Q2.md"
+assert_deny "tee -a → deny" "echo foo | tee -a .claude/knowledge/cfo/decisions/2026-Q2.md"
+
+# --- テスト5: cp / mv → deny ---
+echo ""
+echo "--- テスト5: cp / mv ---"
+
+assert_deny "cp → deny" "cp src.md .claude/knowledge/cfo/decisions/2026-Q2.md"
+assert_deny "mv → deny" "mv src.md .claude/knowledge/cfo/decisions/2026-Q2.md"
+
+# --- テスト6: heredoc → deny（リダイレクト部分でマッチ） ---
+echo ""
+echo "--- テスト6: heredoc ---"
+
+assert_deny "cat <<EOF > path → deny" 'cat <<EOF > .claude/knowledge/cfo/decisions/2026-Q2.md
+content
+EOF'
+assert_deny "cat <<\047EOF\047 >> path → deny" "cat <<'EOF' >> .claude/knowledge/cfo/decisions/2026-Q2.md
+content
+EOF"
+
+# --- テスト7: sed -i / awk -i inplace → deny ---
+echo ""
+echo "--- テスト7: sed -i / awk -i inplace ---"
+
+assert_deny "GNU sed -i → deny" "sed -i 's/foo/bar/' .claude/knowledge/cfo/decisions/2026-Q2.md"
+assert_deny "BSD sed -i '' → deny" "sed -i '' 's/foo/bar/' .claude/knowledge/cfo/decisions/2026-Q2.md"
+assert_deny "awk -i inplace → deny" 'awk -i inplace "{print}" .claude/knowledge/cfo/decisions/2026-Q2.md'
+
+# --- テスト8: 複合コマンド・正規化 ---
+echo ""
+echo "--- テスト8: 複合コマンド・正規化 ---"
+
+assert_deny "cmd1 && cmd2 >> file → deny" "git status && echo foo >> .claude/knowledge/cfo/decisions/2026-Q2.md"
+assert_deny "echo foo | tee path → deny" "echo foo | tee .claude/knowledge/cfo/decisions/2026-Q2.md"
+
+# 環境変数プレフィックス（複数）
+assert_deny "KEY1=v1 cat >> path → deny" "FOO=1 cat >> .claude/knowledge/cfo/decisions/2026-Q2.md"
+assert_deny "KEY1=v1 KEY2=v2 cat >> path → deny" "FOO=1 BAR=2 cat >> .claude/knowledge/cfo/decisions/2026-Q2.md"
+
+# env / command ラッパー
+assert_deny "env KEY=v cat >> path → deny" "env FOO=1 cat >> .claude/knowledge/cfo/decisions/2026-Q2.md"
+assert_deny "command tee path → deny" "command tee .claude/knowledge/cfo/decisions/2026-Q2.md"
+
+# bash -c / sh -c 展開
+assert_deny "bash -c \"cat >> path\" → deny" 'bash -c "cat >> .claude/knowledge/cfo/decisions/2026-Q2.md"'
+assert_deny "sh -c \"tee path\" → deny" "sh -c \"tee .claude/knowledge/cfo/decisions/2026-Q2.md\""
+
+# --- テスト9: 通過（無関係 / knowledge 外） ---
+echo ""
+echo "--- テスト9: 通過パターン ---"
+
+assert_pass "git status → 通過" "git status"
+assert_pass "ls -la → 通過" "ls -la"
+assert_pass ">> /tmp/foo → 通過" "echo foo >> /tmp/foo.md"
+assert_pass "knowledge/ 外 cp → 通過" "cp foo.md /tmp/bar.md"
+# quote 内の偽パスは検出ロジック上 detect される可能性があるが、書込み宛先ではないため通過すべき
+# 現実装は宛先パターンをマッチさせるため、文字列 "...>" に knowledge path が含まれていれば deny される
+# これは false positive だが安全側（fail-secure）なので許容
+
+# --- テスト10: buffer 経由（許可） ---
+echo ""
+echo "--- テスト10: buffer 経由許可 ---"
+
+# 実 buffer worktree パスを取得
+real_buffer_dir="$(. "${PROJECT_DIR}/templates/claude/lib/common.sh" && . "${PROJECT_DIR}/templates/claude/lib/knowledge_buffer.sh" && knowledge_buffer_worktree_dir 2>/dev/null || echo "")"
+
+if [ -n "$real_buffer_dir" ] && [ -d "$real_buffer_dir" ]; then
+  mkdir -p "${real_buffer_dir}/.claude/knowledge/cfo/decisions"
+  buffer_target="${real_buffer_dir}/.claude/knowledge/cfo/decisions/2026-Q2.md"
+  assert_pass "buffer 経由 >> → 許可" "echo foo >> ${buffer_target}"
+else
+  echo "  SKIP: buffer worktree が利用できないため skip"
+fi
+
+# --- テスト11: 既知ギャップ（明示的に「検出しない」を確認） ---
+echo ""
+echo "--- テスト11: 既知ギャップ（多層防御で他の層がカバー） ---"
+
+# bash -c $'...' 形式（$'' quote）は未対応
+result=$(run_hook "bash -c \$'cat >> .claude/knowledge/cfo/decisions/2026-Q2.md'")
+if [ -z "$result" ]; then
+  pass "bash -c \$'...' は通過（既知ギャップ・Edit/Write 層 + agent 定義でカバー）"
+else
+  pass "bash -c \$'...' は deny される（過剰検出だが安全側で許容）"
+fi
+
+# --- テスト12: templates / 本体 同期検証 ---
+echo ""
+echo "--- テスト12: templates と本体の hook 同期 ---"
+
+BODY_HOOK_FILE="${PROJECT_DIR}/.claude/hooks/protect-knowledge-bash-writes.sh"
+if [ -f "$BODY_HOOK_FILE" ]; then
+  if diff -q "$HOOK_FILE" "$BODY_HOOK_FILE" >/dev/null 2>&1; then
+    pass "templates と本体の hook が同一"
+  else
+    fail "templates と本体の hook が乖離している"
+  fi
+else
+  pass "本体 hook 未配置（dogfood 環境のみ存在、新規 install では templates から配布）"
+fi
+
+print_test_summary

--- a/tests/test_protect_knowledge_direct_writes.sh
+++ b/tests/test_protect_knowledge_direct_writes.sh
@@ -231,15 +231,14 @@ else
 fi
 
 # --- テスト10: realpath フォールバック（Python 代替）— 常に検証 ---
+# Issue #448 で _pkw_normalize_path は lib/path_normalize.sh に共通化された
 echo ""
 echo "--- テスト10: Python フォールバック常時検証 ---"
 
-# 関数定義のみを抽出した一時ファイルを作る
-fn_file="${TMPDIR_ROOT}/_pkw_fn.sh"
-awk '/^_pkw_normalize_path\(\)/,/^}$/' "$HOOK_FILE" > "$fn_file"
+LIB_FILE="${PROJECT_DIR}/templates/claude/lib/path_normalize.sh"
 
 # realpath を PATH から外して Python フォールバック経路を強制実行
-# 「native が使える環境では未検証」という穴を塞ぐ（PR で追加した経路を確実に踏ませる）
+# 「native が使える環境では未検証」という穴を塞ぐ
 empty_path="${TMPDIR_ROOT}/empty-bin"
 mkdir -p "$empty_path"
 # 必要最小限のコマンドだけ symlink（realpath は除外）
@@ -250,11 +249,11 @@ for cmd in bash python3 command; do
   fi
 done
 
-result=$(PATH="$empty_path" bash -c "source '${fn_file}'; _pkw_normalize_path '/foo/../bar/./baz'" 2>/dev/null || echo "FAIL")
-if [ "$result" = "/bar/baz" ]; then
+fallback_result=$(PATH="$empty_path" bash -c "source '${LIB_FILE}'; _pkw_normalize_path '/foo/../bar/./baz'" 2>/dev/null || echo "FAIL")
+if [ "${fallback_result}" = "/bar/baz" ]; then
   pass "Python フォールバック（realpath 不在強制）で /foo/../bar/./baz → /bar/baz"
 else
-  fail "Python フォールバック結果が期待外: $result（期待: /bar/baz）"
+  fail "Python フォールバック結果が期待外: ${fallback_result}（期待: /bar/baz）"
 fi
 
 # --- テスト11: deny メッセージの可読性 ---


### PR DESCRIPTION
## 概要

C*O サブエージェント（CFO/CTO/CPO/CISO/CLO/SM）が `.claude/knowledge/{role}/decisions/` への直書きを fail-secure で物理的に拒否されるようになった。

## 🐛 修正前の状況

PR #445（Issue #442）の作業中、C*O 6 エージェントが各自の判断記録を **working tree に直接書き込み**、12 ファイル / 270 行が PR スコープ外にこぼれた（PR #447 で手動回収）。さらに /vibecorp:issue の 3 者ゲートでも同様の流出が再現していた。

## 🎯 根本原因（実機調査済み・3 層）

```text
templates/claude/agents/{cpo,cto,ciso,clo,sm}.md  tools: Read, Bash, Grep, Glob  ← Edit/Write 不在
templates/claude/agents/cfo.md                     tools: Read, Write, Bash, Grep, Glob  ← Bash 利用率高
                                                                                         ↓
PreToolUse hook matcher: "Edit|Write|MultiEdit"                                    ↓
  → Edit/Write 持たない agent はそもそも matcher に到達しない                        ↓
  → CFO も判断記録の append は Bash の `>>` を選ぶ                                  ↓
  Bash matcher chain (block-api-bypass.sh, command-log.sh 等)                       ↓
    → knowledge パス検査が**含まれていない**                              **bypass**
                                                                                    ↓
本体 .claude/settings.json に protect-knowledge-direct-writes.sh が**未登録**       ↓
  → Issue #441 で templates のみ追加され body 同期漏れ                  **二重 bypass**
```

## 🔒 多層防御による修正

### 層 1: Bash 層 hook 新設
- `protect-knowledge-bash-writes.sh` を新設し、Bash matcher chain に登録
- 検出パターン: `>` / `>>` / `tee` / `tee -a` / `cp` / `mv` / `cat <<EOF >` / GNU `sed -i` / BSD `sed -i ''` / `awk -i inplace`
- コマンド正規化: 複数環境変数プレフィックス除去 / `env` / `command` ラッパー除去 / `bash -c` / `sh -c` 内コマンド展開
- buffer prefix 3 段ガード（`buffer_dir` 非空 + `abs_buffer_dir` 非空 + prefix 一致）で fail-open バグを防ぐ

### 層 2: Edit/Write 層強化
- C*O 6 ロール全てに `Edit, Write, MultiEdit` を tools に追加（agent が Edit/Write を選択できるようになった）
- 本体 `.claude/settings.json` に `protect-knowledge-direct-writes.sh` を登録（template 同期漏れの修正）

### 層 3: agent 定義での明文化
- 各 agent の書込みセクションに **「Bash redirect で knowledge 配下に書き込まない」** を明記
- 「Edit/Write/MultiEdit tool で行う」を強制

### 共通化
- パス正規化ヘルパー `lib/path_normalize.sh` を新設し、両 hook から共有（DRY）

## 📚 既知ギャップ（明示的に多層でカバー）

| ギャップ | カバー層 |
|---|---|
| `bash -c $'...'` 形式（`$'' quote`） | Edit/Write 層 + agent 定義の Edit/Write 強制 |
| shell function 経由 (`my_func() { cat > path; }; my_func`) | 同上 |
| `eval "..."` 経由 | 同上 |

## 🧪 テスト結果

```text
test_protect_knowledge_direct_writes.sh  24/24 PASS
test_protect_knowledge_bash_writes.sh    32/32 PASS  ★ 新規
test_co_decisions_buffer.sh              78/78 PASS  ★ tools 検証 + Bash 禁止文検証 追加
test_settings_template_consistency.sh     5/5  PASS
test_settings_json_hooks_exist.sh         6/6  PASS
test_audit_log_structure.sh              27/27 PASS
test_no_direct_knowledge_writes.sh        3/3  PASS
合計: 175/175 PASS
```

## 🔍 レビュー結果

- **CodeRabbit CLI**: ✅ No findings
- **CISO**: ✅ 承認（多層防御 3 層の設計強度妥当、SECURITY.md 整合、攻撃面縮小）

## 📍 起票経路（CEO 直接承認）

3 者ゲートで SM が「ガードレール領域に該当」と判定したが、CEO 直接承認ルートで起票（autopilot 対象外、`/vibecorp:ship` 手動実装ルート）。

close https://github.com/hirokimry/vibecorp/issues/448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **チョア**
  * ナレッジ領域への直接シェル書き込みを防ぐ新たな事前フックを追加し保護層を強化
  * 共通のパス正規化ユーティリティを導入して保護ロジックを一貫化
  * エージェント設定を更新し、安全な書き込みツールの利用を明確化

* **ドキュメント**
  * 保護モデルと制約（ツール利用方針、フェイルセーフ層）を明文化

* **テスト**
  * 各種書き込みパターンを検証する自動テストと宣言チェックを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->