### PR TITLE
🔧 fix: claude-code-action 実行ステップに PR_NUMBER 環境変数が渡るようになる (#523)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -128,6 +128,13 @@ jobs:
         # Issue #521: REVIEW.md の Step 5-7（コメント投稿 / approve 発行）に必要なツールを
         # --allowedTools で明示的に許可する。許可がないと Claude が tool 呼び出しできず
         # 「num_turns: 1, No buffered inline comments」でサイレント終了する。
+        # Issue #523: REVIEW.md の Step 1-7 で gh pr diff / view / review 等を実行するため、
+        # PR_NUMBER と GITHUB_REPOSITORY を env で Claude プロセスに引き継ぐ。
+        # 渡さないと Claude が `gh pr diff "$PR_NUMBER"` を実行する時に変数が空となり、
+        # 「num_turns: 1, No buffered inline comments」でサイレント終了する。
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/templates/.github/workflows/ai-review.yml
+++ b/templates/.github/workflows/ai-review.yml
@@ -128,6 +128,13 @@ jobs:
         # Issue #521: REVIEW.md の Step 5-7（コメント投稿 / approve 発行）に必要なツールを
         # --allowedTools で明示的に許可する。許可がないと Claude が tool 呼び出しできず
         # 「num_turns: 1, No buffered inline comments」でサイレント終了する。
+        # Issue #523: REVIEW.md の Step 1-7 で gh pr diff / view / review 等を実行するため、
+        # PR_NUMBER と GITHUB_REPOSITORY を env で Claude プロセスに引き継ぐ。
+        # 渡さないと Claude が `gh pr diff "$PR_NUMBER"` を実行する時に変数が空となり、
+        # 「num_turns: 1, No buffered inline comments」でサイレント終了する。
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/tests/test_ai_review_directive_prompt.sh
+++ b/tests/test_ai_review_directive_prompt.sh
@@ -145,6 +145,54 @@ check_claude_args "自リポ版 ai-review.yml" "$SELF_AI_REVIEW"
 check_claude_args "配布版 ai-review.yml" "$TEMPLATE_AI_REVIEW"
 
 # ============================================
+# Case 4b: Claude Code Action 実行ステップに env: PR_NUMBER, GITHUB_REPOSITORY が指定されている (Issue #523)
+# ============================================
+echo ""
+echo "--- Case 4b: Claude Code Action 実行ステップの env: 必須変数（Issue #523） ---"
+
+check_env_vars() {
+  local label="$1"
+  local file="$2"
+  # Claude Code Action 実行ステップ範囲を抽出（次の `- name:` または ファイル末まで）
+  local step_block
+  step_block="$(awk '
+    /^      - name: Claude Code Action 実行/ { in_step = 1; print; next }
+    in_step && /^      - name:/ { exit }
+    in_step { print }
+  ' "$file")"
+
+  if [ -z "$step_block" ]; then
+    fail "${label}: Claude Code Action 実行ステップが見つからない"
+    return
+  fi
+
+  if printf '%s' "$step_block" | grep -q -E "^[[:space:]]*env:[[:space:]]*$"; then
+    pass "${label}: Claude Code Action 実行ステップに env: が指定されている"
+  else
+    fail "${label}: Claude Code Action 実行ステップに env: が無い（PR_NUMBER 等が Claude プロセスに渡らずサイレント終了する）"
+  fi
+
+  # PR_NUMBER が github.event.pull_request.number にマップされている
+  if printf '%s' "$step_block" | grep -q -F -- "PR_NUMBER:" \
+    && printf '%s' "$step_block" | grep -q -F -- "github.event.pull_request.number"; then
+    pass "${label}: env で PR_NUMBER が github.event.pull_request.number にマップされている"
+  else
+    fail "${label}: env の PR_NUMBER 設定が不適切（github.event.pull_request.number にマップされるべき）"
+  fi
+
+  # GITHUB_REPOSITORY が github.repository にマップされている
+  if printf '%s' "$step_block" | grep -q -F -- "GITHUB_REPOSITORY:" \
+    && printf '%s' "$step_block" | grep -q -F -- "github.repository"; then
+    pass "${label}: env で GITHUB_REPOSITORY が github.repository にマップされている"
+  else
+    fail "${label}: env の GITHUB_REPOSITORY 設定が不適切（github.repository にマップされるべき）"
+  fi
+}
+
+check_env_vars "自リポ版 ai-review.yml" "$SELF_AI_REVIEW"
+check_env_vars "配布版 ai-review.yml" "$TEMPLATE_AI_REVIEW"
+
+# ============================================
 # Case 5: 自リポ版と配布版 ai-review.yml が完全一致（drift 検知）
 # ============================================
 echo ""

--- a/tests/test_ai_review_directive_prompt.sh
+++ b/tests/test_ai_review_directive_prompt.sh
@@ -172,17 +172,17 @@ check_env_vars() {
     fail "${label}: Claude Code Action 実行ステップに env: が無い（PR_NUMBER 等が Claude プロセスに渡らずサイレント終了する）"
   fi
 
-  # PR_NUMBER が github.event.pull_request.number にマップされている
-  if printf '%s' "$step_block" | grep -q -F -- "PR_NUMBER:" \
-    && printf '%s' "$step_block" | grep -q -F -- "github.event.pull_request.number"; then
+  # PR_NUMBER が github.event.pull_request.number にマップされている（同一行で厳密チェック、CodeRabbit #524 指摘対応）
+  # キーと値を別 grep で見ると将来マッピングが入れ替わっても通る誤検知が発生するため、
+  # 1 行内で `KEY: ${{ EXPR }}` 形式を正規表現一発で照合する。
+  if printf '%s\n' "$step_block" | grep -q -E '^[[:space:]]*PR_NUMBER:[[:space:]]*\$\{\{[[:space:]]*github\.event\.pull_request\.number[[:space:]]*\}\}[[:space:]]*$'; then
     pass "${label}: env で PR_NUMBER が github.event.pull_request.number にマップされている"
   else
     fail "${label}: env の PR_NUMBER 設定が不適切（github.event.pull_request.number にマップされるべき）"
   fi
 
-  # GITHUB_REPOSITORY が github.repository にマップされている
-  if printf '%s' "$step_block" | grep -q -F -- "GITHUB_REPOSITORY:" \
-    && printf '%s' "$step_block" | grep -q -F -- "github.repository"; then
+  # GITHUB_REPOSITORY が github.repository にマップされている（同一行で厳密チェック、CodeRabbit #524 指摘対応）
+  if printf '%s\n' "$step_block" | grep -q -E '^[[:space:]]*GITHUB_REPOSITORY:[[:space:]]*\$\{\{[[:space:]]*github\.repository[[:space:]]*\}\}[[:space:]]*$'; then
     pass "${label}: env で GITHUB_REPOSITORY が github.repository にマップされている"
   else
     fail "${label}: env の GITHUB_REPOSITORY 設定が不適切（github.repository にマップされるべき）"


### PR DESCRIPTION
## 🎯 概要

PR #522（Issue #521）で REVIEW.md を指示書型に + `claude_args` を追加したが、**Claude プロセスに環境変数が渡されていない取り残し** があり、引き続き `num_turns: 1, No buffered inline comments` でサイレント終了していた。本 PR で env: を追加して根本解消する。

Close #523

## 🐛 修正前（PR #522 マージ後の PR #520 で観測）

| 項目 | 値 |
|------|-----|
| `claude_args` 渡し | ✅ ログ確認 |
| 指示書型 REVIEW.md | ✅ ログ確認 |
| `num_turns` | ❌ **1**（1 ターンで終了）|
| `No buffered inline comments` | ❌ 出力 |
| Overall PR review | ❌ 0 件 |

## 🔍 真因

`ai-review.yml` の Claude Code Action 実行ステップに `env:` が無いため、Claude プロセスが `gh pr diff "$PR_NUMBER"` を実行する際 **$PR_NUMBER が空** で失敗 → 「やる仕事ない」と判断して 1 ターンで終了。

## ✨ 修正内容

```yaml
- name: Claude Code Action 実行
  env:
    PR_NUMBER: ${{ github.event.pull_request.number }}
    GITHUB_REPOSITORY: ${{ github.repository }}
  uses: anthropics/claude-code-action@v1
  with:
    claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
    prompt: ${{ steps.review_prompt.outputs.prompt }}
    claude_args: |
      --allowedTools "..."
```

## 🧪 テスト結果

| テスト | 結果 |
|-------|------|
| `tests/test_ai_review_directive_prompt.sh`（Case 4b 追加） | ✅ **49/49 PASS** |
| `tests/test_install_ai_review_workflow.sh` | ✅ 48/48 PASS |
| `tests/test_ai_review_preflight.sh` | ✅ 12/12 PASS |

## 🛡️ 3 者承認ゲート

| エージェント | 判定 |
|-------------|------|
| CISO | ✅ OK（env は新規権限付与ではなく既存 context 引き継ぎ） |
| CPO | ✅ OK（Epic #455 の B 契約達成、規律の自動化バリュー強化） |
| SM | ✅ OK（permissions/secrets/トリガー変更なし） |

## ✅ 完了条件

- ✅ ai-review.yml（自リポ版・配布版）の Claude Code Action 実行ステップに env: PR_NUMBER, GITHUB_REPOSITORY 追加
- ✅ test_ai_review_directive_prompt.sh に env: 検証 6 ケース追加
- ✅ permissions / secrets 参照 / トリガー / Fork PR 除外条件 / GitHub App 権限スコープは **変更していない**

## 🎁 検証経路（重要）

claude-code-action の workflow validation により、**本 PR 自身では動作確認できない**（PR #522 と同じ仕様）。本 PR がマージされた後、**次の新規 PR で claude-code-action のレビューが実際に投稿される**ことが裏付けされる:
- ✅ 修正対象 0 件 → `gh pr review --approve` 発行
- ✅ 修正対象 1 件以上 → 各指摘の inline comment + `gh pr review --request-changes`
- ログ: `num_turns > 1`、`No buffered inline comments` が出なくなる予定

## 🔗 関連

- Issue #521 / PR #522（指示書型 REVIEW.md + claude_args、本 PR で env: 漏れを補完）
- Epic #455（CodeRabbit ローコスト代替）の中核機能の **真の動作開始**

## ⚙️ マージ方針

CEO 指示により **auto-merge は設定しない**。レビュー完了後 CEO 判断でマージする。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CIワークフローの環境変数渡し込みを改善し、外部アクションが正しいプルリクエスト情報を受け取るようにしました。
* **Tests**
  * ワークフロー設定の妥当性を検証する自動テストを追加し、環境変数の存在と正しいマッピングを厳密にチェックするようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->