### PR TITLE
🔒 feat: Branch Protection の Bot approve 経路と required_approvals 設定が確立された

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -973,6 +973,8 @@ claude_action:
     - "build/**"
     - ".cache/**"
     - "vendor/**"
+branch_protection:
+  required_approvals: 1
 diagnose:
   enabled: true
   max_issues_per_run: 7
@@ -1483,9 +1485,32 @@ configure_github_repo() {
   local merged_checks_display
   merged_checks_display=$(echo "$merged_contexts" | jq -r 'join(", ")')
 
+  # vibecorp.yml から required_approvals を読み取る（未設定時はデフォルト 1）
+  # awk でブロック単位パース（shell.md「YAML パース」ルール準拠）
+  local yml="${REPO_ROOT}/.claude/vibecorp.yml"
+  local required_approvals=1
+  if [[ -f "$yml" ]]; then
+    local val
+    val=$(awk '
+      /^branch_protection:[[:space:]]*$/ { in_block = 1; next }
+      in_block && /^[^[:space:]#]/ { exit }
+      in_block && /^[[:space:]]+required_approvals:[[:space:]]*/ {
+        sub(/^[[:space:]]+required_approvals:[[:space:]]*/, "", $0)
+        sub(/[[:space:]]*$/, "", $0)
+        print
+        exit
+      }
+    ' "$yml")
+    # 数字のみ受理、それ以外はデフォルト 1
+    if [[ "$val" =~ ^[0-9]+$ ]]; then
+      required_approvals="$val"
+    fi
+  fi
+
   local protection_json
   protection_json=$(jq -n \
     --argjson contexts "$merged_contexts" \
+    --argjson required_approvals "$required_approvals" \
     '{
       required_status_checks: {
         strict: true,
@@ -1495,7 +1520,7 @@ configure_github_repo() {
         dismiss_stale_reviews: true,
         require_code_owner_reviews: false,
         require_last_push_approval: false,
-        required_approving_review_count: 1
+        required_approving_review_count: $required_approvals
       },
       enforce_admins: true,
       restrictions: null,
@@ -1508,7 +1533,7 @@ configure_github_repo() {
   local put_error
   if put_error=$(echo "$protection_json" | gh api "repos/${name_with_owner}/branches/${base_branch}/protection" \
     -X PUT --input - 2>&1 >/dev/null); then
-    log_info "ブランチ保護を設定（${base_branch}: CI必須、PR必須、approve必須）"
+    log_info "ブランチ保護を設定（${base_branch}: CI必須、PR必須、approve ${required_approvals}件以上必須、push 毎に既存 approve 自動 dismiss）"
   else
     log_error "ブランチ保護の設定に失敗しました（admin 権限が必要です）: ${put_error}"
     print_manual_guidance "$base_branch" "$merged_checks_display"

--- a/install.sh
+++ b/install.sh
@@ -1501,8 +1501,9 @@ configure_github_repo() {
         exit
       }
     ' "$yml")
-    # 数字のみ受理、それ以外はデフォルト 1
-    if [[ "$val" =~ ^[0-9]+$ ]]; then
+    # 1 以上の整数のみ受理（0 や非数値はデフォルト 1 にフォールバック）
+    # 0 を許すと「approve N件以上必須」の前提を崩すため明示的に拒否
+    if [[ "$val" =~ ^[1-9][0-9]*$ ]]; then
       required_approvals="$val"
     fi
   fi

--- a/tests/test_install_branch_protection.sh
+++ b/tests/test_install_branch_protection.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# test_install_branch_protection.sh
+# ─────────────────────────────────────────────
+# install.sh の branch_protection.required_approvals サポート
+# Issue #463: Bot approve 経路（Branch Protection の require approvals 設定可能化）
+#
+# 検証対象:
+#   1. vibecorp.yml に branch_protection.required_approvals: 1 がデフォルトで含まれる
+#   2. 全プリセット（minimal/standard/full）でデフォルト 1
+#   3. configure_github_repo の awk で値を抽出できる（カスタム値含む）
+#   4. dismiss_stale_reviews が常に true で設定される（議論結論）
+#   5. configure_github_repo のログメッセージに required_approvals が含まれる
+#   6. 旧 vibecorp.yml（branch_protection 不在）は default 1 で動作する
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/tests/lib/install_test_helpers.sh"
+
+echo ""
+echo "=== branch_protection.required_approvals サポートのテスト ==="
+
+# ============================================
+# 1. デフォルト required_approvals: 1 で生成
+# ============================================
+echo ""
+echo "--- 1. デフォルト required_approvals: 1 で生成 ---"
+create_test_repo
+bash "$INSTALL_SH" --name test-proj --preset minimal 2>/dev/null
+R="$TMPDIR_ROOT"
+
+assert_file_contains "branch_protection: セクション" "$R/.claude/vibecorp.yml" "branch_protection:"
+assert_file_contains "required_approvals: 1 デフォルト" "$R/.claude/vibecorp.yml" "required_approvals: 1"
+cleanup
+
+# ============================================
+# 2. 全プリセットで required_approvals: 1 デフォルト
+# ============================================
+echo ""
+echo "--- 2. 全プリセットで required_approvals: 1 デフォルト ---"
+for preset in minimal standard full; do
+  create_test_repo
+  bash "$INSTALL_SH" --name test-proj --preset "$preset" 2>/dev/null
+
+  yml="$TMPDIR_ROOT/.claude/vibecorp.yml"
+  val=$(awk '
+    /^branch_protection:[[:space:]]*$/ { in_block = 1; next }
+    in_block && /^[^[:space:]#]/ { exit }
+    in_block && /^[[:space:]]+required_approvals:[[:space:]]*/ {
+      sub(/^[[:space:]]+required_approvals:[[:space:]]*/, "", $0)
+      sub(/[[:space:]]*$/, "", $0)
+      print
+      exit
+    }
+  ' "$yml")
+  assert_eq "preset=${preset}: required_approvals は 1" "1" "$val"
+  cleanup
+done
+
+# ============================================
+# 3. install.sh のロジックが branch_protection ブロックから値を抽出できる
+# ============================================
+echo ""
+echo "--- 3. install.sh の awk が required_approvals 抽出できる ---"
+
+# install.sh から configure_github_repo の必要部分を抽出して動作確認
+INSTALL_SH="${SCRIPT_DIR}/install.sh"
+
+# branch_protection.required_approvals の awk 抽出ロジックが install.sh に存在
+if grep -q "required_approvals:" "$INSTALL_SH"; then
+  pass "install.sh に required_approvals パースロジックがある"
+else
+  fail "install.sh に required_approvals パースロジックがない"
+fi
+
+if grep -q "required_approving_review_count: \\\$required_approvals" "$INSTALL_SH"; then
+  pass "Branch Protection JSON に required_approvals 変数が使われている"
+else
+  fail "Branch Protection JSON で required_approvals が使われていない"
+fi
+
+# ============================================
+# 4. dismiss_stale_reviews: true 固定
+# ============================================
+echo ""
+echo "--- 4. dismiss_stale_reviews: true が常時設定される ---"
+if grep -q "dismiss_stale_reviews: true" "$INSTALL_SH"; then
+  pass "dismiss_stale_reviews: true が install.sh で設定されている"
+else
+  fail "dismiss_stale_reviews が true で設定されていない"
+fi
+
+# ============================================
+# 5. ログメッセージに required_approvals が含まれる
+# ============================================
+echo ""
+echo "--- 5. ブランチ保護ログに required_approvals 件数が出る ---"
+if grep -q 'approve \${required_approvals}件以上必須' "$INSTALL_SH"; then
+  pass "ログメッセージに required_approvals の動的件数が含まれる"
+else
+  fail "ログメッセージが固定文言のまま（required_approvals が反映されない）"
+fi
+
+# ============================================
+# 6. 旧 vibecorp.yml（branch_protection 不在）でも動作
+# ============================================
+echo ""
+echo "--- 6. branch_protection 不在の旧 yml でデフォルト 1 動作 ---"
+create_test_repo
+R="$TMPDIR_ROOT"
+mkdir -p "$R/.claude"
+
+# 旧形式の vibecorp.yml（branch_protection なし）を配置
+cat > "$R/.claude/vibecorp.yml" <<'EOF'
+name: test-proj
+preset: minimal
+language: ja
+base_branch: main
+protected_files:
+  - MVV.md
+coderabbit:
+  enabled: true
+EOF
+
+# install.sh を source して configure_github_repo の値抽出だけテスト
+# （実際の gh api 呼び出しはしない）
+val=$(awk '
+  /^branch_protection:[[:space:]]*$/ { in_block = 1; next }
+  in_block && /^[^[:space:]#]/ { exit }
+  in_block && /^[[:space:]]+required_approvals:[[:space:]]*/ {
+    sub(/^[[:space:]]+required_approvals:[[:space:]]*/, "", $0)
+    sub(/[[:space:]]*$/, "", $0)
+    print
+    exit
+  }
+' "$R/.claude/vibecorp.yml")
+
+# 不在時は空文字列が返り、install.sh 側で「数字でなければデフォルト 1」として扱う
+assert_eq "branch_protection 不在 → 空文字列" "" "$val"
+cleanup
+
+print_test_summary

--- a/tests/test_install_branch_protection.sh
+++ b/tests/test_install_branch_protection.sh
@@ -140,4 +140,35 @@ val=$(awk '
 assert_eq "branch_protection 不在 → 空文字列" "" "$val"
 cleanup
 
+# ============================================
+# 7. required_approvals: 0 や非数値は拒否されてデフォルト 1 にフォールバック
+# ============================================
+echo ""
+echo "--- 7. required_approvals: 0 / 非数値は拒否される ---"
+
+# install.sh の正規表現が 0 を拒否することを確認
+if grep -q '\[1-9\]\[0-9\]\*' "$INSTALL_SH"; then
+  pass "install.sh の正規表現が 1 以上の整数のみ受理する形になっている"
+else
+  fail "install.sh の正規表現が 0 を弾けない形のまま"
+fi
+
+# 動作試験: 0 / 負数 / 文字列 を渡すとデフォルト 1 にフォールバック
+for v in "0" "-1" "abc"; do
+  if [[ "$v" =~ ^[1-9][0-9]*$ ]]; then
+    fail "値 '$v' が誤って受理された"
+  else
+    pass "値 '$v' は正規表現で拒否される（フォールバック対象）"
+  fi
+done
+
+# 1 以上の正常値は受理
+for v in "1" "2" "10" "99"; do
+  if [[ "$v" =~ ^[1-9][0-9]*$ ]]; then
+    pass "値 '$v' は正規表現で受理される"
+  else
+    fail "値 '$v' が誤って拒否された"
+  fi
+done
+
 print_test_summary


### PR DESCRIPTION
## 概要

Issue #463 確定の Bot approve 経路を実装。`vibecorp.yml` に `branch_protection.required_approvals` キーを追加し、利用者が require approvals 件数を変更できるようになった。`dismiss_stale_reviews: true` は議論通り常時設定（push 毎の既存 approve 自動 dismiss）。

## ふるまいの変化

- 🔒 `vibecorp.yml` の `branch_protection.required_approvals` で require approvals 件数を 1/2/3 等に設定できるようになった（デフォルト 1）
- 🔒 `install.sh` が新キーを GitHub Branch Protection の `required_approving_review_count` に反映するようになった
- 🔒 旧形式 `vibecorp.yml`（branch_protection 不在）でもデフォルト 1 で動作するよう、awk パースが空文字列を吸収するようになった
- 🔒 ブランチ保護ログメッセージに「approve N件以上必須、push 毎に既存 approve 自動 dismiss」と動的に表示されるようになった

## #463 議論との照合

| # | 決定事項 | 状態 |
|---|---|---|
| 1 | GitHub App ネイティブ approve | #462 で OAuth 経路確立済み（追加実装不要） |
| 2 | Branch Protection の require approvals: 1（デフォルト）vibecorp.yml で設定可能 | ✅ 本 PR で実装 |
| 3 | CodeRabbit と claude-action 並走時の AND ゲート挙動 | GitHub ネイティブ動作（追加実装不要） |
| 4 | CODEOWNERS: vibecorp テンプレートに含めない | 設計通り何もしない |
| 5 | dismiss-stale-reviews: 適用 | ✅ install.sh で常時 true 設定（既存実装維持） |

## 主な変更

- `install.sh`:
  - `generate_vibecorp_yml` に `branch_protection.required_approvals: 1` キー追加
  - `configure_github_repo` で awk パース → `required_approving_review_count` に反映
  - ログメッセージを動的件数表示に
- `tests/test_install_branch_protection.sh`（新規 10 観点）

## テスト計画

- [x] tests/test_install_branch_protection.sh: 10/10 PASS
- [x] tests/test_install_args.sh: 45/45 PASS
- [x] tests/test_install_update.sh: 62/62 PASS

Refs https://github.com/hirokimry/vibecorp/issues/463

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ブランチ保護設定で必須承認数を構成可能になりました（デフォルト：1）。ログに設定された承認数が表示されます。
  * ブランチ保護で「古いレビューの破棄」が常に有効になります。

* **テスト**
  * 必須承認数のバリデーションと既存互換性を検証するテストスイートを追加しました（正の整数のみ許容）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->