### PR TITLE
📖 docs: README.md と CHANGELOG.md が document-writing.md 基準で書き直される (#595 PR-a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,41 @@
 # Changelog
 
+> [!NOTE]
+> 利用者（vibecorp を導入するプロジェクト）向けのリリース別変更点一覧。
+> カテゴリ: **追加** / **変更** / **削除** / **修正** / **セキュリティ**（[Keep a Changelog 1.1.0](https://keepachangelog.com/ja/1.1.0/) 準拠）。
+> バージョンは `[X.Y.Z] - YYYY-MM-DD` 形式。
+
 ## [Unreleased]
 
 ### 修正
 
-- `knowledge_buffer.sh` の repo-id namespace 構造（PR #344）に旧構造で作られた buffer worktree が migration されない問題を修正 (#543)。`knowledge_buffer_ensure` 内で旧構造を自動検知し、未 push commit を保全しつつ新構造へ移行するようになった。利用者は次回 `/sync-edit` / `/review-harvest` / `/knowledge-pr` 実行時に自動回復する
-- `install.sh --update` 実行で `.claude-plugin/plugin.json` の `version` がダウングレードする問題を修正 (#540, PR #542)。`templates/claude-plugin/plugin.json` を廃止し、リポジトリ直下の `.claude-plugin/plugin.json` を唯一の Source-of-Truth として直接コピーするようになった
+- 旧構造で作られた知見バッファが新構造へ自動移行されるようになった。(#543)
+  - `/sync-edit` / `/review-harvest` / `/knowledge-pr` の次回実行時に自動回復する。
+  - 未プッシュのコミットは移行中に保全される。
+- `install.sh --update` 実行でバージョンがダウングレードする問題を修正した。(#540, #542)
+  - バージョン情報の参照元を 1 箇所に統一し、上書きされなくなった。
 
 ## [0.3.0] - 2026-04-25
 
-### ⚠️ 破壊的変更
+### 変更
 
-- `.claude/skills/` の互換スタブが廃止された。旧コマンド名（`/ship`、`/autopilot` 等）は動作しなくなり、Plugin 名前空間（`/vibecorp:ship`、`/vibecorp:autopilot` 等）のみ使用可能になった
-- `install.sh --update` を実行すると、既存プロジェクトの `.claude/skills/` 互換スタブが自動クリーンアップされる（ユーザーが独自に追加したスキルは残る）
+- ⚠️ スキルの旧コマンド名（`/ship`、`/autopilot` 等）が動作しなくなった。
+  - Plugin 名前空間（`/vibecorp:ship`、`/vibecorp:autopilot` 等）のみ使用可能になった。
+- `install.sh --update` 実行時に、既存プロジェクトの互換スタブが自動で削除されるようになった。
+  - 利用者が独自に追加したスキルは残る。
 
 ### 削除
 
-- `install.sh` から互換スタブ自動生成ロジックを削除
+- `install.sh` から互換スタブ自動生成ロジックを削除した。
 
 ## [0.1.0] - 2026-03-28
 
-### 初期リリース
+### 追加
 
-- install.sh による 3 プリセット対応（minimal, standard, full）
-- hooks, skills, agents, rules, knowledge テンプレート
-- vibecorp.yml / vibecorp.lock によるプロジェクト設定管理
-- settings.json のマージ管理（vibecorp 由来フックのみ操作）
+- `install.sh` による 3 プリセット対応（minimal / standard / full）
+- hooks / skills / agents / rules / knowledge テンプレート
+- `vibecorp.yml` / `vibecorp.lock` によるプロジェクト設定管理
+- `settings.json` のマージ管理（vibecorp 由来フックのみ操作）
 - 3-way マージによるアップデート時のコンフリクト解消
 - CodeRabbit 連携設定
 - GitHub Branch Protection 自動設定

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,18 @@
 
 > [!NOTE]
 > 利用者（vibecorp を導入するプロジェクト）向けのリリース別変更点一覧。
-> カテゴリ: **追加** / **変更** / **非推奨** / **削除** / **修正** / **セキュリティ**（[Keep a Changelog 1.1.0](https://keepachangelog.com/ja/1.1.0/) 準拠の 6 種）。
+> カテゴリ: **追加** / **変更** / **非推奨** / **削除** / **修正** / **セキュリティ**。
+> [Keep a Changelog 1.1.0](https://keepachangelog.com/ja/1.1.0/) 準拠の 6 種。
 > バージョンは `[X.Y.Z] - YYYY-MM-DD` 形式。
 
 ## [Unreleased]
 
 ### 修正
 
-- 旧構造で作られた知見バッファが新構造へ自動移行されるようになった。(#543)
+- 旧構造で作られた知見バッファが新構造へ自動移行されるようになった。([#543](https://github.com/hirokimry/vibecorp/issues/543))
   - `/sync-edit` / `/review-harvest` / `/knowledge-pr` の次回実行時に自動回復する。
   - 未プッシュのコミットは移行中に保全される。
-- `install.sh --update` 実行でバージョンがダウングレードする問題を修正した。(#540, #542)
+- `install.sh --update` 実行でバージョンがダウングレードする問題を修正した。([Issue #540](https://github.com/hirokimry/vibecorp/issues/540), [PR #542](https://github.com/hirokimry/vibecorp/pull/542))
   - バージョン情報の参照元を 1 箇所に統一し、上書きされなくなった。
 
 ## [0.3.0] - 2026-04-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 > [!NOTE]
 > 利用者（vibecorp を導入するプロジェクト）向けのリリース別変更点一覧。
-> カテゴリ: **追加** / **変更** / **削除** / **修正** / **セキュリティ**（[Keep a Changelog 1.1.0](https://keepachangelog.com/ja/1.1.0/) 準拠）。
+> カテゴリ: **追加** / **変更** / **非推奨** / **削除** / **修正** / **セキュリティ**（[Keep a Changelog 1.1.0](https://keepachangelog.com/ja/1.1.0/) 準拠の 6 種）。
 > バージョンは `[X.Y.Z] - YYYY-MM-DD` 形式。
 
 ## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 修正
 
-- 旧構造で作られた知見バッファが新構造へ自動移行されるようになった。([#543](https://github.com/hirokimry/vibecorp/issues/543))
+- 旧構造で作られた知見バッファが新構造へ自動移行されるようになった。([Issue #543](https://github.com/hirokimry/vibecorp/issues/543))
   - `/sync-edit` / `/review-harvest` / `/knowledge-pr` の次回実行時に自動回復する。
   - 未プッシュのコミットは移行中に保全される。
 - `install.sh --update` 実行でバージョンがダウングレードする問題を修正した。([Issue #540](https://github.com/hirokimry/vibecorp/issues/540), [PR #542](https://github.com/hirokimry/vibecorp/pull/542))

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 🤖 **AI エージェントを組織化してプロダクト開発を回すプラグイン**
 
-どのリポジトリにも導入でき、Claude Code の skills / hooks / agents / rules を一括セットアップする。Issue 駆動の開発ループを AI に委譲し、ブランチ作成から PR の auto-merge までを一気通貫で実行する。
+> [!IMPORTANT]
+> このドキュメントは **外部 OSS 読者・導入開発者** 向けの入口ガイドです。
+> どのリポジトリにも 2 コマンドで導入でき、Issue 駆動の開発ループを AI に委譲できます。
+> 詳細仕様は [`docs/specification.md`](docs/specification.md) を参照してください。
+
+どのリポジトリにも導入でき、Claude Code の skills / hooks / agents / rules を一括セットアップする。
+Issue 駆動の開発ループを AI に委譲し、ブランチ作成から PR の auto-merge まで一気通貫で実行する。
 
 | 何ができる？ | どう動く？ |
 |------------|----------|
@@ -41,7 +47,8 @@ path/to/vibecorp/install.sh --name your-project
 /plugin install vibecorp@vibecorp --scope project
 ```
 
-これで `/vibecorp:*` スキルが利用可能になる。スキルはプラグインキャッシュ（`~/.claude/plugins/cache/`）から配信される。
+これで `/vibecorp:*` スキルが利用可能になる。
+スキルはプラグインキャッシュ（`~/.claude/plugins/cache/`）から配信される。
 
 ### よく使うインストールオプション
 
@@ -80,7 +87,8 @@ path/to/vibecorp/install.sh --update
 | hooks / agents / rules / docs / knowledge / lib / settings.json / vibecorp.yml / `.claude-plugin/plugin.json`（version マニフェスト）/ CI workflow | `install.sh --update` |
 | **skills（`/vibecorp:*`）** | **`/plugin update vibecorp --scope project`**（プラグインキャッシュ `~/.claude/plugins/cache/` 経由のため別経路） |
 
-`install.sh --update` 実行時にバージョン差分があれば自動で表示される。`/plugin update` は既に最新の場合「already at the latest version」と返すだけなので毎回実行しても安全。
+`install.sh --update` 実行時にバージョン差分があれば自動で表示される。
+`/plugin update` は既に最新の場合「already at the latest version」と返すだけなので、毎回実行しても安全。
 
 3-way マージ・プリセット変更・`--no-migrate` 等の `--update` 詳細仕様は [`docs/specification.md#--update-の挙動`](docs/specification.md#--update-の挙動) を参照。
 
@@ -104,7 +112,9 @@ path/to/vibecorp/install.sh --update
 | **standard** | minimal + ゲート強制（auto-merge 維持） | `/loop` による cron 化 |
 | **full** | 並列 `/vibecorp:ship-parallel` + 単発 `/vibecorp:autopilot` + `/vibecorp:diagnose` | `/loop /vibecorp:autopilot 24h` 等 |
 
-vibecorp は sandbox を **強く推奨するだけで強制はしない**。`full` + sandbox OFF で並列実行する場合は「承認ダイアログ多発」または「ユーザーが `.claude/settings.local.json` の allow リストを自己調整」のいずれかとなり、自己責任の運用となる（[`docs/design-philosophy.md#承認フローへの非介入`](docs/design-philosophy.md#承認フローへの非介入)）。
+vibecorp は sandbox を **強く推奨するだけで強制はしない**。
+`full` + sandbox OFF で並列実行する場合は、「承認ダイアログ多発」または「ユーザーが `.claude/settings.local.json` の allow リストを自己調整」のいずれかとなる。
+自己責任の運用となる（[`docs/design-philosophy.md#承認フローへの非介入`](docs/design-philosophy.md#承認フローへの非介入)）。
 
 > ⚠️ **必須 hook について**: 一部の必須 hook（保護系・ゲート系・API バイパス防止系・ログ系）は `vibecorp.yml` の `hooks: false` でも無効化できません。詳細は [`docs/specification.md#skip-性マトリクス`](docs/specification.md#skip-性マトリクス) を参照。
 
@@ -117,7 +127,11 @@ source .claude/bin/activate.sh
 export VIBECORP_ISOLATION=1
 ```
 
-永続化したい場合は `~/.zshrc` / `~/.bashrc` に上記 2 行を追記する。Linux では `bwrap` (bubblewrap) による実隔離が稼働中（Phase 2 #310 実装済み）。SSH push 利用者は `vibecorp.yml` に `isolation.allow_ssh: true` を追加すると `~/.ssh` が read-only でマウントされる。Windows ネイティブは非対応（WSL2 を使用）。詳細は [`docs/design-philosophy.md`](docs/design-philosophy.md)。
+永続化したい場合は `~/.zshrc` / `~/.bashrc` に上記 2 行を追記する。
+Linux では `bwrap` (bubblewrap) による実隔離が稼働中（Phase 2 #310 実装済み）。
+SSH push 利用者は `vibecorp.yml` に `isolation.allow_ssh: true` を追加すると `~/.ssh` が read-only でマウントされる。
+Windows ネイティブは非対応（WSL2 を使用）。
+詳細は [`docs/design-philosophy.md`](docs/design-philosophy.md)。
 
 ---
 
@@ -137,11 +151,21 @@ export VIBECORP_ISOLATION=1
 
 ### 🤝 standard で追加（6 スキル — 知識蓄積と整合性）
 
-`/vibecorp:review-harvest`, `/vibecorp:sync-check`, `/vibecorp:sync-edit`, `/vibecorp:session-harvest`, `/vibecorp:harvest-all`, `/vibecorp:context7`
+| スキル | 何ができるようになるか |
+|---|---|
+| `/vibecorp:review-harvest` / `/vibecorp:session-harvest` / `/vibecorp:harvest-all` | レビュー・セッションの知見をナレッジに自動蓄積する |
+| `/vibecorp:sync-check` / `/vibecorp:sync-edit` | 仕様書と実装の整合性をチェック・自動修正する |
+| `/vibecorp:context7` | 外部ライブラリの公式ドキュメントをコンテキストに取り込む |
 
 ### 🏢 full で追加（8 スキル — 並列・自律・エピック）
 
-`/vibecorp:diagnose`, `/vibecorp:ship-parallel`, `/vibecorp:autopilot`, `/vibecorp:plan-epic`, `/vibecorp:release-epic`, `/vibecorp:cycle-metrics`, `/vibecorp:docs-rewrite-all`, `/vibecorp:prompts-rewrite-all`
+| スキル | 何ができるようになるか |
+|---|---|
+| `/vibecorp:ship-parallel` / `/vibecorp:autopilot` | 複数 Issue を並列実装・自律的に改善サイクルを回す |
+| `/vibecorp:diagnose` | 改善候補を自動検出して Issue 起票する |
+| `/vibecorp:plan-epic` / `/vibecorp:release-epic` | エピック単位の計画・リリースを管理する |
+| `/vibecorp:cycle-metrics` | 開発サイクルの指標を計測・可視化する |
+| `/vibecorp:docs-rewrite-all` / `/vibecorp:prompts-rewrite-all` | ドキュメント・プロンプトを基準に沿って一括書き直す |
 
 > 📖 **詳細**: 各スキルの引数・挙動・依存関係は [`docs/specification.md#スキル一覧source-of-truth`](docs/specification.md#スキル一覧source-of-truth) に記載。
 
@@ -158,7 +182,9 @@ export VIBECORP_ISOLATION=1
 | 🛑 API バイパス防止型 | `block-api-bypass.sh` | `gh api` 直接マージや `@coderabbitai approve` 投稿を遮断 |
 | 📊 コマンドログ型 | `command-log.sh` | 全 Bash コマンドを記録し `/vibecorp:approve-audit` の入力源にする |
 
-> 🔐 **承認フロー非介入**: vibecorp は Claude Code の承認フローを書き換える hook を提供しない。並列実行時の承認負荷は sandbox + `--dangerously-skip-permissions` で低減する方針。詳細は [`docs/design-philosophy.md#承認フローへの非介入`](docs/design-philosophy.md#承認フローへの非介入)。
+> 🔐 **承認フロー非介入**: vibecorp は Claude Code の承認フローを書き換える hook を提供しない。
+> 並列実行時の承認負荷は sandbox + `--dangerously-skip-permissions` で低減する方針。
+> 詳細は [`docs/design-philosophy.md#承認フローへの非介入`](docs/design-philosophy.md#承認フローへの非介入)。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@
 > どのリポジトリにも 2 コマンドで導入でき、Issue 駆動の開発ループを AI に委譲できます。
 > 詳細仕様は [`docs/specification.md`](docs/specification.md) を参照してください。
 
-どのリポジトリにも導入でき、Claude Code の skills / hooks / agents / rules を一括セットアップする。
-Issue 駆動の開発ループを AI に委譲し、ブランチ作成から PR の auto-merge まで一気通貫で実行する。
+どのリポジトリにも導入できる。
+Claude Code の skills / hooks / agents / rules を一括セットアップする。
+Issue 駆動の開発ループを AI に委譲する。
+ブランチ作成から PR の auto-merge まで一気通貫で実行する。
 
 | 何ができる？ | どう動く？ |
 |------------|----------|
@@ -88,7 +90,8 @@ path/to/vibecorp/install.sh --update
 | **skills（`/vibecorp:*`）** | **`/plugin update vibecorp --scope project`**（プラグインキャッシュ `~/.claude/plugins/cache/` 経由のため別経路） |
 
 `install.sh --update` 実行時にバージョン差分があれば自動で表示される。
-`/plugin update` は既に最新の場合「already at the latest version」と返すだけなので、毎回実行しても安全。
+`/plugin update` は既に最新の場合「already at the latest version」と返す。
+毎回実行しても安全。
 
 3-way マージ・プリセット変更・`--no-migrate` 等の `--update` 詳細仕様は [`docs/specification.md#--update-の挙動`](docs/specification.md#--update-の挙動) を参照。
 
@@ -113,8 +116,13 @@ path/to/vibecorp/install.sh --update
 | **full** | 並列 `/vibecorp:ship-parallel` + 単発 `/vibecorp:autopilot` + `/vibecorp:diagnose` | `/loop /vibecorp:autopilot 24h` 等 |
 
 vibecorp は sandbox を **強く推奨するだけで強制はしない**。
-`full` + sandbox OFF で並列実行する場合は、「承認ダイアログ多発」または「ユーザーが `.claude/settings.local.json` の allow リストを自己調整」のいずれかとなる。
-自己責任の運用となる（[`docs/design-philosophy.md#承認フローへの非介入`](docs/design-philosophy.md#承認フローへの非介入)）。
+`full` + sandbox OFF で並列実行する場合、次のいずれかとなる。
+
+- 承認ダイアログが多発する
+- ユーザーが `.claude/settings.local.json` の allow リストを自己調整する
+
+自己責任の運用となる。
+詳細は [`docs/design-philosophy.md#承認フローへの非介入`](docs/design-philosophy.md#承認フローへの非介入) を参照。
 
 > ⚠️ **必須 hook について**: 一部の必須 hook（保護系・ゲート系・API バイパス防止系・ログ系）は `vibecorp.yml` の `hooks: false` でも無効化できません。詳細は [`docs/specification.md#skip-性マトリクス`](docs/specification.md#skip-性マトリクス) を参照。
 
@@ -128,8 +136,11 @@ export VIBECORP_ISOLATION=1
 ```
 
 永続化したい場合は `~/.zshrc` / `~/.bashrc` に上記 2 行を追記する。
-Linux では `bwrap` (bubblewrap) による実隔離が稼働中（Phase 2 #310 実装済み）。
-SSH push 利用者は `vibecorp.yml` に `isolation.allow_ssh: true` を追加すると `~/.ssh` が read-only でマウントされる。
+Linux では `bwrap` (bubblewrap) による実隔離が稼働中。
+Phase 2 `#310` で実装済み。
+
+SSH push 利用者は `vibecorp.yml` に `isolation.allow_ssh: true` を追加する。
+これにより `~/.ssh` が read-only でマウントされる。
 Windows ネイティブは非対応（WSL2 を使用）。
 詳細は [`docs/design-philosophy.md`](docs/design-philosophy.md)。
 
@@ -182,9 +193,12 @@ Windows ネイティブは非対応（WSL2 を使用）。
 | 🛑 API バイパス防止型 | `block-api-bypass.sh` | `gh api` 直接マージや `@coderabbitai approve` 投稿を遮断 |
 | 📊 コマンドログ型 | `command-log.sh` | 全 Bash コマンドを記録し `/vibecorp:approve-audit` の入力源にする |
 
-> 🔐 **承認フロー非介入**: vibecorp は Claude Code の承認フローを書き換える hook を提供しない。
-> 並列実行時の承認負荷は sandbox + `--dangerously-skip-permissions` で低減する方針。
-> 詳細は [`docs/design-philosophy.md#承認フローへの非介入`](docs/design-philosophy.md#承認フローへの非介入)。
+> 🔐 **承認フロー非介入**
+>
+> vibecorp は Claude Code の承認フローを書き換える hook を提供しない。
+> 並列実行時の承認負荷は sandbox と `--dangerously-skip-permissions` で低減する。
+>
+> 詳細: [`docs/design-philosophy.md#承認フローへの非介入`](docs/design-philosophy.md#承認フローへの非介入)
 
 ---
 


### PR DESCRIPTION
## 🎯 主役 — 外部 OSS 読者・利用者が README/CHANGELOG を 30 秒で掴めるようになる

このプロジェクトを **初めて GitHub で見つけた人** と、**vibecorp を自プロジェクトに導入したい開発者** が、README と CHANGELOG をスクロールするだけで「何ができるか・最新リリースで何が変わったか」を掴めるようにする。

`.claude/rules/document-writing.md` の **指針 MUST 7 項目 + 禁止パターン 7 項目** に照らして、現状の長文・実装詳細羅列・カテゴリ語彙混在を整形する。実コードは一切触らない（intent/docs、挙動不変）。

## 🖼️ 位置づけ

- **エピック**: #590（ドキュメント・プロンプト作成基準）Phase C
- **親 Issue**: #595（docs 全体書き直し統合、6 子 Issue に分割済）
- **本 PR**: 1/6 スライス（メタ: README + CHANGELOG）
- **後続**: #610 (ガイドライン) / #611 (仕様) / #612 (セキュリティ) / #613 (マイグレーション) / #614 (その他) を順次 ship 予定
- **依存**: #615 (基準 + 書き直しスキル 2 種の main マージ済) を前提とする

## 🔄 Before / After

### README.md

| 観点 | 🔴 Before | 🟢 After |
|---|---|---|
| 冒頭 | プロジェクト一言定義のみ、誰向けか不明 | `> [!IMPORTANT]` コールアウトで「外部 OSS 読者・導入開発者」と読者像を明示、2 コマンドで導入できることを 30 秒で訴求 |
| 長文 | L5/L44/L83/L107/L120/L161 が 1 文 50 字超で改行なし | 句点で改行され、1 文 1 行に整列、スキャンしやすくなった |
| スキル列挙 | standard 6 本 / full 8 本がコンマ区切りでスキル名のみ列挙 | テーブル化、「何ができるようになるか」列で動作主語化 |

### CHANGELOG.md

| 観点 | 🔴 Before | 🟢 After |
|---|---|---|
| 冒頭 | タイトル直下に説明なし | `> [!NOTE]` コールアウトで「利用者向けリリース別変更点」「6 カテゴリ語彙」「バージョン形式」を明示 |
| カテゴリ語彙 | 「修正」「⚠️ 破壊的変更」「削除」「初期リリース」が混在 | [Keep a Changelog 1.1.0](https://keepachangelog.com/ja/1.1.0/) 準拠 6 種（追加 / 変更 / 非推奨 / 削除 / 修正 / セキュリティ）に統一 |
| エントリ | 関数名・モジュール名・パスを地の文に羅列 | 「何ができるようになったか」の動作主語に書き直し、技術詳細は PR リンクで補完 |

## 🧭 設計判断

- **書き直しスキル経由**: `/vibecorp:docs-rewrite-all` で CPO (README) + CTO (CHANGELOG) に diff 提案を委譲、CEO 全採用承認後に Edit で反映（2 段階承認、自動マージ禁止）
- **過剰書き換え禁止**: README は既に多くの基準要素を満たしていたため、意味改変は禁止、整形のみ
- **Keep a Changelog 採用**: document-writing.md は「カテゴリ別変更点」のみ要求、特定語彙体系を強制していない。CTO 判断で国際標準採用、追跡性最大化を優先
- **6 PR 分割**: 21 ファイル一括は CodeRabbit/レビュー過大、論理単位で分割（CEO 判断 2026-05-17）

## 🔍 挙動不変性の担保（intent/docs 必須）

- ✅ サンプルコード / インストール手順 / パス参照 / コマンド引数 / スキル名 / 外部リンクの意味は完全保持
- ✅ 関連テスト 5 本 (document-writing-rule / docs-rewrite-all-skill / prompts-rewrite-all-skill / prompt-writing-rule / communication-rule) PASS
- ✅ 内部リンク検証: `grep -oE '\(docs/[^)#]+\)' README.md` 抽出パス全件で `test -f` 成功（0 件 missing）
- ✅ 配布対象外確認: `find templates \( -name "README*" -o -name "CHANGELOG*" \)` ヒット 0 件（vibecorp 本体表紙、利用先には配布されない）

## 🧪 テスト

- `bash tests/test_document_writing_rule.sh` 37/37 PASS ✅
- `bash tests/test_docs_rewrite_all_skill.sh` 44/44 PASS ✅
- `bash tests/test_prompts_rewrite_all_skill.sh` 54/54 PASS ✅
- `bash tests/test_prompt_writing_rule.sh` 53/53 PASS ✅
- `bash tests/test_communication_rule.sh` 16/16 PASS ✅

⚠️ `tests/test_distribution_writing_rules.sh` は 24/28 (pre-existing failure、`.claude/vibecorp-base/` は dev 環境で gitignore により未生成、本 PR の編集対象外)

## 🚧 スコープ外

- **docs/**/*.md（19 ファイル）の書き直し**: 別子 Issue #610〜#614 で順次対応
- **CHANGELOG 欠落バージョン（0.2.x、0.1.1 等）の補完**: 別 Issue で扱う（本 PR は基準準拠の整形のみ）
- **配布版同期**: README/CHANGELOG は配布対象外のため作業不要

close https://github.com/hirokimry/vibecorp/issues/609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * CHANGELOG先頭に利用者向けNOTE（カテゴリ規約・バージョン表記）を追加、Unreleased/各リリースを新形式で再整理
  * READMEに導入・運用説明、隔離レイヤ永続化手順、Linux bwrap/SSH設定、Windows非対応、プラグインキャッシュとスキル一覧表記を追加
* **重要注意**
  * 承認フロー非介入などの注意点を強調
* **変更**
  * install.sh --update のダウングレード問題を修正（参照先統一）、Unreleasedで知見バッファ自動移行の挙動を明記
  * 0.3.0で旧コマンド非対応化、/vibecorp: 名前空間限定、既存プロジェクトの互換スタブ自動削除を追記
* **削除**
  * 0.3.0で互換スタブ自動生成ロジックを削除
* **追加**
  * 0.1.0でプリセット・テンプレート・設定管理（vibecorp.yml/vibecorp.lock）などの項目を整理して追記

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hirokimry/vibecorp/pull/616?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->