### PR TITLE
🐛 fix: LICENSE の Copyright 年が 2026 になり事実と整合するようになった

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 hirokimry
+Copyright (c) 2026 hirokimry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## 関連 Issue

close https://github.com/hirokimry/vibecorp/issues/583

## 概要

🐛 LICENSE の Copyright 年がプロジェクト発足年（2026）と一致するようになった。

### Before / After

- **Before**: `Copyright (c) 2025 hirokimry`
- **After**: `Copyright (c) 2026 hirokimry`

### 動作の変化

- ✅ LICENSE の Copyright 表記が事実（vibecorp 初回コミット: 2026-03-20）と整合するようになった
- ✅ Issue #580 内で CEO が明示指定した `Copyright (c) 2026 hirokimry` と一致するようになった
- ✅ GitHub の自動ライセンス認識は MIT のまま動作する（MIT 本文 4 行目以降は変更なし）

### 懸念事項

- なし（LICENSE 1 ファイル 1 行のみの修正、本文は完全維持）

## テスト計画

- [x] `grep -E '^Copyright \(c\) 2026 hirokimry$' LICENSE` が 1 件マッチする
- [x] `grep -cE '^Copyright \(c\) 2025' LICENSE` が `0` を返す
- [x] `grep -c '^MIT License$' LICENSE` が `1` を返す（MIT ヘッダ維持）
- [ ] PR マージ後、GitHub UI の右サイドバーに "MIT License" が表示される

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ライセンス情報の著作権表示を更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hirokimry/vibecorp/pull/584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->