### PR TITLE
🐛 fix: session-harvest 連続実行で knowledge/buffer ブランチが累積 divergence しなくなった

### DIFF
--- a/templates/claude/lib/knowledge_buffer.sh
+++ b/templates/claude/lib/knowledge_buffer.sh
@@ -196,14 +196,23 @@ knowledge_buffer_ensure() {
   if [ ! -d "$dir/.git" ] && [ ! -f "$dir/.git" ]; then
     # 古い worktree 参照が残っていれば prune
     git -C "$repo_root" worktree prune >/dev/null 2>&1 || true
-    # origin/main を最新化
-    if ! git -C "$repo_root" fetch origin main >/dev/null 2>&1; then
-      echo "[knowledge-buffer] git fetch origin main 失敗" >&2
+    # origin を最新化（knowledge/buffer も含めて全 ref を取得）
+    if ! git -C "$repo_root" fetch origin >/dev/null 2>&1; then
+      echo "[knowledge-buffer] git fetch origin 失敗" >&2
       return 1
     fi
+    # ベース選択: リモートに既存の knowledge/buffer 蓄積があればそれを引き継ぐ
+    # （別マシン初回 / cache クリア後の再作成で蓄積を破壊しないため）
+    # 無ければ origin/main から新規派生する（リポジトリ史上初の harvest）
+    local base_ref
+    if git -C "$repo_root" rev-parse --verify origin/knowledge/buffer >/dev/null 2>&1; then
+      base_ref="origin/knowledge/buffer"
+    else
+      base_ref="origin/main"
+    fi
     # worktree 作成（knowledge/buffer ブランチが未存在でも -B で作る）
-    if ! git -C "$repo_root" worktree add -B knowledge/buffer "$dir" origin/main >/dev/null 2>&1; then
-      echo "[knowledge-buffer] git worktree add 失敗: ${dir}" >&2
+    if ! git -C "$repo_root" worktree add -B knowledge/buffer "$dir" "$base_ref" >/dev/null 2>&1; then
+      echo "[knowledge-buffer] git worktree add 失敗: ${dir} (base=${base_ref})" >&2
       return 1
     fi
     return 0
@@ -230,9 +239,12 @@ knowledge_buffer_ensure() {
     return 1
   fi
 
-  echo "[knowledge-buffer] ff 失敗のため origin/main にリセットします" >&2
-  if ! git -C "$dir" reset --hard origin/main >/dev/null 2>&1; then
-    echo "[knowledge-buffer] reset --hard origin/main 失敗" >&2
+  # ff 失敗時は origin/knowledge/buffer にリセットする（origin/main にリセットすると
+  # まだ knowledge-pr で main に反映していない harvest 蓄積を破壊するため）。
+  # unpushed 検査で abort 済みなので、未 push の harvest commit ロストは発生しない。
+  echo "[knowledge-buffer] ff 失敗のため origin/knowledge/buffer にリセットします（蓄積保持）" >&2
+  if ! git -C "$dir" reset --hard origin/knowledge/buffer >/dev/null 2>&1; then
+    echo "[knowledge-buffer] reset --hard origin/knowledge/buffer 失敗" >&2
     return 1
   fi
   return 0
@@ -280,6 +292,11 @@ knowledge_buffer_commit() {
   local dir
   dir="$(knowledge_buffer_worktree_dir)"
   git -C "$dir" add -A
+  # .buffer.lock.d/ は worktree 排他ロック用 pid 格納で commit に含めない
+  # - 通常: lock 取得中の pid file が staged された状態で commit に混入するのを防ぐ
+  # - 異常時: 過去 orphan で committed された .buffer.lock.d/ も同時に index から除去される
+  #   （次回 commit で履歴上から消え、孤児ロック→ lock acquire timeout の再発を防ぐ）
+  git -C "$dir" rm --cached -r -f -- .buffer.lock.d 2>/dev/null || true
 
   # 差分なしならスキップ
   if git -C "$dir" diff --cached --quiet; then

--- a/tests/test_knowledge_buffer.sh
+++ b/tests/test_knowledge_buffer.sh
@@ -245,6 +245,119 @@ assert_eq "push 失敗時 exit 3" "3" "$PUSH_EXIT"
 
 # ============================================
 echo ""
+echo "=== ensure: 蓄積保持シナリオ (Issue #541) ==="
+# ============================================
+
+# 復旧用 origin を作り直す（push 失敗テストで origin が破壊されているため）
+git init --bare "$ORIGIN_REPO" >/dev/null 2>&1
+git -C "$ORIGIN_REPO" symbolic-ref HEAD refs/heads/main
+git -C "$WORK_REPO" push origin main >/dev/null 2>&1
+
+# まず buffer worktree を初期化し、harvest 1 件目を push して origin/knowledge/buffer を作る
+rm -rf "$WORKTREE_DIR"
+git -C "$WORK_REPO" worktree prune >/dev/null 2>&1 || true
+git -C "$WORK_REPO" branch -D knowledge/buffer 2>/dev/null || true
+knowledge_buffer_ensure >/dev/null 2>&1
+echo "harvest #1" > "$(knowledge_buffer_path 'harvest-1.txt')"
+knowledge_buffer_commit "test: harvest 1" >/dev/null 2>&1
+knowledge_buffer_push >/dev/null 2>&1
+
+# シナリオ A（別マシン初回）: worktree dir を削除した状態から ensure() →
+# origin/knowledge/buffer をベースに作り直すことで harvest 蓄積を引き継ぐ
+rm -rf "$WORKTREE_DIR"
+git -C "$WORK_REPO" worktree prune >/dev/null 2>&1 || true
+git -C "$WORK_REPO" branch -D knowledge/buffer 2>/dev/null || true
+if knowledge_buffer_ensure >/dev/null 2>&1; then
+  pass "ensure: cache クリア後に origin/knowledge/buffer から復元する"
+else
+  fail "ensure: cache クリア後の復元に失敗"
+fi
+if [ -f "$(knowledge_buffer_path 'harvest-1.txt')" ]; then
+  pass "ensure: 復元後に過去 harvest が working tree に存在する"
+else
+  fail "ensure: 復元後に過去 harvest が消失している（origin/main から派生してしまった）"
+fi
+
+# シナリオ B（ff 失敗時の reset 先）: 別 worktree からリモートに同一ファイルへの変更を
+# push し、ローカル側でも同じファイルを汚す。pull --ff-only が dirty tree コンフリクトで
+# 失敗する経路を作り、ensure() が origin/main ではなく origin/knowledge/buffer に
+# reset することを検証する。
+TMP_WT="${TMPDIR_ROOT}/tmp-buffer-wt"
+git -C "$WORK_REPO" worktree add -B tmp-buffer "$TMP_WT" origin/knowledge/buffer >/dev/null 2>&1
+echo "remote modification" >> "${TMP_WT}/harvest-1.txt"
+git -C "$TMP_WT" add -A >/dev/null 2>&1
+git -C "$TMP_WT" commit -m "remote: harvest-1 を変更" >/dev/null 2>&1
+git -C "$TMP_WT" push origin tmp-buffer:knowledge/buffer >/dev/null 2>&1
+git -C "$WORK_REPO" worktree remove --force "$TMP_WT" >/dev/null 2>&1
+git -C "$WORK_REPO" branch -D tmp-buffer >/dev/null 2>&1
+
+# ローカル dirty: 同じファイルを汚すと pull --ff-only がコンフリクトで失敗する
+echo "local dirty change" >> "$(knowledge_buffer_path 'harvest-1.txt')"
+
+ENSURE_OUT=$(knowledge_buffer_ensure 2>&1) || true
+HEAD_AFTER=$(git -C "$WORKTREE_DIR" rev-parse HEAD)
+ORIGIN_BUFFER_AFTER=$(git -C "$WORKTREE_DIR" rev-parse origin/knowledge/buffer)
+assert_eq "ensure: ff 失敗時に origin/knowledge/buffer にリセットする" \
+  "$ORIGIN_BUFFER_AFTER" "$HEAD_AFTER"
+assert_contains "ensure: リセット先メッセージが origin/knowledge/buffer を示す" \
+  "origin/knowledge/buffer" "$ENSURE_OUT"
+
+# Issue #541 リグレッション防止: ソースコードに `reset --hard origin/main` が残っていないこと
+if grep -qF -- 'reset --hard origin/main' "$LIB"; then
+  fail "regression: knowledge_buffer.sh が依然として origin/main へリセットしている (Issue #541)"
+else
+  pass "knowledge_buffer.sh は origin/main へリセットしない (Issue #541 修正済)"
+fi
+
+# ============================================
+echo ""
+echo "=== commit: lock dir 除外 (Issue #541) ==="
+# ============================================
+
+# lock 取得中に commit が呼ばれても .buffer.lock.d/ が commit に含まれないこと
+knowledge_buffer_lock_acquire >/dev/null 2>&1
+LOCK_PID_FILE="${WORKTREE_DIR}/.buffer.lock.d/pid"
+if [ -f "$LOCK_PID_FILE" ]; then
+  pass "lock_acquire: lock pid file が working tree に作成される"
+else
+  fail "lock_acquire: lock pid file が作成されていない"
+fi
+echo "note while locked" > "$(knowledge_buffer_path 'locked-note.txt')"
+knowledge_buffer_commit "test: lock 取得中のコミット" >/dev/null 2>&1
+TRACKED=$(git -C "$WORKTREE_DIR" ls-tree -r HEAD --name-only)
+if echo "$TRACKED" | grep -q '^\.buffer\.lock\.d/'; then
+  fail "commit: lock dir が commit に含まれてしまった"
+else
+  pass "commit: lock dir が commit に含まれない"
+fi
+knowledge_buffer_lock_release
+
+# orphan な .buffer.lock.d/ が HEAD にある状態 → 次の commit で削除される（自動掃除）
+mkdir -p "${WORKTREE_DIR}/.buffer.lock.d"
+echo 99999 > "${WORKTREE_DIR}/.buffer.lock.d/pid"
+git -C "$WORKTREE_DIR" add -f .buffer.lock.d/pid >/dev/null 2>&1
+git -C "$WORKTREE_DIR" commit -m "test: simulate orphan lock" >/dev/null 2>&1
+TRACKED_BEFORE=$(git -C "$WORKTREE_DIR" ls-tree -r HEAD --name-only)
+if echo "$TRACKED_BEFORE" | grep -q '^\.buffer\.lock\.d/pid$'; then
+  pass "前提: orphan lock dir が HEAD に含まれている状態を再現できた"
+else
+  fail "前提: orphan lock dir 再現に失敗"
+fi
+echo "next harvest" > "$(knowledge_buffer_path 'next-harvest.txt')"
+knowledge_buffer_commit "test: orphan 自動掃除" >/dev/null 2>&1
+TRACKED_AFTER=$(git -C "$WORKTREE_DIR" ls-tree -r HEAD --name-only)
+if echo "$TRACKED_AFTER" | grep -q '^\.buffer\.lock\.d/'; then
+  fail "commit: orphan な lock dir が次の commit でも残存している"
+else
+  pass "commit: orphan な lock dir が次の commit で削除される（自動掃除）"
+fi
+
+# 後続の lock テスト用に working tree の .buffer.lock.d/ を片付ける
+# （rm --cached は index からのみ除去し、working tree のディレクトリは残るため）
+rm -rf "${WORKTREE_DIR}/.buffer.lock.d"
+
+# ============================================
+echo ""
 echo "=== knowledge_buffer_lock ==="
 # ============================================
 


### PR DESCRIPTION
## 関連 Issue

close https://github.com/hirokimry/vibecorp/issues/541

## 概要

✅ `/vibecorp:session-harvest` を複数回実行しても `knowledge/buffer` ブランチが累積 divergence しなくなり、リモート push が永続的に non-fast-forward で reject される不具合が解消された。

### Before / After

| 観点 | Before（不具合） | After（修正後） |
|---|---|---|
| 新規 worktree のベース | 必ず `origin/main` から切る → 別マシン初回 / cache クリア後の再作成でリモート蓄積を捨ててしまう | `origin/knowledge/buffer` が存在すれば優先、なければ `origin/main`（初回 push 前のフォールバック）|
| ff 失敗時のリセット先 | `origin/main` → 過去の harvest 蓄積が破壊される | `origin/knowledge/buffer` → 蓄積を保持したまま頭出しだけ揃える |
| commit に混入する内容 | `.buffer.lock.d/` の lock pid file が紛れ込む可能性 | index から除外 + orphan lock dir の自動掃除 |

未 push commit がある場合は依然として abort して保全されるため、データロス経路は閉じている。

## テスト計画

- [x] `tests/test_knowledge_buffer.sh` で 32/32 全 pass
- [x] 新規追加テスト 9 件: 蓄積保持シナリオ A/B + lock dir 除外 + リグレッション防止（`origin/main` リセットの再発検知）
- [x] CI（test-ubuntu / intent label / PR Issue 参照）が通る

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * バッファの作業ツリー初期化で、欠損時に適切なリモート参照を選んで復元するよう改善しました（復元先を知識用ブランチ優先に変更）。
  * フェッチ/プル失敗時のリセット先を正しい知識用ブランチに変更し、復旧ログを改善しました。
  * ロック管理ディレクトリがコミットに含まれる問題を修正し、既存の孤立したロック状態も自動で掃除します。

* **テスト**
  * 回帰防止とロック／ブランチ復旧の動作確認テストを追加・強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->