### PR TITLE
🚀 release: plugin.json を 0.3.0 に bump して新スキル群をリリースする

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vibecorp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "AI エージェントチームによる再現可能なプロダクト開発フレームワーク"
 }

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ which claude
 |---|---|---|---|---|---|
 | **minimal** | /vibecorp:review, /vibecorp:review-loop, /vibecorp:pr-fix, /vibecorp:pr-fix-loop, /vibecorp:pr, /vibecorp:commit, /vibecorp:issue, /vibecorp:ship, /vibecorp:plan, /vibecorp:branch, /vibecorp:plan-review-loop, /vibecorp:worktree, /vibecorp:approve-audit | protect-files, protect-branch, block-api-bypass, command-log | なし | Claude Max 定額内 | 個人〜小規模 |
 | **standard** | 上記 + /vibecorp:review-harvest, /vibecorp:sync-check, /vibecorp:sync-edit, /vibecorp:session-harvest, /vibecorp:harvest-all, /vibecorp:context7 | 上記 + sync-gate, review-gate | CTO, CPO | Claude Max 定額内 | チーム開発 |
-| **full** | 上記 + /vibecorp:diagnose, /vibecorp:ship-parallel, /vibecorp:autopilot | 上記 + role-gate, diagnose-guard | C-suite全員 + SM + 分析員（14ロール） | **ANTHROPIC_API_KEY 従量課金に到達しうる**（[詳細](docs/cost-analysis.md#実行モード別の課金モデル)） | AI企業・コンプライアンス重視 |
+| **full** | 上記 + /vibecorp:diagnose, /vibecorp:ship-parallel, /vibecorp:autopilot, /vibecorp:plan-epic, /vibecorp:release-epic, /vibecorp:cycle-metrics | 上記 + role-gate, diagnose-guard | C-suite全員 + SM + 分析員（14ロール） | **ANTHROPIC_API_KEY 従量課金に到達しうる**（[詳細](docs/cost-analysis.md#実行モード別の課金モデル)） | AI企業・コンプライアンス重視 |
 
 ## インストールされるもの
 
@@ -215,13 +215,16 @@ your-project/
 | `/vibecorp:harvest-all` | コードベース全体を棚卸しし、ドキュメント化されていない暗黙知を docs / rules / knowledge に反映 |
 | `/vibecorp:context7` | Context7 CLI 経由でライブラリ・フレームワークの最新ドキュメントを取得・要約 |
 
-### full プリセットで追加（4スキル）
+### full プリセットで追加（6スキル）
 
 | スキル | 説明 |
 |---|---|
 | `/vibecorp:diagnose` | コードベースを自律的に診断し、改善点を発見 → フィルタリング → GitHub Issue 起票。実装は行わない |
 | `/vibecorp:ship-parallel` | 複数 Issue を並列に `/vibecorp:ship` 実行。SM エージェントで依存関係を分析し同時進行。full プリセット専用（課金リスクを伴う大規模並列実行のため） |
 | `/vibecorp:autopilot` | `/vibecorp:diagnose` → `/vibecorp:ship-parallel` の自律改善サイクルを1回実行。全 open Issue を対象に実行（ラベルによる絞り込みなし）。デフォルトは ship 前にユーザー確認、`--auto` で省略可能。`/loop 24h /vibecorp:autopilot` での定期実行を推奨（12h は Claude Max のレート制限を逼迫させやすいため非推奨。詳細は `docs/cost-analysis.md`）。full プリセット専用 |
+| `/vibecorp:plan-epic` | 親エピックの Issue と子 Issue を一括作成し sub-issue で紐付ける。feature ブランチ（`feature/epic-{Issue番号}_{要約}`）を作成する。full プリセット専用（エピック運用は大規模機能開発向け） |
+| `/vibecorp:release-epic` | feature ブランチから main への集約 PR を作成する。全子 Issue がマージされたエピックを main に取り込む最終ステップ。full プリセット専用 |
+| `/vibecorp:cycle-metrics` | 開発サイクルの計測データ（スループット・リードタイム等）を集計し、`~/.cache/vibecorp/state/<repo-id>/cycle-metrics/` に出力する。揮発データのため `.claude/knowledge/` 外に保存される |
 
 ## フック一覧
 


### PR DESCRIPTION
## 関連 Issue

close https://github.com/hirokimry/vibecorp/issues/457

## 概要

🚀 vibecorp プラグインの version が **v0.3.0** になり、既マージ済みの新スキル 3 つが利用者環境のキャッシュに反映されるようになった。

### ✨ 何が変わったか

- ✅ `.claude-plugin/plugin.json` の version が `0.2.0` → `0.3.0` に上がった
- ✅ Claude Code の `/plugin update vibecorp` で利用者キャッシュの更新が可能になった
- ✅ `/vibecorp:plan-epic` / `/vibecorp:release-epic` / `/vibecorp:cycle-metrics` がスキル一覧に出るようになる
- ✅ `docs/migration/plugin-namespace.md` の v0.3.0（Phase 3）表記と plugin.json の version が整合した
- 📖 README.md の full プリセットスキル一覧に上記 3 スキルが並ぶようになった（specification.md の Source of Truth 原則と整合）

### Before / After

| 項目 | Before | After |
|------|--------|-------|
| `plugin.json` の version | `0.2.0` | `0.3.0` |
| `/vibecorp:plan-epic` | キャッシュに反映されない | 利用者環境で出るようになる |
| `/vibecorp:release-epic` | 同上 | 同上 |
| `/vibecorp:cycle-metrics` | 同上 | 同上 |
| README full プリセット表記 | 4スキル（誤）/ 3 スキル未掲載 | 6 スキル（正）/ 3 スキル掲載 |

### 🔒 スコープ外（重要）

- ⚠ `templates/claude-plugin/plugin.json` の version 管理（利用者用テンプレート、別系統）
- ⚠ git tag v0.3.0 の打刻（リリース管理は別 Issue）
- ⚠ version bump 漏れの再発防止（Issue #458 で別途対応）

## テスト計画

- [x] `tests/test_plugin_structure.sh` 実行: 21/21 passed
- [x] `tests/test_plugin_autoload.sh` 実行: 20/20 passed
- [x] `/vibecorp:sync-check`: CTO/CPO ともに OK 判定
- [ ] マージ後、ユーザー側で `/plugin update vibecorp` を実行してキャッシュ更新を確認
- [ ] マージ後、`/vibecorp:plan-epic` がスキル一覧に出ることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * 「full」プリセットの説明を更新し、新しいスキル3つを追加しました。

* **Chores**
  * バージョンを 0.2.0 から 0.3.0 にアップデートしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->