### PR TITLE
🔧 ci: plugin.json の version bump 漏れを自動検知できるようになる

### DIFF
--- a/.github/workflows/plugin-version-bump-check.yml
+++ b/.github/workflows/plugin-version-bump-check.yml
@@ -1,0 +1,55 @@
+name: Plugin Version Bump Check
+
+# .claude-plugin/marketplace.json の plugins[0].skills が変化した PR で
+# .claude-plugin/plugin.json の version が bump されていない場合に警告コメントを投稿する。
+# Issue #458「PR #459 で発生した plugin.json bump 漏れの再発防止」の実装。
+#
+# 設計方針（CPO 申し送り通り「初期版は警告のみ・非ブロック」）:
+# - workflow は continue-on-error: true で失敗しても緑で完了させる
+# - required check には登録しない（マージブロックしない）
+# - 警告コメントで利用者に気づかせ、手動で plugin.json を bump してもらう
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '.claude-plugin/marketplace.json'
+      - '.claude-plugin/plugin.json'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: plugin-version-bump-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  plugin-version-bump-check:
+    name: plugin.json bump 漏れチェック
+    runs-on: ubuntu-latest
+    # Fork PR は secrets が渡らないため除外
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: チェックアウト（fetch-depth 0 で base 履歴も取得）
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: bump 漏れ検査
+        id: bump_check
+        continue-on-error: true
+        env:
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+        run: |
+          bash scripts/check-plugin-version-bump.sh "$BASE_REF" "HEAD"
+
+      - name: bump 漏れ警告コメント投稿
+        if: steps.bump_check.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "$REPO" \
+            --body "⚠️ \`.claude-plugin/marketplace.json\` の \`plugins[0].skills\` が変更されていますが、\`.claude-plugin/plugin.json\` の \`version\` が bump されていません。利用者は新しいスキルを取得するために version bump を必要とします（PR #459 と同種の取りこぼし防止）。マージ前に \`.claude-plugin/plugin.json\` の \`version\` を更新してください。本チェックは警告のみ・非ブロックです。"

--- a/scripts/check-plugin-version-bump.sh
+++ b/scripts/check-plugin-version-bump.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# check-plugin-version-bump.sh — plugin.json bump 漏れ自動検知
+#
+# Issue #458: PR で .claude-plugin/marketplace.json の plugins[0].skills が変化したのに
+# .claude-plugin/plugin.json の version が bump されていない場合に警告する。
+# PR #459 で発生した「新スキル 3 件追加したのに plugin.json を 0.2.0 のまま放置」事象の再発防止。
+#
+# 使い方:
+#   bash scripts/check-plugin-version-bump.sh <BASE_REF> <HEAD_REF>
+#
+# 終了コード:
+#   0 — 問題なし（skills 不変、または skills 変更ありかつ version bump あり、または marketplace.json 不在）
+#   1 — 警告（skills 変更ありかつ plugin.json version 不変）
+#   2 — 引数不足・前提コマンド不在等のエラー
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "使い方: bash scripts/check-plugin-version-bump.sh <BASE_REF> <HEAD_REF>" >&2
+  exit 2
+fi
+
+BASE_REF="$1"
+HEAD_REF="$2"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "❌ jq が必要です" >&2
+  exit 2
+fi
+if ! command -v git >/dev/null 2>&1; then
+  echo "❌ git が必要です" >&2
+  exit 2
+fi
+
+MARKETPLACE_PATH=".claude-plugin/marketplace.json"
+PLUGIN_PATH=".claude-plugin/plugin.json"
+
+# git show で base / head の各ファイル中身を取得する。存在しない場合は空文字を返す。
+git_show_or_empty() {
+  local ref="$1"
+  local path="$2"
+  if git cat-file -e "${ref}:${path}" 2>/dev/null; then
+    git show "${ref}:${path}"
+  else
+    echo ""
+  fi
+}
+
+base_marketplace=$(git_show_or_empty "$BASE_REF" "$MARKETPLACE_PATH")
+head_marketplace=$(git_show_or_empty "$HEAD_REF" "$MARKETPLACE_PATH")
+
+# どちらかに marketplace.json が無ければ graceful skip（plugin リポではない、または初期化前）
+if [[ -z "$base_marketplace" || -z "$head_marketplace" ]]; then
+  echo "✅ marketplace.json が base / head のいずれかに存在しないため、チェックをスキップします"
+  exit 0
+fi
+
+# plugins[0].skills を JSON 完全一致で比較
+base_skills=$(echo "$base_marketplace" | jq -c '.plugins[0].skills // []')
+head_skills=$(echo "$head_marketplace" | jq -c '.plugins[0].skills // []')
+
+if [[ "$base_skills" == "$head_skills" ]]; then
+  echo "✅ marketplace.json の plugins[0].skills に変更なし"
+  exit 0
+fi
+
+# skills が変化している → plugin.json の version を比較
+base_plugin=$(git_show_or_empty "$BASE_REF" "$PLUGIN_PATH")
+head_plugin=$(git_show_or_empty "$HEAD_REF" "$PLUGIN_PATH")
+
+if [[ -z "$base_plugin" || -z "$head_plugin" ]]; then
+  echo "✅ plugin.json が base / head のいずれかに存在しないため、チェックをスキップします"
+  exit 0
+fi
+
+base_version=$(echo "$base_plugin" | jq -r '.version // ""')
+head_version=$(echo "$head_plugin" | jq -r '.version // ""')
+
+if [[ -z "$base_version" || -z "$head_version" ]]; then
+  echo "✅ plugin.json に version フィールドが見つからないため、チェックをスキップします"
+  exit 0
+fi
+
+if [[ "$base_version" != "$head_version" ]]; then
+  echo "✅ skills 変更ありかつ plugin.json version が ${base_version} → ${head_version} に bump 済み"
+  exit 0
+fi
+
+# skills 変更あり + version 不変 → 警告
+{
+  echo "⚠️ marketplace.json の plugins[0].skills が変更されているが、plugin.json の version (${base_version}) が bump されていません。"
+  echo "   利用者は新しいスキルを取得するために version bump を必要とします。"
+  echo "   PR #459 と同種の取りこぼしを防ぐため、.claude-plugin/plugin.json の version を更新してください。"
+} >&2
+exit 1

--- a/tests/test_plugin_version_bump_check.sh
+++ b/tests/test_plugin_version_bump_check.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# test_plugin_version_bump_check.sh
+# ─────────────────────────────────────────────
+# Issue #458「plugin.json bump 漏れ自動検知 CI」の単体テスト
+#
+# scripts/check-plugin-version-bump.sh を 5 ケースで検証:
+#   1. skills 追加 + version bump → exit 0
+#   2. skills 追加 + version 不変 → exit 1（警告）
+#   3. skills 不変 → exit 0
+#   4. marketplace.json が base に不在 → exit 0（graceful skip）
+#   5. skills 削除 + version 不変 → exit 1（警告）
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/tests/lib/test_helpers.sh"
+
+CHECK_SCRIPT="${SCRIPT_DIR}/scripts/check-plugin-version-bump.sh"
+
+if [[ ! -x "$CHECK_SCRIPT" ]]; then
+  fail "scripts/check-plugin-version-bump.sh が存在しないか実行権限なし"
+  exit 1
+fi
+
+TMPDIR_ROOT=""
+cleanup() {
+  if [[ -n "$TMPDIR_ROOT" && -d "$TMPDIR_ROOT" ]]; then
+    rm -rf "$TMPDIR_ROOT" || true
+  fi
+}
+trap cleanup EXIT
+
+# 仮想 plugin リポを作る:
+#   - .claude-plugin/plugin.json と .claude-plugin/marketplace.json を持つ
+#   - main commit の後に PR ブランチで内容を編集する
+setup_repo() {
+  TMPDIR_ROOT=$(mktemp -d)
+  cd "$TMPDIR_ROOT"
+  git init -q -b main
+  git config user.name "vibecorp-test"
+  git config user.email "vibecorp-test@example.com"
+  mkdir -p .claude-plugin scripts tests/lib
+  # check スクリプト本体をコピー（仮想リポ内で同じパスから呼び出すため）
+  cp "$CHECK_SCRIPT" scripts/check-plugin-version-bump.sh
+  chmod +x scripts/check-plugin-version-bump.sh
+}
+
+write_plugin_json() {
+  local version="$1"
+  cat > .claude-plugin/plugin.json <<EOF
+{
+  "name": "vibecorp",
+  "version": "${version}",
+  "description": "test"
+}
+EOF
+}
+
+write_marketplace_json() {
+  # 残りの引数が skills の配列要素
+  local skills_json
+  skills_json=$(printf '"%s",' "$@")
+  skills_json="[${skills_json%,}]"
+  cat > .claude-plugin/marketplace.json <<EOF
+{
+  "name": "vibecorp",
+  "plugins": [
+    {
+      "name": "vibecorp",
+      "skills": ${skills_json}
+    }
+  ]
+}
+EOF
+}
+
+run_check() {
+  local rc=0
+  bash scripts/check-plugin-version-bump.sh main HEAD >/dev/null 2>&1 || rc=$?
+  echo "$rc"
+}
+
+# ============================================
+# Case 1: skills 追加 + version bump → exit 0
+# ============================================
+echo ""
+echo "--- Case 1: skills 追加 + version bump → exit 0 ---"
+setup_repo
+write_plugin_json "0.1.0"
+write_marketplace_json "./skills/a" "./skills/b"
+git add -A
+git commit -q -m "initial"
+git checkout -q -b pr
+write_plugin_json "0.2.0"
+write_marketplace_json "./skills/a" "./skills/b" "./skills/c"
+git add -A
+git commit -q -m "add skill c + bump"
+rc=$(run_check)
+assert_eq "Case 1: exit 0" "0" "$rc"
+cd "$SCRIPT_DIR"
+cleanup
+TMPDIR_ROOT=""
+
+# ============================================
+# Case 2: skills 追加 + version 不変 → exit 1
+# ============================================
+echo ""
+echo "--- Case 2: skills 追加 + version 不変 → exit 1 ---"
+setup_repo
+write_plugin_json "0.1.0"
+write_marketplace_json "./skills/a" "./skills/b"
+git add -A
+git commit -q -m "initial"
+git checkout -q -b pr
+write_plugin_json "0.1.0"
+write_marketplace_json "./skills/a" "./skills/b" "./skills/c"
+git add -A
+git commit -q -m "add skill c without bump"
+rc=$(run_check)
+assert_eq "Case 2: exit 1" "1" "$rc"
+cd "$SCRIPT_DIR"
+cleanup
+TMPDIR_ROOT=""
+
+# ============================================
+# Case 3: skills 不変 → exit 0
+# ============================================
+echo ""
+echo "--- Case 3: skills 不変 → exit 0 ---"
+setup_repo
+write_plugin_json "0.1.0"
+write_marketplace_json "./skills/a" "./skills/b"
+git add -A
+git commit -q -m "initial"
+git checkout -q -b pr
+write_plugin_json "0.1.0"
+write_marketplace_json "./skills/a" "./skills/b"
+echo "// unrelated" > README.md
+git add -A
+git commit -q -m "unrelated change"
+rc=$(run_check)
+assert_eq "Case 3: exit 0" "0" "$rc"
+cd "$SCRIPT_DIR"
+cleanup
+TMPDIR_ROOT=""
+
+# ============================================
+# Case 4: marketplace.json が base に不在 → graceful skip (exit 0)
+# ============================================
+echo ""
+echo "--- Case 4: marketplace.json が base に不在 → exit 0 (graceful skip) ---"
+setup_repo
+# base には marketplace.json なし
+mkdir -p docs
+echo "test" > docs/README.md
+git add -A
+git commit -q -m "initial without marketplace"
+git checkout -q -b pr
+# head で marketplace.json + plugin.json を新規追加
+write_plugin_json "0.1.0"
+write_marketplace_json "./skills/a"
+git add -A
+git commit -q -m "introduce plugin manifests"
+rc=$(run_check)
+assert_eq "Case 4: exit 0 (graceful skip)" "0" "$rc"
+cd "$SCRIPT_DIR"
+cleanup
+TMPDIR_ROOT=""
+
+# ============================================
+# Case 5: skills 削除 + version 不変 → exit 1
+# ============================================
+echo ""
+echo "--- Case 5: skills 削除 + version 不変 → exit 1 ---"
+setup_repo
+write_plugin_json "0.1.0"
+write_marketplace_json "./skills/a" "./skills/b" "./skills/c"
+git add -A
+git commit -q -m "initial"
+git checkout -q -b pr
+write_plugin_json "0.1.0"
+write_marketplace_json "./skills/a" "./skills/b"
+git add -A
+git commit -q -m "remove skill c without bump"
+rc=$(run_check)
+assert_eq "Case 5: exit 1" "1" "$rc"
+cd "$SCRIPT_DIR"
+cleanup
+TMPDIR_ROOT=""
+
+print_test_summary


### PR DESCRIPTION
## 概要

PR で `.claude-plugin/marketplace.json` の `plugins[0].skills` が変わったのに `.claude-plugin/plugin.json` の `version` が据え置きの場合、CI が PR に警告コメントを自動投稿する。

PR #459 で発生した「新スキル 3 件追加したのに plugin.json を `0.2.0` のまま放置」事象の再発防止。

## 何が変わるか（CEO 視点）

- 🚀 plugin.json の bump 忘れた PR には CI が「⚠️ version bump されていません」と勝手にコメントしてくれる
- 🔒 マージはブロックしない（CPO 申し送り通り「初期版は警告のみ・非ブロック」）
- ✅ 配布パッケージとして利用者影響が出る前に PR で気づける

## 動作仕様

| 状態 | 結果 |
|---|---|
| skills 配列を変えて plugin.json も bump した | ✅ 緑（コメント無し） |
| skills 配列を変えたが plugin.json は据え置き | ⚠️ 警告コメント投稿（マージはブロックしない） |
| skills 配列を触っていない PR | ✅ 緑（コメント無し、ワークフロー自体スキップ） |
| Fork PR | ⏭ 除外（secrets 不在のためスキップ） |

## 実装内容

- 🆕 `scripts/check-plugin-version-bump.sh` — base/head の skills を JSON 完全一致で比較し、bump 漏れを exit code で返す
- 🆕 `.github/workflows/plugin-version-bump-check.yml` — vibecorp 自リポ専用。`paths` フィルタで `.claude-plugin/*.json` 変更時のみ起動
- 🆕 `tests/test_plugin_version_bump_check.sh` — 5 ケース全 PASS（追加+bump、追加+据え置き、不変、graceful skip、削除+据え置き）

## スコープ外

- pre-commit hook 化（CI と二重実装は不要）
- 完全ブロック化（運用を見て後日判断）
- vibecorp 利用者リポへの配布（vibecorp 固有規律のため `templates/` には置かない）

close https://github.com/hirokimry/vibecorp/issues/458

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * プラグインのリリース品質保証に向けた自動検査システムを整備しました。プラグイン関連ファイルの変更時に自動検証が実行され、リリース時の一般的な誤りを防ぐことができます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->