### PR TITLE
🧪 test: migration-knowledge-buffer.md のヘッダー検証が行全体一致になる

### DIFF
--- a/tests/test_migration_doc_exists.sh
+++ b/tests/test_migration_doc_exists.sh
@@ -97,14 +97,19 @@ echo "--- テスト8: ヘッダー文字列の agent / skill / docs 一致 ---"
 # 厳格指定された文字列。バリエーション禁止（半角カッコ・別語句・見出しレベル変更）
 HEADER='### 判断記録（記録先取得失敗）'
 
-# migration-knowledge-buffer.md にヘッダー文字列が含まれる（救済手順として明文化）
-if grep -qF -- "$HEADER" "$MIG_FILE"; then
-  pass "migration-knowledge-buffer.md にヘッダー文字列が記載されている"
+# migration-knowledge-buffer.md にヘッダー文字列が **単独行で** 記載されている
+# CodeRabbit 指摘 (PR #453 r3161539735): SoT として migration-knowledge-buffer.md には
+# ヘッダーを単独行（見出し）として示すため、行全体一致（-qxF）で検証する
+if grep -qxF -- "$HEADER" "$MIG_FILE"; then
+  pass "migration-knowledge-buffer.md にヘッダー文字列が単独行で記載されている（行全体一致）"
 else
-  fail "migration-knowledge-buffer.md にヘッダー文字列が無い"
+  fail "migration-knowledge-buffer.md にヘッダー文字列が単独行で無い"
 fi
 
 # C*O 6 体 + 分析員 3 体 = 9 ファイルにヘッダー文字列が含まれる
+# 注: C*O 6 体は説明文中で「### 判断記録（記録先取得失敗）」を引用するスタイルのため
+# 部分一致（-qF）で検証する。分析員 3 体はフォールバック出力例として行頭で書いているが、
+# 一貫性のため 9 体すべて部分一致で検証する（-qxF だと C*O 6 体が fail する）
 agents_dir="${PROJECT_DIR}/templates/claude/agents"
 expected_agents="cfo cto cpo ciso clo sm accounting-analyst security-analyst legal-analyst"
 agent_miss_count=0


### PR DESCRIPTION
## 関連 Issue

ref https://github.com/hirokimry/vibecorp/issues/452
follow-up of https://github.com/hirokimry/vibecorp/pull/453

## 概要

PR #453 のマージ後に来た CodeRabbit 追加指摘（[r3161539735](https://github.com/hirokimry/vibecorp/pull/453#discussion_r3161539735)）への follow-up 対応。auto-merge 発動と最後の修正コミット push のタイミングが重なり、PR #453 にこの修正を含められなかったため別 PR で main に反映する。

### 🛠️ Before / After

| ファイル | Before | After |
|---|---|---|
| `tests/test_migration_doc_exists.sh:101` | `grep -qF`（部分一致）で `migration-knowledge-buffer.md` のヘッダー有無を検査 | ✅ `grep -qxF`（行全体一致）で **単独行（見出し）として** 記載されているか厳密に検証 |

### 📋 部分採用の理由

CodeRabbit は agent files 9 体のチェックも `-qxF` への強化を提案していたが、実態確認の結果 **half-correct** と判定し却下:

| 種別 | 行全体一致適合 | 記述スタイル |
|---|---|---|
| 分析員 3 体（accounting / security / legal-analyst） | ✅ | フォールバック出力例として行頭に記載 |
| C\*O 6 体（cfo / cto / cpo / ciso / clo / sm） | ❌ | 説明文中で「`### 判断記録（記録先取得失敗）`」を引用するスタイル |

C\*O 6 体は「このヘッダーで返してください」と指示する説明文として正しい記述で、`-qxF` を強制すると本来正しい記述まで fail します。詳細は [PR #453 の返信](https://github.com/hirokimry/vibecorp/pull/453#discussion_r3161559065) 参照。

### ⚠️ 影響範囲

- 実装コード（hooks / agents / skills / settings.json）は **一切変更しない**
- `tests/test_migration_doc_exists.sh` のみ 1 関数の grep フラグ変更（部分一致 → 行全体一致）

## テスト計画

- [x] `bash tests/test_migration_doc_exists.sh` 通過（27/27、テスト 8 で行全体一致を確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## テスト改善

* **テスト**
  * ドキュメント検証テストの判定条件をより厳密に改善し、検証精度を向上させました。関連するエラーメッセージも更新され、テスト結果がより正確になっています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->