### PR TITLE
🐛 fix: worktree 配下からも main と同じ repo_id が生成され、guide-gate / sync-gate / review-gate のスタンプが共有されるようになった

### DIFF
--- a/templates/claude/lib/common.sh
+++ b/templates/claude/lib/common.sh
@@ -73,11 +73,29 @@ _vibecorp_sha256_short() {
 # 出力例: vibecorp-a1b2c3d4
 # 形式: <basename（サニタイズ済み）>-<sha256先頭8桁>
 # ゲートスタンプ（vibecorp_stamp_dir）と knowledge/buffer worktree（knowledge_buffer.sh）で共有する
+#
+# worktree 対応: `--git-common-dir` は main repo の .git ディレクトリを常に返すため、
+# main / 各 worktree のどこから呼んでも同一 repo_id が生成される。
+# `--show-toplevel` は worktree ごとに別パスを返すため不可（Issue #600）。
 vibecorp_repo_id() {
   local root
-  if ! root="$(git -C "${CLAUDE_PROJECT_DIR:-$PWD}" rev-parse --show-toplevel 2>/dev/null)"; then
-    root="${CLAUDE_PROJECT_DIR:-$PWD}"
-    echo "vibecorp_repo_id: git toplevel 取得に失敗、フォールバック使用: ${root}" >&2
+  local common_dir
+  local start_dir="${CLAUDE_PROJECT_DIR:-$PWD}"
+  if common_dir="$(git -C "$start_dir" rev-parse --git-common-dir 2>/dev/null)"; then
+    # common_dir は main では ".git"（相対）、worktree では絶対パスを返すため正規化する
+    if [[ "$common_dir" != /* ]]; then
+      common_dir="$start_dir/$common_dir"
+    fi
+    # main repo root = .git の親ディレクトリ。
+    # `pwd -P` で物理パスに正規化する（macOS の /tmp → /private/tmp 等のシンボリックリンクで
+    #  main と worktree の解決パスが食い違うのを防ぐ）
+    if ! root="$(cd "$(dirname "$common_dir")" 2>/dev/null && pwd -P)"; then
+      root="$start_dir"
+      echo "vibecorp_repo_id: git common-dir 解決に失敗、フォールバック使用: ${root}" >&2
+    fi
+  else
+    root="$start_dir"
+    echo "vibecorp_repo_id: git common-dir 取得に失敗、フォールバック使用: ${root}" >&2
   fi
   # basename をサニタイズ（shell.md「ファイル名に外部入力を使う場合」ルール準拠）
   # printf で trailing newline を剥がしてから tr に渡す（改行が "_" に変換される副作用を防ぐ）

--- a/tests/test_repo_id_worktree.sh
+++ b/tests/test_repo_id_worktree.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# test_repo_id_worktree.sh — vibecorp_repo_id が main / worktree で同一 ID を返すことを検証
+# 使い方: bash tests/test_repo_id_worktree.sh
+# CI: GitHub Actions で自動実行
+#
+# Issue #600 のリグレッション防止:
+# - 旧実装は `git rev-parse --show-toplevel` ベースで worktree ごとに別 ID を生成し、
+#   guide-gate / sync-gate / review-gate のスタンプ消費が成立しなかった。
+# - 新実装は `git rev-parse --git-common-dir` ベースで main の .git を常に指すため、
+#   main / 各 worktree のどこから呼んでも同一 ID が生成される。
+
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${TESTS_DIR}/lib/test_helpers.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LIB="${SCRIPT_DIR}/templates/claude/lib/common.sh"
+
+# 前提ファイル確認
+if [[ ! -f "$LIB" ]]; then
+  fail "前提: $LIB が存在する"
+  # 前提ファイル不在 → 後続テストは全て無意味なので即終了
+  exit 1
+fi
+
+# ============================================
+echo "=== 一時 git リポジトリと worktree を作成 ==="
+# ============================================
+
+TMPROOT="$(mktemp -d)"
+
+cleanup() {
+  # worktree を先に除去（main を消すと worktree 側 git も壊れる）
+  if [[ -d "${TMPROOT}/main" ]]; then
+    git -C "${TMPROOT}/main" worktree remove --force "${TMPROOT}/wt1" 2>/dev/null || true
+    git -C "${TMPROOT}/main" worktree remove --force "${TMPROOT}/wt2" 2>/dev/null || true
+  fi
+  rm -rf "$TMPROOT" || true
+}
+trap cleanup EXIT
+
+# main リポジトリ作成（vibecorp という名前で）
+mkdir -p "${TMPROOT}/main"
+git -C "${TMPROOT}/main" init -q -b main
+git -C "${TMPROOT}/main" config user.email "test@example.com"
+git -C "${TMPROOT}/main" config user.name "test"
+echo "init" > "${TMPROOT}/main/README.md"
+git -C "${TMPROOT}/main" add README.md
+git -C "${TMPROOT}/main" commit -q -m "init"
+
+# worktree 2 つ作成（パス名は意図的に main と異なる）
+git -C "${TMPROOT}/main" worktree add -q -b feature/test1 "${TMPROOT}/wt1" >/dev/null 2>&1
+git -C "${TMPROOT}/main" worktree add -q -b feature/test2 "${TMPROOT}/wt2" >/dev/null 2>&1
+
+pass "main / wt1 / wt2 の git リポジトリ準備"
+
+# ============================================
+echo ""
+echo "=== vibecorp_repo_id が main / worktree で同一 ==="
+# ============================================
+
+# サブシェルで独立評価（CLAUDE_PROJECT_DIR の汚染を避ける）
+ID_MAIN="$(unset CLAUDE_PROJECT_DIR; cd "${TMPROOT}/main" && bash -c "source '$LIB' && vibecorp_repo_id")"
+ID_WT1="$(unset CLAUDE_PROJECT_DIR; cd "${TMPROOT}/wt1" && bash -c "source '$LIB' && vibecorp_repo_id")"
+ID_WT2="$(unset CLAUDE_PROJECT_DIR; cd "${TMPROOT}/wt2" && bash -c "source '$LIB' && vibecorp_repo_id")"
+
+echo "  main repo_id: $ID_MAIN"
+echo "  wt1 repo_id:  $ID_WT1"
+echo "  wt2 repo_id:  $ID_WT2"
+
+assert_eq "main と wt1 の repo_id が一致する" "$ID_MAIN" "$ID_WT1"
+assert_eq "main と wt2 の repo_id が一致する" "$ID_MAIN" "$ID_WT2"
+assert_eq "wt1 と wt2 の repo_id が一致する" "$ID_WT1" "$ID_WT2"
+
+# ============================================
+echo ""
+echo "=== ID の構成要素: basename は main 側の名前 ==="
+# ============================================
+
+# 期待: main ディレクトリ名は "main" なので prefix は "main-..."
+# basename が main / wt1 / wt2 のどれを使うかで差が出る → main を採用していることを確認
+case "$ID_WT1" in
+  main-*)
+    pass "worktree から呼んでも basename は main 側を使う"
+    ;;
+  *)
+    fail "worktree から呼んだ basename が main を指していない（実際: '$ID_WT1'）"
+    ;;
+esac
+
+# ============================================
+echo ""
+echo "=== CLAUDE_PROJECT_DIR が worktree でも main の repo_id が返る ==="
+# ============================================
+
+# 実運用: Claude Code 親プロセスは main で起動するが、子プロセスが worktree 内ファイルを
+# 編集する際は CLAUDE_PROJECT_DIR=worktree でも main のスタンプを参照したい
+ID_VIA_WT_ENV="$(CLAUDE_PROJECT_DIR="${TMPROOT}/wt1" bash -c "source '$LIB' && vibecorp_repo_id")"
+assert_eq "CLAUDE_PROJECT_DIR=worktree でも main の repo_id が返る" "$ID_MAIN" "$ID_VIA_WT_ENV"
+
+# ============================================
+echo ""
+echo "=== vibecorp_stamp_path / vibecorp_stamp_dir も worktree 共有 ==="
+# ============================================
+
+STAMP_MAIN="$(unset CLAUDE_PROJECT_DIR; cd "${TMPROOT}/main" && bash -c "source '$LIB' && vibecorp_stamp_path guide")"
+STAMP_WT1="$(unset CLAUDE_PROJECT_DIR; cd "${TMPROOT}/wt1" && bash -c "source '$LIB' && vibecorp_stamp_path guide")"
+
+assert_eq "guide スタンプパスが main / worktree で一致する" "$STAMP_MAIN" "$STAMP_WT1"
+
+# ============================================
+echo ""
+echo "=== 非 git ディレクトリ: フォールバックで PWD ベースの ID を返す ==="
+# ============================================
+
+NON_GIT="${TMPROOT}/notgit"
+mkdir -p "$NON_GIT"
+ID_NON_GIT="$(unset CLAUDE_PROJECT_DIR; cd "$NON_GIT" && bash -c "source '$LIB' && vibecorp_repo_id" 2>/dev/null)"
+
+# フォールバック ID は notgit ディレクトリ名で始まるはず（git common-dir 失敗 → start_dir に倒れる）
+case "$ID_NON_GIT" in
+  notgit-*)
+    pass "非 git ディレクトリでフォールバック ID を返す"
+    ;;
+  *)
+    fail "非 git ディレクトリでフォールバック ID が不正（実際: '$ID_NON_GIT'）"
+    ;;
+esac
+
+# ============================================
+echo ""
+print_test_summary

--- a/tests/test_stamp_path.sh
+++ b/tests/test_stamp_path.sh
@@ -122,13 +122,13 @@ else
   fail "同 basename・別パスで同じディレクトリが生成された (${DIR_SA})"
 fi
 
-# --- ケース 6: git 外（git toplevel 取得失敗）でフォールバック + stderr 警告 ---
+# --- ケース 6: git 外（git common-dir 取得失敗）でフォールバック + stderr 警告 ---
 
 echo "Test 6: git 外で stderr 警告が出る"
 NON_GIT_DIR="${TMPDIR_ROOT}/non-git"
 mkdir -p "$NON_GIT_DIR"
 STDERR_OUT=$( cd "$NON_GIT_DIR" && CLAUDE_PROJECT_DIR="$NON_GIT_DIR" vibecorp_stamp_dir 2>&1 >/dev/null )
-assert_contains "git 外で stderr 警告" "git toplevel 取得に失敗" "$STDERR_OUT"
+assert_contains "git 外で stderr 警告" "git common-dir 取得に失敗" "$STDERR_OUT"
 
 STDOUT_OUT=$( cd "$NON_GIT_DIR" && CLAUDE_PROJECT_DIR="$NON_GIT_DIR" vibecorp_stamp_dir 2>/dev/null )
 assert_starts_with "git 外でもパスは生成される" "${HOME}/.cache/vibecorp/state/non-git-" "$STDOUT_OUT"
@@ -297,9 +297,11 @@ CACHE_ROOT_NOHOME=$( cd "$REPO_DIR" && env -u HOME -u XDG_CACHE_HOME CLAUDE_PROJ
 # HOME 未設定時は "${HOME}/.cache" → "/.cache" になる（関数自体は失敗しない）
 assert_eq "HOME 未設定で vibecorp_cache_root が /.cache を返す" "/.cache" "$CACHE_ROOT_NOHOME"
 
-# --- ケース 14: worktree で repo-id が親と異なる ---
+# --- ケース 14: worktree と親 main で repo-id が同一（Issue #600 修正後の前提） ---
+# git-common-dir ベースで main の .git を常に指すため、main / worktree のどこから呼んでも
+# 同一 repo-id が生成され、guide-gate / sync-gate / review-gate のスタンプが共有される。
 
-echo "Test 14: git worktree で repo-id が親とは別（plans 自動分離の保証）"
+echo "Test 14: git worktree で repo-id が親と同一（スタンプ共有の保証）"
 WT_MAIN="${TMPDIR_ROOT}/wt-main"
 mkdir -p "$WT_MAIN"
 ( cd "$WT_MAIN" && git init -q -b main . && git config user.email t@example.com && git config user.name t && git commit -q --allow-empty -m init )
@@ -309,10 +311,10 @@ WT_CHILD="${TMPDIR_ROOT}/wt-child"
 ID_MAIN=$( cd "$WT_MAIN" && CLAUDE_PROJECT_DIR="$WT_MAIN" vibecorp_repo_id )
 ID_CHILD=$( cd "$WT_CHILD" && CLAUDE_PROJECT_DIR="$WT_CHILD" vibecorp_repo_id )
 
-if [ "$ID_MAIN" != "$ID_CHILD" ]; then
-  pass "worktree で repo-id が親と異なる (main=${ID_MAIN}, child=${ID_CHILD})"
+if [ "$ID_MAIN" = "$ID_CHILD" ]; then
+  pass "worktree で repo-id が親と同一 (${ID_MAIN})"
 else
-  fail "worktree で repo-id が親と同じ (${ID_MAIN})"
+  fail "worktree で repo-id が親と異なる (main=${ID_MAIN}, child=${ID_CHILD})"
 fi
 
 # worktree を片付け（後続テストに影響しないように）


### PR DESCRIPTION
> ⏸️ **auto-merge 解除済み / CEO レビュー待ち**
> 本 PR は手動 merge 前提。`gh pr merge --auto` は設定していない。

close https://github.com/hirokimry/vibecorp/issues/600

## ✅ 変更で何ができるようになったか

- ✅ worktree 配下から `.claude/` を編集しても **guide-gate / sync-gate / review-gate のスタンプが正しく消費される**ようになった
- ✅ main と worktree の **両方で同一 `repo_id` が生成される**ようになり、`~/.cache/vibecorp/state/<repo-id>/` が共有される
- ✅ 各 Agent が「claude-code-guide を 3 回呼び直す」「手動 `touch` でスタンプ偽造」といった workaround を**取らなくて済むようになった**
- ✅ macOS の `/tmp` → `/private/tmp` シンボリックリンク差で repo_id が食い違うケースも**物理パス正規化で吸収**されるようになった

## 🔧 何を変えたか

| ファイル | 変更内容 |
|---|---|
| `templates/claude/lib/common.sh` | `vibecorp_repo_id()` を `git rev-parse --show-toplevel` ベース → `--git-common-dir` ベースに変更。`pwd -P` で物理パス正規化を追加 |
| `tests/test_repo_id_worktree.sh` | 新設。main / 複数 worktree 間で同一 repo_id を返すことを assert（8 ケース）|

> ⚠️ `.claude/lib/common.sh` は `.gitignore` 対象（`install.sh` が `templates/claude/lib/*.sh` を自動コピー）。
> 既存環境への反映は `install.sh --update` を再実行する。

## 🧪 検証結果

| テスト | 結果 |
|---|---|
| 🆕 `tests/test_repo_id_worktree.sh` | ✅ 8/8 passed |
| `tests/test_common_lib.sh` | ✅ 17/17 passed |
| `tests/test_common.sh` | ✅ 7/7 passed |
| `tests/test_guide_gate.sh` | ✅ 24/24 passed |
| `tests/test_sync_gate.sh` | ✅ 13/13 passed |
| `tests/test_review_gate.sh` | ✅ 12/12 passed |
| `tests/test_worktree.sh` | ✅ 27/27 passed |

### 実機検証（CEO 環境）

```bash
# main repo
$ source templates/claude/lib/common.sh && vibecorp_repo_id
vibecorp-54064690

# worktree (dev_600_repo_id_worktree_fix)
$ source templates/claude/lib/common.sh && vibecorp_repo_id
vibecorp-54064690   # ← main と一致
```

## 🛡️ セキュリティ観点

- ✅ ガードレールを**強化**する方向の修正（worktree でも hook が正しく走るようになる）
- ✅ 既存ガードレールを**緩めていない**
- ✅ `--git-common-dir` は git 標準コマンドで信頼性が高い（claude-code-guide にも確認済み）
- ⚠️ 旧 `repo_id` 配下の `~/.cache/vibecorp/state/<旧 id>/` は孤児スタンプとして残る（手動 cleanup 想定、別 Issue 化候補）

## 🚧 スコープ外（別 Issue）

- 旧 repo_id 配下スタンプの自動 cleanup
- knowledge/buffer worktree の repo_id 共有検証


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * Git の共通ディレクトリ判定を使ったリポジトリ識別子生成を改善し、メインとワークツリーで同一のリポジトリIDが返るようにしました。非Gitパス時のフォールバックID生成も安定化しています。
  * 取得失敗時の警告文言を更新しました。

* **テスト**
  * ワークツリー間でIDが一致することやスタンプパスの整合性を検証するテストを追加／更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hirokimry/vibecorp/pull/603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->