### PR TITLE
🐛 fix: PR #511 の不適切な docs 追加を取り消すようになった

### DIFF
--- a/docs/ai-review-auth.md
+++ b/docs/ai-review-auth.md
@@ -43,15 +43,6 @@ claude setup-token
 
 `claude setup-token` は **1 年間有効な OAuth トークン**を発行する。発行されたトークンを次の手順でリポジトリ secrets に登録する。
 
-> **注: `claude` エイリアス使用時の罠**
->
-> シェルで `alias claude='claude --add-dir ..'` のような alias が定義されていると、`claude setup-token` が `claude --add-dir .. setup-token` として展開され、サブコマンド解釈が壊れて対話 Claude Code セッションが起動してしまう（`setup-token` が実行されない）。回避方法のいずれかを使うこと:
->
-> ```bash
-> command claude setup-token   # command ビルトインで alias 展開を抑制（推奨）
-> \claude setup-token          # バックスラッシュで alias 展開を回避
-> ```
-
 ### secrets 登録
 
 ```bash


### PR DESCRIPTION
## 概要

PR #511 で docs/ai-review-auth.md に追加した「claude エイリアス使用時の setup-token 回避手順」セクションを **削除** する revert PR。

## なぜ revert するか

PR #511 で追加した内容は **vibecorp の docs に書くべきではなかった**。問題点:

1. ❌ **CEO 個人環境のローカル alias 設定を vibecorp の公式 docs に勝手に書き込んだ**
   - `alias claude='claude --add-dir ..'` は CEO 個人の zshrc 設定であり、vibecorp 利用者全員に該当する話ではない
2. ❌ **`.claude/rules/public-ready.md` 違反**
   - 「ローカル環境・ユーザー設定への依存禁止」「特定マシンパスをハードコードしない」に抵触
3. ❌ **スコープ違反**
   - claude-code CLI の挙動の話で vibecorp の責任範囲ではない（claude-code 公式 docs に書くべき内容）
4. ❌ **CEO 確認なしに直接 PR 化した**
   - 「動作確認用 PR の題材」として勝手に判断したが、題材選びが完全に間違っていた

## 何が変わるか（CEO 視点）

- ✅ vibecorp の docs/ai-review-auth.md が、CEO の個人環境設定を含まない元の状態に戻る
- ✅ 公式 docs の中立性・汎用性が回復する

## 影響範囲

`docs/ai-review-auth.md` の 9 行を削除（PR #511 のコミット 87f10a0 を `git revert` で取り消し）。他に変更なし。

## 学び（再発防止）

- 「動作確認用の小さな PR」を作る際の題材選定でも CEO 確認を取る
- 個人環境固有の情報は OSS docs に書かない（public-ready.md の徹底）
- 自分が体験した問題を即「ドキュメント化すべき」と判断しない

Refs #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* ドキュメント内の注記を再配置しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->