### PR TITLE
📖 docs: 配布物の Source-of-Truth 不整合が POLICY.md 完成と組織図記述統一で解消された (#515)

### DIFF
--- a/.claude/knowledge/sm/organization.md
+++ b/.claude/knowledge/sm/organization.md
@@ -23,16 +23,19 @@ AI組織構成は `docs/ai-organization.md` を参照すること。
 
 ### docs/ 書き込み権限（role-gate.sh で制御）
 
+`docs/ai-organization.md` を Source of Truth として、各エージェントの docs/ 編集権限は次の通り。
+
 | ロール | 書き込み可能な docs/ パス |
 |--------|------------------------|
-| CTO | docs/specification.md（技術スタック部分） |
-| CPO | docs/specification.md（プロダクト仕様部分） |
+| CTO | docs/specification.md（技術スタック部分）, docs/design-philosophy.md |
+| CPO | docs/specification.md（プロダクト仕様部分）, docs/screen-flow.md |
 | SM | docs/ai-organization.md |
-| 分析員 legal | docs/POLICY.md |
-| 分析員 accounting | docs/cost-analysis.md |
-| 分析員 security | docs/SECURITY.md |
+| accounting-analyst | docs/cost-analysis.md（直接編集） |
+| security-analyst | docs/SECURITY.md（直接編集） |
 
-統括職（CFO, CLO, CISO）は role-gate.sh に個別ケースを持たず、docs/ への直接書き込み権限がない。統括職は分析員チームのメタレビューを行う立場であり、docs/ の更新は分析員が実行する。
+統括職（CFO, CLO, CISO）は role-gate.sh に個別ケースを持たず、docs/ への直接書き込み権限がない。統括職は分析員チームのメタレビューを行う立場であり、docs/ の更新は原則として分析員が実行する。
+
+`docs/POLICY.md` は CLO 経由で編集する（`legal-analyst` は frontmatter で `Write` / `Edit` ツールを保有しないため、自身では POLICY.md を直接編集できない）。CLO 自身も role-gate.sh の docs/ 直接書き込み許可リストには含まれないため、POLICY.md の更新は CLO の判断のもと、組織運用フロー（COO による代行 / CEO 承認）を経て実施される。
 
 SM は組織運営ドキュメント `docs/ai-organization.md` のみ書き込み可能。他の docs/ ファイルには権限を持たない。
 

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -1,31 +1,92 @@
 # vibecorp ポリシー
 
-> このドキュメントはプロジェクト全体のポリシーを定義する Source of Truth です。
+> このドキュメントはプロジェクト全体のポリシーを定義する Source of Truth です。実運用の細則は `.claude/rules/` 配下と各 SOT ドキュメントに委ね、本ファイルでは大方針のみを定める。
 
 ## 開発ポリシー
 
 ### ブランチ戦略
 
-（ブランチ命名規則・マージ戦略を記載）
+ブランチ運用は Issue 駆動で行う（細則: [`.claude/rules/workflow.md`](../.claude/rules/workflow.md)）。
+
+| 種別 | パターン | 例 |
+|------|---------|-----|
+| 通常 Issue | `dev/{Issue番号}_{要約}` | `dev/123_add_login` |
+| 親エピック（feature ブランチ） | `feature/epic-{Issue番号}_{要約}` | `feature/epic-345_plan_epic_skill` |
+| エピック配下の子 Issue | `dev/{Issue番号}_{要約}` | `dev/346_ship_epic_child` |
+
+- 要約は英語スネークケース 2〜4 語
+- 直接 `main`（base_branch）で作業することは `protect-branch.sh` フックで禁止
+- マージ戦略は **squash merge**（GitHub auto-merge により CI パス + approve 後に自動マージ）
+- 親エピック feature ブランチは `/vibecorp:plan-epic`（full プリセット）が作成し、子 Issue の PR は親 feature ブランチを base に取る
 
 ### コードレビュー
 
-（レビューの必須条件・承認基準を記載）
+全 PR は CodeRabbit Bot レビュー必須（細則: [`.claude/rules/review-handling.md`](../.claude/rules/review-handling.md)）。
+
+修正対象の判定は **intent ラベル × severity** の掛け合わせで行う。
+
+| severity | 扱い |
+|---------|------|
+| 🔴 Critical | intent 問わず必ず対応 |
+| 🟠 Major | intent 問わず必ず対応 |
+| 🟡 Minor | intent の重視軸該当なら対応、外なら管轄外 |
+| 🔵 Trivial | intent の重視軸該当なら対応、外なら管轄外 |
+| ⚪ Info | intent の重視軸該当なら対応、外なら管轄外 |
+
+severity 定義は CodeRabbit 公式仕様に完全準拠する（[`.claude/rules/severity/coderabbit.md`](../.claude/rules/severity/coderabbit.md)）。1 PR 1 intent を厳守し、複数 intent にまたがる変更は Issue を分割する。
+
+承認基準は「CodeRabbit Bot の未解決指摘 0 件 + required CI パス」。`/vibecorp:pr-review-loop` が PR をマージまで監視し、auto-merge が GitHub 側で自動実行する。
 
 ### デプロイ
 
-（デプロイフロー・承認プロセスを記載）
+- main へのマージは PR auto-merge により実行される（手動 force push / 直接 commit は禁止）
+- リリースは GitHub Release（タグ + リリースノート）で行う
+- 自律改善ループ（`/vibecorp:diagnose` → `/vibecorp:autopilot` → `/vibecorp:ship-parallel`）は `.claude/rules/autonomous-restrictions.md` に列挙された **不可領域 6 分類** を CISO がフィルタリングし、人間（CEO）の明示承認が無いと自動実行されない
+  - 1: 認証 / 2: 暗号 / 3: 課金構造 / 4: ガードレール / 5: MVV / 6: CI エージェント権限
+- 上記不可領域に踏み込む変更は CEO 直接承認のもと、手動 Issue 起票 + `/vibecorp:ship` で実装する
 
 ## コミュニケーションポリシー
 
-（Issue・PR・ドキュメントの運用方針を記載）
+CEO への対話応答・Issue 本文・PR 本文・コミットメッセージ・監査レポートは [`communication.md`](../.claude/rules/communication.md) 規約に従う。
+
+- **動作主語で語る**: 「このソフトウェア／このフック／このスキルが〜になった／〜できるようになった」を使う。関数名・ファイルパス・diff で喋らない
+- **マークダウンと状態絵文字**: ✅（完了） / ⚠️（警告） / ❌（失敗） / 🚀（リリース） / 🔒（セキュリティ） / 🐛（バグ） / ✨（新機能） / 📖（ドキュメント） / 🔄（リファクタ） / 🧪（テスト） / 📍（根拠） / 🤖（エージェント）
+- **30 秒ルール**: CEO が 30 秒読んで「何が変わるか」を掴めることを目標にする
+- **intent ラベル**: Issue / PR には `intent/*` を 1 つだけ付与する（細則: [`.claude/rules/intent-labels.md`](../.claude/rules/intent-labels.md)）
+- **言語**: 応答・コードコメント・ログメッセージ・エラーメッセージは全て **日本語**で書く（変数名・関数名は英語可）
 
 ## 品質ポリシー
 
 ### テスト
 
-（テスト戦略・カバレッジ基準を記載）
+hooks やスクリプトを追加・変更した場合は、`tests/` 配下に対応するテストを必ず追加する（細則: [`.claude/rules/testing.md`](../.claude/rules/testing.md)）。
+
+- テストファイル命名規則: `test_*.sh`
+- CI で自動実行される前提で書く
+- 既存テストが壊れていないことを確認してからコミットする
+- `set -euo pipefail` 下のテストでは、前提ファイル不在時に `fail` だけでなく `exit 1` で早期終了する
+- `trap cleanup EXIT` 内のリソース解放コマンドには `|| true` を付けて失敗を無害化する（テスト結果に影響させない）
+
+カバレッジは「変更箇所の挙動が再現できる回帰テストを必ず添えること」を最低基準とする。intent ラベル別の重視軸（[`.claude/rules/review-observations.md`](../.claude/rules/review-observations.md)）に従い、bugfix では再現テスト、feature ではエッジケーステスト、performance ではベンチマークを必須とする。
 
 ### ドキュメント
 
-（ドキュメント管理方針を記載）
+ドキュメントは管轄を明確にし、各 SOT ファイルへの集約と相互リンクで運用する。
+
+| SOT ファイル | 管轄 | 内容 |
+|------------|------|------|
+| `MVV.md` | CEO のみ編集可 | ミッション・ビジョン・バリュー（プロダクトの根幹） |
+| `docs/POLICY.md` | CLO 経由（legal-analyst は Write 権限なし） | プロジェクト全体ポリシー（本ファイル） |
+| `docs/ai-organization.md` | SM | AI 組織運用方針 |
+| `docs/SECURITY.md` | security-analyst（直接編集） | セキュリティ方針・脅威モデル |
+| `docs/cost-analysis.md` | accounting-analyst（直接編集） | コスト分析・予算管理 |
+| `docs/specification.md` | CTO（技術スタック）/ CPO（プロダクト仕様） | プロダクト仕様 |
+| `docs/design-philosophy.md` | CTO | 技術設計指針 |
+| `docs/screen-flow.md` | CPO | UI / 画面遷移 |
+| `.claude/rules/*.md` | 全エージェント（管轄分） | 運用細則（本ファイルから委譲） |
+
+ドキュメント運用の細則:
+
+- **Markdown のフェンスコードブロックには必ず言語指定を付ける**: ` ```bash` / ` ```text` / ` ```markdown` 等を明示する（[`.claude/rules/markdown.md`](../.claude/rules/markdown.md)）
+- **コードコメントは実コードの挙動と一致させる**: 誤解を招くコメントはバグと同等に扱う（[`.claude/rules/comments.md`](../.claude/rules/comments.md)）
+- **管轄外ファイルの編集は禁止**: `role-gate.sh` フックが docs/ 配下の書き込みを管轄エージェントに制限する。管轄外の更新が必要な場合は管轄エージェントに承認を仰ぎ、管轄エージェントが代行する


### PR DESCRIPTION
## 概要

✅ `docs/POLICY.md` がプレースホルダなしで実運用方針（ブランチ戦略・コードレビュー・デプロイ・コミュニケーション・テスト・ドキュメント）を伝えるようになった
✅ `.claude/knowledge/sm/organization.md` の docs/ 書き込み権限テーブルが `docs/ai-organization.md` を SOT として整合するようになった

close https://github.com/hirokimry/vibecorp/issues/515

## 変更内容

### 📖 docs/POLICY.md（プレースホルダ → 実運用方針）

| セクション | 反映元 |
|----------|--------|
| 開発ポリシー / ブランチ戦略 | `.claude/rules/workflow.md` |
| 開発ポリシー / コードレビュー | `.claude/rules/review-handling.md`, `severity/coderabbit.md` |
| 開発ポリシー / デプロイ | `.claude/rules/workflow.md`, `autonomous-restrictions.md` |
| コミュニケーションポリシー | `.claude/rules/communication.md`, `intent-labels.md` |
| 品質ポリシー / テスト | `.claude/rules/testing.md` |
| 品質ポリシー / ドキュメント | `docs/ai-organization.md`, `markdown.md`, `comments.md` |

詳細な細則は既存の `.claude/rules/*` へのリンクで委譲し、SOT としての網羅性と簡潔さを両立した。

### 🔄 .claude/knowledge/sm/organization.md（記述衝突解消）

CPO レビューでの指摘により **`docs/ai-organization.md` を Source of Truth** として整合させた。

- accounting-analyst / security-analyst の直接編集権を ai-organization.md と一致させた
- legal-analyst が Write/Edit ツール非保有のため POLICY.md を直接編集できない旨を明記した
- POLICY.md は CLO 経由（COO 代行 / CEO 承認フロー）で編集される旨を明記した
- 「分析員 legal | docs/POLICY.md」の誤った記述を削除した

## 🔍 挙動不変性の確認（intent/docs 必須チェック）

ドキュメント変更がコード本体の挙動を要求していないことを確認した。

- ❌ `templates/claude/hooks/role-gate.sh` は変更していない
- ❌ `templates/claude/agents/*.md` の frontmatter `tools:` は変更していない
- ❌ `/vibecorp:*` スキルの挙動は変更していない
- ✅ 既存テスト全 pass（`tests/test_role_gate.sh` 36/36, `tests/test_protect_branch.sh` 35/35）

## 親 Issue / 分離した子課題

- 親 epic: #360
- 分離: `docs/cost-analysis.md` のプレースホルダ埋めは `autonomous-restrictions.md §3 課金構造` に明示列挙されているため CISO 除外判定。CEO 直接承認下で別 Issue 化が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * 組織内のドキュメント編集権限の役割別制御を明確化し、アクセス管理を強化しました。
  * ポリシードキュメントを大幅に充実させ、ブランチ戦略、マージプロセス、コードレビュー基準、デプロイメント制約、コミュニケーション規約、テスト要件、ドキュメント管理ガイドラインを定義しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->