### PR TITLE
🔄 refactor: install.sh の shellcheck 指摘 (SC2015 / SC2295) が解消された

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2062,9 +2062,11 @@ create_labels() {
     if echo "$existing_labels" | grep -qxF "$label_name"; then
       log_skip "ラベル '${label_name}' は既存のためスキップ"
     else
-      gh label create "$label_name" --color "$label_color" --description "$label_desc" 2>/dev/null \
-        && log_info "ラベル '${label_name}' を作成" \
-        || log_skip "ラベル '${label_name}' の作成に失敗（スキップ）"
+      if gh label create "$label_name" --color "$label_color" --description "$label_desc" 2>/dev/null; then
+        log_info "ラベル '${label_name}' を作成"
+      else
+        log_skip "ラベル '${label_name}' の作成に失敗（スキップ）"
+      fi
     fi
   done
 }
@@ -2078,7 +2080,7 @@ copy_rules() {
   # find -maxdepth 2 でサブディレクトリ 1 階層まで対応（深いネストは想定外）
   while IFS= read -r rule; do
     [[ -f "$rule" ]] || continue
-    local rel_path="${rule#${src}/}"  # 例: severity/coderabbit.md
+    local rel_path="${rule#"${src}"/}"  # 例: severity/coderabbit.md
     local rel_dir
     rel_dir=$(dirname "$rel_path")
     if [[ "$rel_dir" != "." ]]; then


### PR DESCRIPTION
## Summary

✅ `install.sh` の shellcheck info 指摘 2 件が解消され、無警告で通るようになった（挙動不変の refactor）。

- 🔄 ラベル作成の `gh label create ... && log_info ... || log_skip ...` を `if-then-else` 構造に書き換えた
  - `A && B || C` は「A 成功 → B、失敗 → C」ではなく、「B 失敗時にも C が走り得る」セマンティクスだった
  - 真の if-then-else に置換することで意図と挙動が一致するようになった
- 🔄 `${rule#${src}/}` を `${rule#"${src}"/}` に引用追加した
  - `${src}` が glob パターンとして解釈される余地を排除した
  - `${src}` 自体に glob メタ文字は含まれないため挙動不変

## 🧪 検証

- ✅ `shellcheck install.sh` が無警告（exit 0）になった
- ✅ `bash -n install.sh` 構文 OK
- ✅ `tests/test_install_intent_labels.sh` 37/37 pass（ラベル作成ロジック）
- ✅ `tests/test_install_review_md.sh` 40/40 pass（rules コピーロジック）

## 🔗

close https://github.com/hirokimry/vibecorp/issues/536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* インストールスクリプトの内部処理を改善しました。ラベル作成のエラーハンドリングとルールファイルパスの処理がより堅牢で正確になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->