### PR TITLE
📋 chore: vibecorp が自分自身に対する install.sh を流したら templates/ 配下の追跡漏れファイルが .claude/ 側に反映されるようになった

### DIFF
--- a/.claude/knowledge/accounting/cycle-metrics-template.md
+++ b/.claude/knowledge/accounting/cycle-metrics-template.md
@@ -1,0 +1,77 @@
+# Issue サイクル実測レポート雛形
+
+`/cycle-metrics` による実測データの記録雛形。実施ごとに `cycle-metrics-YYYY-MM-DD.md` としてコピーして使用する。
+
+判断（Critical/Major、Issue 起票要否）は CFO の `/audit-cost` 側で行う。本レポートは **データ生成専用**。
+
+---
+
+## 実施日
+
+YYYY-MM-DD（生成スキル: `/vibecorp:cycle-metrics`）
+
+## 集計範囲
+
+- 対象 PR: 直近 N 件（マージ済み）
+- 集計ブランチ: M 件（`dev/` プレフィックス付き）
+
+## PR サマリ
+
+| 指標 | 値 |
+|---|---|
+| PR 件数 | N |
+| 平均サイクル時間 | X h |
+| 最大サイクル時間 | X h |
+| 中央値サイクル時間 | X h |
+| 平均初回レビュー待ち時間 | X h |
+| 平均 CI 所要時間 | X h |
+| 総追加行数 | N |
+| 総削除行数 | N |
+
+## PR 別詳細
+
+| PR | Issue | タイトル | 総時間 | 初回レビュー | CI | +行 | -行 |
+|---|---|---|---|---|---|---|---|
+| #N | #N | （PR タイトル） | Xh | Xh | Xh | N | N |
+
+## エージェント・トークン消費（ブランチ別）
+
+総トークン: input=N / output=N / cache_creation=N / cache_read=N
+サブエージェント呼び出し合計（sidechain）: N
+
+| ブランチ | Issue | セッション数 | input | output | cache_creation | cache_read | sidechain |
+|---|---|---|---|---|---|---|---|
+| dev/N_summary | #N | N | N | N | N | N | N |
+
+## モデル別集計
+
+| モデル | input | output | cache_creation | cache_read | message数 |
+|---|---|---|---|---|---|
+| claude-opus-4-7 | N | N | N | N | N |
+| claude-sonnet-4-6 | N | N | N | N | N |
+| claude-haiku-4-5 | N | N | N | N | N |
+
+## サブエージェント別呼び出し回数
+
+| subagent_type | 呼び出し回数 |
+|---|---|
+| general-purpose | N |
+| Explore | N |
+| cfo | N |
+
+## ボトルネック
+
+- 最長サイクル: PR #N (Xh)
+  - 初回レビュー: Xh
+  - CI: Xh
+
+## 関連
+
+- `docs/cost-analysis.md`（実測値で補正する前提データ）
+- `/audit-cost`（本レポートを参照する CFO 監査スキル）
+- Issue #353（本スキル新設の根拠）
+
+## 生データ
+
+- PR メトリクス JSON: `fetch-pr-metrics.sh` の出力を参照
+- Agent メトリクス JSON: `fetch-agent-metrics.sh` の出力を参照

--- a/.claude/knowledge/accounting/cycle-metrics-template.md
+++ b/.claude/knowledge/accounting/cycle-metrics-template.md
@@ -1,6 +1,6 @@
 # Issue サイクル実測レポート雛形
 
-`/cycle-metrics` による実測データの記録雛形。実施ごとに `cycle-metrics-YYYY-MM-DD.md` としてコピーして使用する。
+`/vibecorp:cycle-metrics` による実測データの記録雛形。実施ごとに `cycle-metrics-YYYY-MM-DD.md` としてコピーして使用する。
 
 判断（Critical/Major、Issue 起票要否）は CFO の `/audit-cost` 側で行う。本レポートは **データ生成専用**。
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,22 +1,22 @@
 {
   "permissions": {
     "allow": [
-      "Write(.claude/knowledge/**)",
       "Edit(.claude/knowledge/**)",
-      "Write(.claude/rules/**)",
-      "Edit(.claude/rules/**)",
-      "Write(.claude/plans/**)",
       "Edit(.claude/plans/**)",
-      "Write(.claude/skills/**)",
+      "Edit(.claude/rules/**)",
       "Edit(.claude/skills/**)",
-      "Write(//Users/**/.cache/vibecorp/plans/**)",
       "Edit(//Users/**/.cache/vibecorp/plans/**)",
-      "Write(//Users/**/.cache/vibecorp/state/**)",
       "Edit(//Users/**/.cache/vibecorp/state/**)",
-      "Write(//home/**/.cache/vibecorp/plans/**)",
       "Edit(//home/**/.cache/vibecorp/plans/**)",
-      "Write(//home/**/.cache/vibecorp/state/**)",
-      "Edit(//home/**/.cache/vibecorp/state/**)"
+      "Edit(//home/**/.cache/vibecorp/state/**)",
+      "Write(.claude/knowledge/**)",
+      "Write(.claude/plans/**)",
+      "Write(.claude/rules/**)",
+      "Write(.claude/skills/**)",
+      "Write(//Users/**/.cache/vibecorp/plans/**)",
+      "Write(//Users/**/.cache/vibecorp/state/**)",
+      "Write(//home/**/.cache/vibecorp/plans/**)",
+      "Write(//home/**/.cache/vibecorp/state/**)"
     ]
   },
   "hooks": {
@@ -34,11 +34,11 @@
           },
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/protect-knowledge-bash-writes.sh"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/protect-branch.sh"
           },
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/protect-branch.sh"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/protect-knowledge-bash-writes.sh"
           },
           {
             "type": "command",
@@ -59,6 +59,10 @@
           },
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/guide-gate.sh"
+          },
+          {
+            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/protect-branch.sh"
           },
           {
@@ -67,15 +71,11 @@
           },
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/role-gate.sh"
-          },
-          {
-            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/protect-knowledge-direct-writes.sh"
           },
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/guide-gate.sh"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/role-gate.sh"
           }
         ]
       }
@@ -83,5 +83,13 @@
   },
   "enabledPlugins": {
     "vibecorp@vibecorp": true
+  },
+  "extraKnownMarketplaces": {
+    "vibecorp": {
+      "source": {
+        "source": "github",
+        "repo": "hirokimry/vibecorp"
+      }
+    }
   }
 }


### PR DESCRIPTION
## 関連 Issue

close #538

## 概要

✅ vibecorp 自身のリポジトリで `./install.sh --update` を流して、`templates/` の最新内容が `.claude/` 側に追従するようになった。

### 何が変わったか

- ⚙️ **`.claude/settings.json`**: permissions の Edit/Write 並び順が template に整列、hooks 実行順が最新に追従、`extraKnownMarketplaces` が追加された
- 📦 **`.claude/knowledge/accounting/cycle-metrics-template.md`**: `/vibecorp:cycle-metrics` スキルが参照するテンプレが untracked から追跡対象に取り込まれた

### 何が変わらないか

- ⚪ ロジック挙動は不変（intent/infra）。templates/ 側は触っていない、`.claude/` 側を `templates/` に同期しただけ

### 別件として分離した問題

⚠️ self-update 実行時に **`.claude-plugin/plugin.json` が 0.3.0 → 0.2.0 にダウングレード**する現象を検出。本 PR では戻して別 Issue で扱う:
- 真因: `templates/claude-plugin/plugin.json` が 0.2.0 のまま放置（PR #459 のリリース時に bump 漏れ）
- install.sh:734 が無条件 `cp` で配信先を上書き → vibecorp 利用者全体に波及するリグレッション
- 本 PR スコープ外として別 Issue で対応

## テスト計画

- [x] `./install.sh --update` 完走を確認
- [x] `.claude-plugin/plugin.json` のダウングレードを `git checkout` で除外
- [x] `cycle-metrics-template.md` が `/vibecorp:cycle-metrics` SKILL.md の参照先と一致することを確認
- [ ] CI（`intent-label-check`, `pr-issue-link-check`, `test`）が green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * サイクルメトリクス測定レポート用の新しいテンプレートを追加しました。実行日、集計スコープ、PR要約と詳細、消費リソース・ボトルネック分析、関連参照、および生データへのリンクを含む構成です。

* **その他**
  * 設定を更新し、編集・書き込み権限と事前実行フックの順序を見直して保護とガイドラインを強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->