### PR TITLE
🐛 fix: 旧パスに残存した buffer worktree が新 repo-id namespace 構造で読み込まれるようになった

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### 修正
+
+- `knowledge_buffer.sh` の repo-id namespace 構造（PR #344）に旧構造で作られた buffer worktree が migration されない問題を修正 (#543)。`knowledge_buffer_ensure` 内で旧構造を自動検知し、未 push commit を保全しつつ新構造へ移行するようになった。利用者は次回 `/sync-edit` / `/review-harvest` / `/knowledge-pr` 実行時に自動回復する
+- `install.sh --update` 実行で `.claude-plugin/plugin.json` の `version` がダウングレードする問題を修正 (#540, PR #542)。`templates/claude-plugin/plugin.json` を廃止し、リポジトリ直下の `.claude-plugin/plugin.json` を唯一の Source-of-Truth として直接コピーするようになった
+
 ## [0.3.0] - 2026-04-25
 
 ### ⚠️ 破壊的変更

--- a/docs/migration-knowledge-buffer.md
+++ b/docs/migration-knowledge-buffer.md
@@ -146,6 +146,52 @@ rm -rf "$BUFFER_DIR/.buffer.lock.d"
 - `/vibecorp:sync-edit`（sync-check で検出された不整合の修正）
 - `/vibecorp:audit-cost` / `/vibecorp:audit-security`（CFO / CISO 監査）
 
+## buffer worktree 旧構造からの自動 migration（Issue #543）
+
+PR #344 (2026-04-18) で `knowledge_buffer.sh` が以下の構造変更を行った:
+
+- 旧: `~/.cache/vibecorp/buffer-worktree/`（直下に worktree）
+- 新: `~/.cache/vibecorp/buffer-worktree/<repo-id>/`（repo-id namespace）
+
+それ以前に作成された buffer worktree は新コードが期待する場所と整合せず、`/sync-edit` / `/review-harvest` / `/knowledge-pr` が無音失敗していた。Issue #543 で `knowledge_buffer_ensure` に **自動 migration ロジック** を追加し、旧構造を検出したら自動的に新構造へ移行する。
+
+### 自動 migration の動作
+
+利用者が `/vibecorp:sync-edit` などのスキルを実行すると `knowledge_buffer_ensure` が呼ばれ、以下が自動で行われる:
+
+1. `git worktree list --porcelain` で旧構造（buffer-worktree/ 直下が worktree）を検出
+2. 旧 worktree に **未 push commit がない** 場合のみ migrate を続行
+3. `git worktree remove --force` で旧 worktree を解除
+4. 旧 path 自体を削除
+5. 新構造（buffer-worktree/<repo-id>/）で worktree を再作成
+
+利用者は何もしなくても次回 skill 実行時に自動回復する。
+
+### 未 push commit がある場合（手動復旧）
+
+旧 worktree に未 push の harvest commit が残っている場合、データ保全のため migration は **強制中断** され、stderr に以下のメッセージが出る:
+
+```text
+[knowledge-buffer] 旧構造 worktree に N 件の未 push commit があります: ~/.cache/vibecorp/buffer-worktree
+[knowledge-buffer] データ保全のため migration を停止します
+[knowledge-buffer] 復旧手順:
+[knowledge-buffer]   1. cd ~/.cache/vibecorp/buffer-worktree
+[knowledge-buffer]   2. git push origin knowledge/buffer
+[knowledge-buffer]   3. 元のスキルを再実行
+```
+
+このメッセージに従って未 push commit を push してから skill を再実行すれば、自動 migration が走って新構造に移行する。
+
+### 確認方法
+
+migration が成功したかは `git worktree list` で確認できる:
+
+```bash
+git worktree list
+```
+
+新構造（`<repo-id>` を含むパス）に worktree が登録されており、旧構造（`<repo-id>` を含まないパス）が登録されていなければ migration 完了。
+
 ## audit-log 構造移行（Issue #442）
 
 旧構造 `accounting/audit-YYYY-MM-DD.md` フラット直置き → 新構造 `accounting/audit-log/YYYY-QN.md` 四半期集約。

--- a/templates/claude/lib/knowledge_buffer.sh
+++ b/templates/claude/lib/knowledge_buffer.sh
@@ -87,10 +87,73 @@ knowledge_buffer_lock_release() {
   fi
 }
 
+# knowledge_buffer_is_legacy_layout — 旧構造（PR #344 以前）の worktree が残存しているか
+# 旧構造: ${cache_root}/vibecorp/buffer-worktree/ 自体が worktree として登録されている
+# 新構造: ${cache_root}/vibecorp/buffer-worktree/<repo-id>/ が worktree（こちらは正常）
+# 引数: $1 = repo_root (CLAUDE_PROJECT_DIR の git toplevel), $2 = legacy_dir (= dirname new_dir)
+# 出力: 該当時のみ "yes" を stdout に出す（grep -q yes で判定）
+knowledge_buffer_is_legacy_layout() {
+  local repo_root="$1"
+  local legacy_dir="$2"
+  git -C "$repo_root" worktree list --porcelain 2>/dev/null \
+    | awk -v target="$legacy_dir" '
+        /^worktree / { if ($2 == target) { print "yes"; exit } }
+      '
+}
+
+# knowledge_buffer_migrate_legacy — 旧構造の worktree を新構造へ移行する
+# 1. 未 push commit があれば停止（データ保全）
+# 2. 旧 worktree を git worktree remove --force で解除
+# 3. 旧 path 自体を rm -rf でクリーンアップ
+# 引数: $1 = repo_root, $2 = legacy_dir, $3 = new_dir
+# 戻り値: 0 = 移行成功 / 1 = 未 push 等で中断
+knowledge_buffer_migrate_legacy() {
+  local repo_root="$1"
+  local legacy_dir="$2"
+  local new_dir="$3"
+
+  # データ保全: 未 push commit があれば停止
+  local unpushed
+  if git -C "$legacy_dir" rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1; then
+    unpushed="$(git -C "$legacy_dir" rev-list --count "@{u}..HEAD" 2>/dev/null || echo 0)"
+  else
+    # upstream 未設定の場合: HEAD に到達可能な commit があるかで判定
+    unpushed="$(git -C "$legacy_dir" rev-list --count HEAD 2>/dev/null || echo 0)"
+  fi
+  if [ "${unpushed:-0}" -gt 0 ]; then
+    {
+      echo "[knowledge-buffer] 旧構造 worktree に ${unpushed} 件の未 push commit があります: ${legacy_dir}"
+      echo "[knowledge-buffer] データ保全のため migration を停止します"
+      echo "[knowledge-buffer] 復旧手順:"
+      echo "[knowledge-buffer]   1. cd ${legacy_dir}"
+      echo "[knowledge-buffer]   2. git push origin knowledge/buffer"
+      echo "[knowledge-buffer]   3. 元のスキルを再実行"
+    } >&2
+    return 1
+  fi
+
+  echo "[knowledge-buffer] 旧構造 worktree を新構造に migrate します: ${legacy_dir} -> ${new_dir}" >&2
+
+  # 旧 worktree を解除（worktree 内に未 commit 変更があっても remove --force で除去）
+  if ! git -C "$repo_root" worktree remove --force "$legacy_dir" >/dev/null 2>&1; then
+    echo "[knowledge-buffer] 旧 worktree の remove に失敗しました: ${legacy_dir}" >&2
+    return 1
+  fi
+
+  # 残骸ディレクトリのクリーンアップ（git worktree remove はディレクトリも削除するが念のため）
+  rm -rf "$legacy_dir" 2>/dev/null || true
+
+  # 新構造の親ディレクトリを再作成（呼出元が後段で mkdir -p しているが明示的に）
+  mkdir -p "$(dirname "$new_dir")"
+
+  return 0
+}
+
 # knowledge_buffer_ensure — worktree を最新化する（未作成なら新規作成）
 # - 未作成: git worktree add -B knowledge/buffer <dir> origin/main
 # - 既存: git fetch origin → git pull --ff-only（失敗時は未push commit有無を検査して reset または中断）
 # - worktree prune 必要なら自動復旧
+# - 旧構造（PR #344 以前）の worktree を検出したら新構造へ自動 migrate（Issue #543）
 # 呼出元は CLAUDE_PROJECT_DIR（git toplevel）で実行する想定
 knowledge_buffer_ensure() {
   local dir
@@ -103,6 +166,13 @@ knowledge_buffer_ensure() {
   if ! repo_root="$(git -C "${CLAUDE_PROJECT_DIR:-$PWD}" rev-parse --show-toplevel 2>/dev/null)"; then
     echo "[knowledge-buffer] git toplevel が取得できません" >&2
     return 1
+  fi
+
+  # 旧構造（buffer-worktree/ 直下が worktree）を検出したら自動 migrate
+  if knowledge_buffer_is_legacy_layout "$repo_root" "$parent" | grep -q yes; then
+    if ! knowledge_buffer_migrate_legacy "$repo_root" "$parent" "$dir"; then
+      return 1
+    fi
   fi
 
   # worktree が未作成、またはディレクトリが削除済み

--- a/templates/claude/lib/knowledge_buffer.sh
+++ b/templates/claude/lib/knowledge_buffer.sh
@@ -95,9 +95,13 @@ knowledge_buffer_lock_release() {
 knowledge_buffer_is_legacy_layout() {
   local repo_root="$1"
   local legacy_dir="$2"
+  # awk: "worktree " (9 文字) 以降を path として抽出。$2 だとスペース含むパスで切れる
   git -C "$repo_root" worktree list --porcelain 2>/dev/null \
     | awk -v target="$legacy_dir" '
-        /^worktree / { if ($2 == target) { print "yes"; exit } }
+        /^worktree / {
+          path = substr($0, 10)
+          if (path == target) { print "yes"; exit }
+        }
       '
 }
 

--- a/tests/test_knowledge_buffer_migration.sh
+++ b/tests/test_knowledge_buffer_migration.sh
@@ -1,0 +1,299 @@
+#!/bin/bash
+# test_knowledge_buffer_migration.sh — Issue #543: 旧構造 buffer worktree の自動 migration
+#
+# PR #344 (2026-04-18) で knowledge_buffer.sh が
+#   ~/.cache/vibecorp/buffer-worktree/<repo-id>/
+# の repo-id namespace 構造に変更された。それ以前に旧構造
+#   ~/.cache/vibecorp/buffer-worktree/
+# 直下に作られた worktree を新構造へ自動 migrate するロジックを検証する。
+#
+# 使い方: bash tests/test_knowledge_buffer_migration.sh
+
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${TESTS_DIR}/lib/test_helpers.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LIB="${SCRIPT_DIR}/templates/claude/lib/knowledge_buffer.sh"
+COMMON_LIB="${SCRIPT_DIR}/templates/claude/lib/common.sh"
+
+if [ ! -f "$LIB" ]; then
+  fail "knowledge_buffer.sh が存在しない: $LIB"
+  exit 1
+fi
+if [ ! -f "$COMMON_LIB" ]; then
+  fail "common.sh が存在しない: $COMMON_LIB"
+  exit 1
+fi
+
+# 各テストごとに環境を作り直す（前のテストの worktree 状態に汚染されないため）
+TMPDIR_ROOT=""
+ORIGIN_REPO=""
+WORK_REPO=""
+LEGACY_DIR=""
+NEW_DIR=""
+
+setup_env() {
+  TMPDIR_ROOT=$(mktemp -d)
+  # macOS の /var → /private/var canonicalization 対策（git worktree list は canonical path を返すため）
+  TMPDIR_ROOT="$(cd "$TMPDIR_ROOT" && pwd -P)"
+  ORIGIN_REPO="${TMPDIR_ROOT}/origin.git"
+  WORK_REPO="${TMPDIR_ROOT}/work"
+  local cache_root="${TMPDIR_ROOT}/cache"
+
+  git init --bare "$ORIGIN_REPO" >/dev/null 2>&1
+  git -C "$ORIGIN_REPO" symbolic-ref HEAD refs/heads/main
+
+  git init "$WORK_REPO" >/dev/null 2>&1
+  git -C "$WORK_REPO" config user.email "test@example.com"
+  git -C "$WORK_REPO" config user.name "Test User"
+  git -C "$WORK_REPO" checkout -b main >/dev/null 2>&1
+  echo "hello" > "${WORK_REPO}/README.md"
+  git -C "$WORK_REPO" add README.md
+  git -C "$WORK_REPO" commit -m "initial" >/dev/null 2>&1
+  git -C "$WORK_REPO" remote add origin "$ORIGIN_REPO"
+  git -C "$WORK_REPO" push -u origin main >/dev/null 2>&1
+
+  export CLAUDE_PROJECT_DIR="$WORK_REPO"
+  export XDG_CACHE_HOME="$cache_root"
+  export VIBECORP_LOCK_TIMEOUT=2
+
+  # shellcheck disable=SC1090
+  source "$LIB"
+
+  NEW_DIR="$(knowledge_buffer_worktree_dir)"
+  LEGACY_DIR="$(dirname "$NEW_DIR")"
+  mkdir -p "$LEGACY_DIR"
+}
+
+teardown_env() {
+  if [ -n "${WORK_REPO:-}" ] && [ -d "$WORK_REPO/.git" ]; then
+    git -C "$WORK_REPO" worktree prune >/dev/null 2>&1 || true
+  fi
+  if [ -n "${TMPDIR_ROOT:-}" ] && [ -d "$TMPDIR_ROOT" ]; then
+    rm -rf "$TMPDIR_ROOT" || true
+  fi
+  TMPDIR_ROOT=""
+  ORIGIN_REPO=""
+  WORK_REPO=""
+  LEGACY_DIR=""
+  NEW_DIR=""
+}
+
+# 全 case 終了後に最終 cleanup（途中失敗時の保険）
+trap teardown_env EXIT
+
+# 旧構造 worktree を `git worktree add` で作る
+# 引数: $1 = legacy_dir
+create_legacy_worktree() {
+  local legacy="$1"
+  rm -rf "$legacy"
+  mkdir -p "$(dirname "$legacy")"
+  git -C "$WORK_REPO" worktree add -B knowledge/buffer "$legacy" origin/main >/dev/null 2>&1
+}
+
+# Worktree が登録されているか（git worktree list の path 完全一致）
+is_worktree_registered() {
+  local target="$1"
+  git -C "$WORK_REPO" worktree list --porcelain 2>/dev/null \
+    | awk -v target="$target" '
+        /^worktree / { if ($2 == target) { print "yes"; exit } }
+      ' \
+    | grep -q yes
+}
+
+# ============================================
+echo ""
+echo "=== Issue #543: buffer worktree 旧構造 自動 migration ==="
+# ============================================
+
+# --- Case 1: 旧構造のみ存在 → 新構造へ migrate ---
+
+echo ""
+echo "--- Case 1: 旧構造のみ → 新構造へ migrate ---"
+setup_env
+
+# 旧構造 worktree を作成
+create_legacy_worktree "$LEGACY_DIR"
+
+# 前提確認
+if is_worktree_registered "$LEGACY_DIR"; then
+  pass "前提: 旧構造 worktree が登録されている"
+else
+  fail "前提: 旧構造 worktree が登録されていない"
+  teardown_env
+  exit 1
+fi
+
+# knowledge_buffer_ensure を実行
+if knowledge_buffer_ensure >/dev/null 2>&1; then
+  pass "Case 1: ensure が migration 経路で成功する"
+else
+  fail "Case 1: ensure が失敗した"
+fi
+
+# 旧構造が登録解除されている
+if is_worktree_registered "$LEGACY_DIR"; then
+  fail "Case 1: 旧構造 worktree がまだ登録されている"
+else
+  pass "Case 1: 旧構造 worktree が登録解除されている"
+fi
+
+# 新構造が登録されている
+if is_worktree_registered "$NEW_DIR"; then
+  pass "Case 1: 新構造 worktree が登録されている"
+else
+  fail "Case 1: 新構造 worktree が登録されていない"
+fi
+
+# 新構造ディレクトリに .git が存在する
+if [ -e "${NEW_DIR}/.git" ]; then
+  pass "Case 1: 新構造ディレクトリに .git が存在する"
+else
+  fail "Case 1: 新構造ディレクトリに .git が存在しない"
+fi
+
+teardown_env
+
+# --- Case 2: 新構造のみ存在 → idempotent (migration 不要) ---
+
+echo ""
+echo "--- Case 2: 新構造のみ → migration 不要 (idempotent) ---"
+setup_env
+
+# 通常フローで新構造作成（migration ロジックを通らない）
+if knowledge_buffer_ensure >/dev/null 2>&1; then
+  pass "前提: 新構造を初回作成"
+else
+  fail "前提: 新構造の初回作成に失敗"
+  teardown_env
+  exit 1
+fi
+
+# 旧構造は無いことを確認
+if is_worktree_registered "$LEGACY_DIR"; then
+  fail "前提: 旧構造が誤って登録されている"
+fi
+
+# 再度 ensure → 何も変化しない
+if knowledge_buffer_ensure >/dev/null 2>&1; then
+  pass "Case 2: ensure が新構造のみで idempotent"
+else
+  fail "Case 2: ensure が新構造のみで失敗した"
+fi
+
+if is_worktree_registered "$NEW_DIR"; then
+  pass "Case 2: 新構造のまま登録されている"
+else
+  fail "Case 2: 新構造の登録が失われた"
+fi
+
+if is_worktree_registered "$LEGACY_DIR"; then
+  fail "Case 2: 旧構造が誤って登録された"
+else
+  pass "Case 2: 旧構造は登録されないまま"
+fi
+
+teardown_env
+
+# --- Case 3: 旧構造 + 新 path に残骸ディレクトリ → migrate ---
+
+echo ""
+echo "--- Case 3: 旧構造 + 新 path 残骸 → 旧解除 + 残骸削除 + 新作成 ---"
+setup_env
+
+# 旧構造を作成
+create_legacy_worktree "$LEGACY_DIR"
+
+# 新 path に空ディレクトリ（残骸）を仕込む
+mkdir -p "$NEW_DIR"
+
+if [ -d "$NEW_DIR" ]; then
+  pass "前提: 新 path に残骸ディレクトリが存在"
+else
+  fail "前提: 新 path 残骸の作成に失敗"
+  teardown_env
+  exit 1
+fi
+
+# ensure 実行
+if knowledge_buffer_ensure >/dev/null 2>&1; then
+  pass "Case 3: ensure が migration + 残骸クリーンアップで成功する"
+else
+  fail "Case 3: ensure が失敗した"
+fi
+
+if is_worktree_registered "$LEGACY_DIR"; then
+  fail "Case 3: 旧構造がまだ登録されている"
+else
+  pass "Case 3: 旧構造が登録解除されている"
+fi
+
+if is_worktree_registered "$NEW_DIR"; then
+  pass "Case 3: 新構造が正しく登録されている"
+else
+  fail "Case 3: 新構造が登録されていない"
+fi
+
+if [ -e "${NEW_DIR}/.git" ]; then
+  pass "Case 3: 新構造ディレクトリに .git が存在する"
+else
+  fail "Case 3: 新構造ディレクトリに .git が存在しない"
+fi
+
+teardown_env
+
+# --- Case 4: 旧構造に未 push commit あり → migration 中断（データ保全） ---
+
+echo ""
+echo "--- Case 4: 旧構造に未 push commit → 停止して保全 ---"
+setup_env
+
+# 旧構造作成 + 未 push commit を残す
+create_legacy_worktree "$LEGACY_DIR"
+
+# upstream を作るために空 push（worktree から）
+# まず空 push を成功させ、upstream を確立する
+git -C "$LEGACY_DIR" push --set-upstream origin knowledge/buffer >/dev/null 2>&1
+
+# 未 push commit を作成
+echo "unpushed harvest data" > "${LEGACY_DIR}/harvest.txt"
+git -C "$LEGACY_DIR" add harvest.txt
+git -C "$LEGACY_DIR" commit -m "wip harvest (unpushed)" >/dev/null 2>&1
+
+# 未 push 件数の前提確認
+unpushed=$(git -C "$LEGACY_DIR" rev-list --count "@{u}..HEAD" 2>/dev/null)
+if [ "${unpushed:-0}" -gt 0 ]; then
+  pass "前提: 旧 worktree に ${unpushed} 件の未 push commit がある"
+else
+  fail "前提: 未 push commit の作成に失敗"
+  teardown_env
+  exit 1
+fi
+
+# ensure 実行 → 失敗するべき
+if knowledge_buffer_ensure >/dev/null 2>&1; then
+  fail "Case 4: 未 push commit があるのに migration が実行された (データロストリスク)"
+else
+  pass "Case 4: 未 push commit を検知して ensure が中断した"
+fi
+
+# 旧構造はまだ登録されている（保全されている）
+if is_worktree_registered "$LEGACY_DIR"; then
+  pass "Case 4: 旧構造 worktree が保全されている"
+else
+  fail "Case 4: 旧構造 worktree が誤って削除された"
+fi
+
+# 旧 worktree の commit が残っている
+if [ -f "${LEGACY_DIR}/harvest.txt" ]; then
+  pass "Case 4: 未 push データがディスク上に保全されている"
+else
+  fail "Case 4: 未 push データが消えた"
+fi
+
+teardown_env
+
+print_test_summary


### PR DESCRIPTION
## 関連 Issue

close #543

## 概要

⚠️ PR #344 (2026-04-18) で `knowledge_buffer.sh` が repo-id namespace 構造（`buffer-worktree/<repo-id>/`）に変更された際、それ以前に作られた buffer worktree（`buffer-worktree/` 直下）の migration ロジックが欠落していた問題を、`knowledge_buffer_ensure` 内で **自動 migration** することで解消した。

利用者は何もしなくても次回 `/sync-edit` / `/review-harvest` / `/knowledge-pr` 実行時に自動で旧構造から新構造へ移行する。

## 影響範囲

- 4/18 以降に vibecorp を更新した利用者で、4/18 以前に buffer worktree を作成済の人は **knowledge/buffer フローが完全に止まっていた**
- `/sync-edit`、`/review-harvest`、`/knowledge-pr` が無音失敗していた

## 設計

### 何が変わったか

- ✅ `templates/claude/lib/knowledge_buffer.sh`: `knowledge_buffer_is_legacy_layout` / `knowledge_buffer_migrate_legacy` 関数を新規追加。`knowledge_buffer_ensure` 冒頭に旧構造検出 + migration 呼出を挿入
- 🛡️ **データ保全**: 旧 worktree に未 push commit があれば migration を中断し、復旧手順を stderr に明示する
- 🧪 `tests/test_knowledge_buffer_migration.sh` 新規: 4 ケース 18 アサーション（旧構造のみ / 新構造のみ / 両方残存 / 未 push commit 保護）
- 📖 `docs/migration-knowledge-buffer.md`: 自動 migration の動作と手動復旧手順を追記
- 📖 `CHANGELOG.md`: `[Unreleased]` セクションに本件と Issue #540 修正を記載

### 何が変わらないか

- ⚪ consumer 側の API 互換性。`knowledge_buffer_ensure` の呼出インタフェース不変
- ⚪ docs/specification.md の knowledge/buffer フロー設計（buffer 経由蓄積 → knowledge-pr で main 反映）

### 設計選択肢の比較

| 方針 | 採用 | 理由 |
|---|---|---|
| A. `knowledge_buffer_ensure` 内で auto-migrate | ✅ | 利用者は何もしなくても自動回復。「規律の自動化」原則と整合 |
| B. `install.sh` で migrate | ❌ | install.sh は state directory を管理しない設計。ライブラリ責務範囲内で完結すべき |
| C. 手動 migration script のみ | ❌ | 利用者の手作業を要求するのは負け筋 |

## テスト計画

- [x] `tests/test_knowledge_buffer_migration.sh`: 18/18 PASS
- [x] `tests/test_knowledge_buffer.sh`: 23/23 PASS（既存、回帰なし）
- [x] CodeRabbit CLI: No findings（awk スペース対応の指摘 1 件を反映後）
- [x] sync-check: CTO / CPO ともに OK（decisions 追記は後追い対応で合意）
- [ ] CI（`intent-label-check`, `pr-issue-link-check`, `test`）が green

## 関連

- #344: knowledge/buffer 再設計 PR（migration 漏れの起点）
- #540 (#542): plugin.json drift 防止（同じ「state migrate 漏れ」家系の別バグ）
- #538 / #539: self-update 取りこぼし（templates/ → .claude/ の drift 検出元）
- #539, #542 が main にマージされた後に本 PR がマージされると、CTO / CPO の decisions 記録が後追いで反映可能になる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Buffer worktree の自動移行機能を実装。旧構造で作成された worktree を新構造に自動的に移行し、未プッシュコミットを保全します。
  * インストール更新実行時のバージョンダウングレード問題を修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->