### PR TITLE
📖 docs: claude エイリアス使用時の setup-token 回避手順がドキュメントに載るようになった

### DIFF
--- a/docs/ai-review-auth.md
+++ b/docs/ai-review-auth.md
@@ -43,6 +43,15 @@ claude setup-token
 
 `claude setup-token` は **1 年間有効な OAuth トークン**を発行する。発行されたトークンを次の手順でリポジトリ secrets に登録する。
 
+> **注: `claude` エイリアス使用時の罠**
+>
+> シェルで `alias claude='claude --add-dir ..'` のような alias が定義されていると、`claude setup-token` が `claude --add-dir .. setup-token` として展開され、サブコマンド解釈が壊れて対話 Claude Code セッションが起動してしまう（`setup-token` が実行されない）。回避方法のいずれかを使うこと:
+>
+> ```bash
+> command claude setup-token   # command ビルトインで alias 展開を抑制（推奨）
+> \claude setup-token          # バックスラッシュで alias 展開を回避
+> ```
+
 ### secrets 登録
 
 ```bash


### PR DESCRIPTION
## 概要

シェルで `alias claude='claude --add-dir ..'` のような alias が定義されていると、`claude setup-token` がエイリアス展開で壊れて対話 Claude Code セッションに進入してしまい、token 発行できない問題を docs に記録する。

## 何が変わるか（CEO 視点）

- 📖 利用者が claude alias を定義済みでも、`command claude setup-token` または `\claude setup-token` で正しく token 発行できることが docs/ai-review-auth.md で明確になる
- ✅ 同じ罠（私自身が今回ハマった）に他の利用者が時間を溶かさずに済む

## 変更内容

`docs/ai-review-auth.md` セクション 2「CLAUDE_CODE_OAUTH_TOKEN の調達」の「発行手順」直後に注記ブロックを追加。

## この PR の隠れた目的

Issue #509 の preflight ガードと CEO による secret 再設定の **総合動作確認** を兼ねる:

- ✅ preflight が「secret 設定済み」を検知して通過すること
- ✅ claude-code-action が **実際にレビュー本文を出すこと**（PR #508 / #510 では空 secret で起動失敗していた）

claude-action が今回 SUCCESS で完了し、レビューコメントが出れば Epic #455 の片翼が **本当に生き返ったこと** が立証される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメンテーション**
  * Claude OAuth トークン設定時における alias 設定に関する注意事項を追加しました。
  * alias の展開による予期しない動作を回避するための推奨方法およびワークアラウンドを記載しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Refs #509
