### PR TITLE
⚙️ chore: vibecorp.yml に branch_protection セクションが追記される

### DIFF
--- a/.claude/vibecorp.yml
+++ b/.claude/vibecorp.yml
@@ -17,6 +17,8 @@ claude_action:
     - "build/**"
     - ".cache/**"
     - "vendor/**"
+branch_protection:
+  required_approvals: 1
 guide_gate:
   extra_paths:
     - templates/claude/


### PR DESCRIPTION
## 💡 概要

vibecorp 自身の `.claude/vibecorp.yml` に `branch_protection.required_approvals: 1` が追記されるようになった。`install.sh` テンプレート（L976-977）と構造が一致するようになった。

## ✅ 何が変わったか

- ⚙️ `.claude/vibecorp.yml` に `branch_protection: required_approvals: 1` の 2 行を追記
- 📖 `install.sh` の新規 install テンプレートと vibecorp 自身の `vibecorp.yml` の構造が揃った
- 🔒 GitHub ruleset の `required_approving_review_count: 1` と一致するため **運用挙動は不変**

## 📍 変更ファイル

- `.claude/vibecorp.yml`（+2 行）

## 🛡️ intent ラベル

`intent/infra` — 開発基盤の品質を底上げする（挙動不変）。GitHub ruleset と既定値が一致するため、レビュー要求数は変わらない。

## ✅ 完了条件チェック

- [x] `.claude/vibecorp.yml` に `branch_protection: required_approvals: 1` が追記されている
- [x] 設定の挙動が変わらない（GitHub ruleset と整合）
- [x] `install.sh` テンプレートと vibecorp 自身の `vibecorp.yml` の構造が一致する

close https://github.com/hirokimry/vibecorp/issues/500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チア**
  * ブランチ保護設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->