### PR TITLE
📖 docs: README のアップデート手順にスキル更新コマンドが追記される

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,30 @@ path/to/vibecorp/install.sh --name your-project --version v1.0.0
 
 ### アップデート
 
+vibecorp の更新は **以下の 3 ステップを順番に実行する** のが正しい手順。`install.sh --update` は hooks / agents / rules / docs / settings.json / `.claude-plugin/plugin.json`（version マニフェスト）等は更新するが、**スキル本体（`/vibecorp:*`）はプラグインキャッシュから配信される別経路** のため、Claude Code の `/plugin update` を別途実行しないとスキルが古いまま放置される。
+
 ```bash
-# vibecorp リポジトリを最新化
+# 1. vibecorp リポジトリを最新化
 cd path/to/vibecorp && git pull
 
-# 導入先リポジトリに移動してアップデート実行
+# 2. 導入先リポジトリに移動してインストーラを再実行
 cd your-project
 path/to/vibecorp/install.sh --update
 ```
 
-`--update` 実行時にバージョン差分がある場合、自動的に表示される。
+```bash
+# 3. Claude Code を起動して、スキル本体を最新版に更新する
+/plugin update vibecorp --scope project
+```
+
+`--update` 実行時にバージョン差分がある場合、自動的に表示される。`/plugin update` は既に最新の場合「already at the latest version」と返すだけなので毎回実行しても安全。
+
+#### `install.sh --update` で更新されるもの／されないもの
+
+| 配信経路 | 更新方法 |
+|---------|---------|
+| hooks / agents / rules / docs / knowledge / lib / settings.json / vibecorp.yml / `.claude-plugin/plugin.json`（version マニフェスト）/ CI workflow | `install.sh --update` |
+| **skills（`/vibecorp:*`）** | **`/plugin update vibecorp --scope project`**（プラグインキャッシュ `~/.claude/plugins/cache/` 経由で配信されるため別経路） |
 
 > **Note**: vibecorp 0.3.0 リリース（2026-05-03）から #540 修正前までに `--update` を流した利用者は、`.claude-plugin/plugin.json` の `version` が 0.3.0 → 0.2.0 にダウングレードされている可能性があります。修正版の vibecorp を `git pull` 後に再度 `path/to/vibecorp/install.sh --update` を実行すれば自動的に最新 version へ復旧します。明示的なマイグレーションは不要です。
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ path/to/vibecorp/install.sh --name your-project --version v1.0.0
 
 ### アップデート
 
-vibecorp の更新は **以下の 3 ステップを順番に実行する** のが正しい手順。`install.sh --update` は hooks / agents / rules / docs / settings.json / `.claude-plugin/plugin.json`（version マニフェスト）等は更新するが、**スキル本体（`/vibecorp:*`）はプラグインキャッシュから配信される別経路** のため、Claude Code の `/plugin update` を別途実行しないとスキルが古いまま放置される。
+vibecorp の更新は **以下の 3 ステップを順番に実行する** のが正しい手順。`install.sh --update` は hooks / agents / rules / docs（新規・未管理分の反映）/ settings.json / `.claude-plugin/plugin.json`（version マニフェスト）等を更新するが、**スキル本体（`/vibecorp:*`）はプラグインキャッシュから配信される別経路** のため、Claude Code の `/plugin update` を別途実行しないとスキルが古いまま放置される。
 
 ```bash
 # 1. vibecorp リポジトリを最新化


### PR DESCRIPTION
## 📖 概要

✅ README の「アップデート」節が **3 ステップ構成** に書き換わり、`install.sh --update` だけで終わって `/vibecorp:*` スキルが古いまま放置される事故経路がふさがった。

利用者は今後、3 番目のステップとして Claude Code を起動して `/plugin update vibecorp --scope project` を実行することで、**プラグインキャッシュ経由配信のスキル本体** も最新化できるようになった。

## 📊 Before / After

| 観点 | Before | After |
|---|---|---|
| 「正しいアップデート手順」 | 2 ステップ（`git pull` → `install.sh --update`）として記載 | **3 ステップ**（`git pull` → `install.sh --update` → `/plugin update vibecorp --scope project`）として記載 |
| `install.sh --update` の更新範囲 | 文中に散在 | **テーブルで明示**（更新されるもの／されないもの） |
| skills 更新経路 | 記載なし（`grep -i "plugin update" README.md` → 0 件） | テーブルに **`/plugin update vibecorp --scope project`** を明記（grep → 4 件） |
| スキル配信経路の周知 | line 37 に 1 箇所 | アップデート節のテーブルでも 30 秒で掴める |

## 🔍 主な変更

- 📍 `README.md` 46-73 行目「アップデート」節
  - 冒頭に「3 ステップを順番に実行するのが正しい手順」と断定的な前置きを追加
  - コードブロックを 2 つに分割（`install.sh --update` までと `/plugin update` の Claude Code 内コマンドを分離）
  - 「`install.sh --update` で更新されるもの／されないもの」テーブルを追加
  - `/plugin update` が「already at the latest version」を返すため毎回実行可能である旨を補足
  - 既存の 0.3.0 ダウングレード Note は保持

## ⚠️ 懸念事項

- なし。intent/docs（挙動不変系）であり、コード本体・hooks・install.sh には触れていない

## ✅ 完了条件

Issue #567 の完了条件を全て満たした:

- ✅ 3 ステップ目として `/plugin update vibecorp --scope project` が追記
- ✅ 「更新されるもの／されないもの」テーブル追加、skills がプラグインキャッシュ経由である事実を明記
- ✅ 3 ステップが「正しいアップデート手順」と断定的に書かれている
- ✅ `grep -i "plugin update" README.md` が 4 件ヒット（0 → 4）
- ✅ サンプルコマンド構文が Claude Code 公式（`<plugin> [options]`、`-s, --scope <scope>`）と一致

close https://github.com/hirokimry/vibecorp/issues/567


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * READMEの「アップデート」手順を3ステップ構成に明確化。install.sh --update で更新される項目／されない項目を表で示し、スキル本体（/vibecorp:*）は自動更新されないため、個別に `plugin update vibecorp --scope project` を実行する手順（Step 3）を追加。スキルがプラグインキャッシュ経由で配信される点も明記しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hirokimry/vibecorp/pull/568)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->