### PR TITLE
✨ feat: /vibecorp:issue スキルが旧 type 14 種廃止と COO 文脈判定で intent ラベルを付与するようになる

### DIFF
--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -171,7 +171,7 @@ intent → CC prefix の主従順で対応 prefix を選ぶ（逆引き禁止、
 
 - COO が intent → prefix → 絵文字の順で確定する（逆順禁止）
 - 既存ラベル（`bug` / `enhancement` 等）はリポジトリに存在する場合のみ付与する
-- ユーザーが既にタイプ付きタイトルを入力していれば、その prefix と整合する intent を選ぶ
+- ユーザーが既にタイプ付きタイトルを入力していても、判定は **常に本文から intent を先に確定**する（intent → prefix の主従順、絶対条件）。本文から確定した intent と既存タイトルの prefix が整合しない場合は、本文を優先して prefix と絵文字をタイトル側で修正する
 - 既存ラベル一覧は `gh label list --json name --jq '.[].name' --limit 100` で取得する
 
 ### 5. 👤 Assignees 決定

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -115,42 +115,64 @@ override が適用された場合、返却時に「CEO override: あり」を明
   - `/vibecorp:plan-epic` の出力（親 Issue URL + 子 Issue URL 一覧）をそのまま CEO に返す
   - エピック化判定時は本スキルのステップ 4 以降（タイプ判定・3 者承認ゲート・起票）は実行しない（`/plan-epic` 側で必要なゲートが実装される前提）
 
-### 4. 🏷️ タイプ判定・ラベル自動付与
+### 4. 🏷️ intent ラベル判定 + CC prefix 選択（COO 主体・FIX）
 
-まずリポジトリの既存ラベル一覧を取得する。
+#### 4a. COO による intent 判定
 
-```bash
-gh label list --json name --jq '.[].name' --limit 100
-```
+旧 type 14 種のキーワード判定表は **廃止**（Issue #469 議論結論）。COO（メインセッション）が Issue 本文を読んで文脈で intent ラベルを判定する。
 
-次に、タイトルと本文のテキストからキーワードベースでタイプを判定し、対応するラベル候補を決定する。
-タイプは Conventional Commits 形式と統一する。
+判定対象は **`.claude/rules/intent-labels.md` の 7 種**:
 
-| タイプ | 絵文字 | キーワード | ラベル候補 |
-|-------|-------|-----------|-----------|
-| `feat` | ✨ | 機能, 追加, 改善, feature, enhance | `enhancement` |
-| `fix` | 🐛 | バグ, 不具合, エラー, bug, fix, crash | `bug` |
-| `docs` | 📖 | ドキュメント, README, docs, 仕様書 | `documentation` |
-| `test` | 🧪 | テスト, test, coverage, 検証 | `testing` |
-| `refactor` | 🔄 | リファクタ, refactor, 整理, 統一, 移行 | `refactor` |
-| `design` | 📋 | 設計, design, 計画, plan, スキーマ, 分析 | `design` |
-| `chore` | ⚙️ | 雑務, 依存, chore, deps | — |
-| `ci` | 🔧 | CI, workflow, pipeline, Actions | — |
-| `security` | 🔒 | セキュリティ, 認証, protection, auth, gate | — |
-| `perf` | ⚡ | パフォーマンス, 高速化, 最適化, performance | — |
-| `agent` | 🤖 | エージェント, agent, 自律 | — |
-| `integrate` | 🔌 | 統合, 連携, integration | — |
-| `release` | 🚀 | リリース, 公開, publish, deploy | — |
-| `template` | 📦 | テンプレート, template, プリセット | — |
+- `intent/feature` — 新機能を確実に動かす（影響を与える系）
+- `intent/bugfix` — 既存バグを最小修正で直す（影響を与える系）
+- `intent/performance` — 性能を測定可能な形で改善する（影響を与える系）
+- `intent/security` — 脆弱性を塞ぐ（影響を与える系）
+- `intent/refactor` — 構造の品質を高める（挙動不変系）
+- `intent/infra` — 開発基盤の品質を底上げする（挙動不変系）
+- `intent/docs` — ドキュメントの正確性を担保する（挙動不変系）
 
-**ラベル付与ルール**: 候補ラベルのうち、リポジトリに存在するものだけを付与する。存在しないラベルは除外する。
+**絶対条件**: 1 Issue 1 intent 厳守。複数 intent にまたがる変更は Issue を分割するよう CEO に提案する。
 
-**タイトル形式**: `<emoji> <type>: <subject>`
+#### 4b. COO による CC prefix 選択
 
-- タイプはキーワードマッチで自動決定する
-- 複数マッチした場合は最初にマッチしたタイプを採用し、存在するラベルは全て付与する
-- マッチなしの場合はタイプなし（プレフィックスなし）、ラベルなしで起票する
-- ユーザーが既にタイプ付きタイトルを入力した場合はそのまま使用する
+intent → CC prefix の主従順で対応 prefix を選ぶ（逆引き禁止、`docs/conventional-commits.md` の絶対条件）。
+
+| intent ラベル | 対応する CC prefix |
+|--------------|------------------|
+| `intent/feature` | `feat` |
+| `intent/bugfix` | `fix`, `revert`（差し戻しは regression 修正の一形態） |
+| `intent/performance` | `perf`, `feat`（性能向上目的の機能）, `fix`（パフォーマンス系バグ） |
+| `intent/security` | `fix`（脆弱性修正）, `feat`（セキュリティ機能追加）, `chore`（依存パッケージのセキュリティアップデート） |
+| `intent/refactor` | `refactor`, `style` |
+| `intent/infra` | `test`, `ci`, `chore`, `build` |
+| `intent/docs` | `docs` |
+
+同じ intent に対応する prefix が複数ある場合は、内容に応じて最も適切なものを COO が選ぶ。
+
+#### 4c. CC prefix → 絵文字 1:1 マッピング
+
+`docs/conventional-commits.md` 確定の絵文字 11 種:
+
+| CC prefix | 絵文字 |
+|-----------|------|
+| feat | ✨ |
+| fix | 🐛 |
+| perf | ⚡ |
+| refactor | 🔄 |
+| style | 💄 |
+| docs | 📖 |
+| test | 🧪 |
+| ci | 🔧 |
+| chore | ⚙️ |
+| build | 📦 |
+| revert | ⏪ |
+
+**タイトル形式**: `<emoji> <CC prefix>: <動作主語の subject>`
+
+- COO が intent → prefix → 絵文字の順で確定する（逆順禁止）
+- 既存ラベル（`bug` / `enhancement` 等）はリポジトリに存在する場合のみ付与する
+- ユーザーが既にタイプ付きタイトルを入力していれば、その prefix と整合する intent を選ぶ
+- 既存ラベル一覧は `gh label list --json name --jq '.[].name' --limit 100` で取得する
 
 ### 5. 👤 Assignees 決定
 
@@ -187,6 +209,7 @@ CISO エージェント（`.claude/agents/ciso.md`）に以下を依頼する:
 3. 課金構造（docs/cost-analysis.md, max_issues_per_day 等のコスト上限, claude -p / npx / bunx で LLM を呼ぶ箇所）
 4. ガードレール（protect-files.sh, diagnose-guard.sh, forbidden_targets, diagnose-active スタンプの制御）
 5. MVV（MVV.md 自体の変更）
+6. CI エージェント（GitHub Actions）（`.github/workflows/claude*.{yml,yaml}` / `.github/workflows/ai-review.{yml,yaml}` の `permissions` / `secrets` 参照変更、`pull_request_target` への変更、`CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` の参照方式変更、Fork PR 除外条件削除・緩和、GitHub App 権限スコープ追加）
 
 判定: OK または 除外（該当領域名を明記）
 ```
@@ -226,7 +249,7 @@ SM エージェント（`.claude/agents/sm.md`）に以下を依頼する:
 タイトル: <タイトル>
 本文: <本文>
 
-不可領域5分類（認証 / 暗号 / 課金構造 / ガードレール / MVV）のいずれかに該当する変更を Issue が意図している場合は「除外」と判定し、該当領域名を付記してください。
+不可領域 6 分類（認証 / 暗号 / 課金構造 / ガードレール / MVV / CI エージェント）のいずれかに該当する変更を Issue が意図している場合は「除外」と判定し、該当領域名を付記してください。
 
 判定: OK または 除外（該当領域名を明記）
 ```
@@ -242,10 +265,12 @@ SM エージェント（`.claude/agents/sm.md`）に以下を依頼する:
 ### 7. 🚀 Issue 起票
 
 ```bash
-gh issue create --title "<emoji> <type>: <subject>" --body "<本文>" --assignee "<assignee>" --label "<label1>" --label "<label2>"
+gh issue create --title "<emoji> <CC prefix>: <subject>" --body "<本文>" --assignee "<assignee>" --label "intent/<intent>" --label "<additional_label_if_any>"
 ```
 
-ラベルなしの場合は `--label` オプションを省略する。
+- **`intent/*` ラベルは必須**（COO が ステップ 4a で確定したもの 1 つだけ）
+- 既存ラベル（`bug` / `enhancement` 等）はリポジトリに存在し、内容に該当する場合のみ追加付与する
+- ラベルが intent のみの場合は `--label "intent/<intent>"` のみ指定する
 
 ### 8. ✅ 結果報告
 

--- a/tests/test_issue_skill_intent_rewrite.sh
+++ b/tests/test_issue_skill_intent_rewrite.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# test_issue_skill_intent_rewrite.sh
+# ─────────────────────────────────────────────
+# Issue #485: /vibecorp:issue スキルが旧 type 14 種廃止 + COO 文脈判定 + intent ラベル付与に書き換わったことを検証
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/tests/lib/install_test_helpers.sh"
+
+echo ""
+echo "=== Issue #485 /vibecorp:issue 書き換え検証 ==="
+
+SKILL="${SCRIPT_DIR}/skills/issue/SKILL.md"
+
+# ============================================
+# 1. 旧 type 14 種キーワード判定表が削除されている
+# ============================================
+echo ""
+echo "--- 1. 旧 type 14 種キーワード判定表の廃止 ---"
+
+# 旧テーブルにあったがなくなった type
+if grep -q -E "\| \`design\` \| 📋 \|" "$SKILL"; then
+  fail "旧 type 'design' のキーワード判定表行が残っている"
+else
+  pass "旧 type 'design' のキーワード判定表行が削除された"
+fi
+
+if grep -q -E "\| \`agent\` \| 🤖 \|" "$SKILL"; then
+  fail "旧 type 'agent' のキーワード判定表行が残っている"
+else
+  pass "旧 type 'agent' のキーワード判定表行が削除された"
+fi
+
+if grep -q -E "\| \`integrate\` \| 🔌 \|" "$SKILL"; then
+  fail "旧 type 'integrate' のキーワード判定表行が残っている"
+else
+  pass "旧 type 'integrate' のキーワード判定表行が削除された"
+fi
+
+if grep -q -E "\| \`release\` \| 🚀 \|" "$SKILL"; then
+  fail "旧 type 'release' のキーワード判定表行が残っている"
+else
+  pass "旧 type 'release' のキーワード判定表行が削除された"
+fi
+
+if grep -q -E "\| \`template\` \| 📦 \|" "$SKILL"; then
+  fail "旧 type 'template' のキーワード判定表行が残っている"
+else
+  pass "旧 type 'template' のキーワード判定表行が削除された"
+fi
+
+# ============================================
+# 2. COO 主体の intent 判定が記載されている
+# ============================================
+echo ""
+echo "--- 2. COO 主体の intent 判定 ---"
+assert_file_contains "COO による intent 判定セクション" "$SKILL" "COO による intent 判定"
+assert_file_contains "Issue #469 議論結論への参照"      "$SKILL" "#469"
+
+# ============================================
+# 3. intent ラベル 7 種すべての言及
+# ============================================
+echo ""
+echo "--- 3. intent ラベル 7 種 ---"
+for intent in intent/feature intent/bugfix intent/performance intent/security intent/refactor intent/infra intent/docs; do
+  if grep -q -F -- "$intent" "$SKILL"; then
+    pass "$intent への言及がある"
+  else
+    fail "$intent への言及がない"
+  fi
+done
+
+# ============================================
+# 4. CC prefix 11 種の絵文字マッピングが記載されている
+# ============================================
+echo ""
+echo "--- 4. CC prefix 11 種の絵文字マッピング ---"
+for prefix in feat fix perf refactor style docs test ci chore build revert; do
+  if grep -q -E "^\| ${prefix} \|" "$SKILL"; then
+    pass "CC prefix '$prefix' の絵文字マッピング行がある"
+  else
+    fail "CC prefix '$prefix' の絵文字マッピング行がない"
+  fi
+done
+
+# ============================================
+# 5. 主従関係の絶対条件
+# ============================================
+echo ""
+echo "--- 5. 主従関係（intent → prefix）の絶対条件 ---"
+assert_file_contains "1 Issue 1 intent 厳守"    "$SKILL" "1 Issue 1 intent"
+assert_file_contains "intent → prefix 主従順"   "$SKILL" "intent → prefix"
+assert_file_contains "逆引き禁止"               "$SKILL" "逆引き禁止"
+
+# ============================================
+# 6. SM フィルタ（不可領域 6 分類）
+# ============================================
+echo ""
+echo "--- 6. SM フィルタの不可領域 6 分類 ---"
+assert_file_contains "不可領域 6 分類" "$SKILL" "不可領域 6 分類"
+assert_file_contains "CI エージェント領域追加" "$SKILL" "CI エージェント"
+
+# ============================================
+# 7. Issue 起票で intent/* ラベル必須
+# ============================================
+echo ""
+echo "--- 7. Issue 起票で intent/* ラベル必須 ---"
+assert_file_contains_fixed() {
+  local desc="$1"
+  local path="$2"
+  local pattern="$3"
+  if grep -q -F -- "$pattern" "$path" 2>/dev/null; then
+    pass "$desc"
+  else
+    fail "$desc (パターン '${pattern}' がファイルに含まれない: ${path})"
+  fi
+}
+
+assert_file_contains_fixed "gh issue create で intent/* 必須" "$SKILL" '--label "intent/<intent>"'
+assert_file_contains_fixed "intent/* ラベルは必須" "$SKILL" "\`intent/*\` ラベルは必須"
+
+# ============================================
+# 8. 関連ドキュメント参照
+# ============================================
+echo ""
+echo "--- 8. 関連ドキュメント参照 ---"
+assert_file_contains "intent-labels.md 参照"          "$SKILL" "intent-labels.md"
+assert_file_contains "conventional-commits.md 参照"   "$SKILL" "conventional-commits.md"
+
+print_test_summary


### PR DESCRIPTION
## 概要

Issue #485 確定の通り、`/vibecorp:issue` スキルから旧 type 14 種のキーワード判定表を削除し、COO（メインセッション）の文脈判断で intent ラベル 7 種から 1 つ確定するフローに書き換えた。

## ふるまいの変化

- 🏷️ Issue 起票時に COO が文脈で intent を判定し、`intent/*` ラベル（7 種から 1 つ）が必ず付与されるようになった
- 📝 タイトル形式が `<emoji> <CC prefix>: <subject>` に統一された
- 🚫 旧 type 14 種（design / agent / integrate / release / template など）のキーワード判定表が完全削除された
- 🔗 intent → CC prefix の主従順マッピング表（M:N）が docs/conventional-commits.md と整合する形で読めるようになった
- ⚠️ SM フィルタの不可領域が 5 分類 → 6 分類（CI エージェント追加）に拡張された

## #485 議論との照合

| 項目 | 実装 |
|---|---|
| 旧 type 14 種廃止 | ✅ キーワード判定表削除 |
| COO 文脈判定 | ✅ ステップ 4a で COO 主体記載 |
| intent → CC prefix の主従順 | ✅ ステップ 4b マッピング表 |
| 絵文字 1:1 マッピング | ✅ ステップ 4c の表 |
| 1 Issue 1 intent 厳守 | ✅ 絶対条件記載 |
| 既存 3 者承認ゲート連携維持 | ✅ ステップ 6a〜6c |
| gh issue create で intent ラベル必須 | ✅ ステップ 7 |

## 主な変更

- `skills/issue/SKILL.md`: ステップ 4 全面書き換え + ステップ 6c / 7 の更新
- `tests/test_issue_skill_intent_rewrite.sh`（新規 34 観点）

## テスト計画

- [x] tests/test_issue_skill_intent_rewrite.sh: 34/34 PASS

Refs https://github.com/hirokimry/vibecorp/issues/485

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Issue 分類をキーワードベースから intent（7種）ベースに統一し、1 Issue = 1 intent を明文化しました
  * 起票時は intent ラベル必須化／既存ラベルのみ付与するルールを導入し、本文に基づきタイトルの prefix/絵文字を自動修正します
  * エピック化フローの扱いを明確化し、承認ゲートに CI エージェント領域を追加しました

* **Tests**
  * 仕様変更を検証する自動テストスクリプトを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->