### PR TITLE
🔄 refactor: check 系 4 workflow のインラインシェルが .github/scripts/ に切り出される (#624)

### DIFF
--- a/.github/scripts/check-intent-label-issue.sh
+++ b/.github/scripts/check-intent-label-issue.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# check-intent-label-issue.sh — Issue に許可された intent/* ラベル 1 つだけが
+# 付与されていることを機械的に強制する。
+#
+# .github/workflows/intent-label-issue-check.yml から呼ばれる。
+# Issue #469 残 #3「intent ラベル不在 Issue/PR は CI/hook で必須化（fail）」の Issue 側実装。
+# Source of Truth: docs/conventional-commits.md, .claude/rules/intent-labels.md
+#
+# 終了コード:
+#   0 — 許可 intent ラベルが 1 つだけ付与されている
+#   1 — 未知の intent/* 混在 / intent 不在 / 複数 intent 付与（いずれも警告コメント投稿後 fail）
+#
+# 必須 env:
+#   GH_TOKEN      GitHub CLI 認証トークン
+#   ISSUE_NUMBER  対象 Issue 番号
+#   REPO          owner/repo 形式のリポジトリ識別子
+
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN が未設定です}"
+: "${ISSUE_NUMBER:?ISSUE_NUMBER が未設定です}"
+: "${REPO:?REPO が未設定です}"
+
+# intent/* ラベルの全体数と許可ラベル 7 種のカウントを別々に取得
+# 全体数 != 許可数 → 未知の intent/* (intent/unknown 等) が混在 → fail
+allowed='["intent/feature","intent/bugfix","intent/performance","intent/security","intent/refactor","intent/infra","intent/docs"]'
+counts=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/labels" \
+  | jq --argjson allowed "$allowed" '{
+      total_intent: ([.[] | .name | select(startswith("intent/"))] | length),
+      allowed_intent: ([.[] | .name | select(IN($allowed[]))] | length)
+    }')
+total_intent=$(jq -r '.total_intent' <<< "$counts")
+allowed_intent=$(jq -r '.allowed_intent' <<< "$counts")
+unknown_intent=$(( total_intent - allowed_intent ))
+
+if [[ "$unknown_intent" -gt 0 ]]; then
+  gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
+    --body "⚠️ 許可されていない intent/* ラベルが含まれています。1 Issue 1 intent ルールに従い、許可 7 種（intent/feature, intent/bugfix, intent/performance, intent/security, intent/refactor, intent/infra, intent/docs）から 1 つだけ付与してください。"
+  exit 1
+fi
+if [[ "$allowed_intent" -eq 0 ]]; then
+  gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
+    --body "⚠️ intent/* ラベルが付与されていません（許可 7 種のうち 1 つを付ける必要があります）。1 Issue 1 intent ルール（intent/feature, intent/bugfix, intent/performance, intent/security, intent/refactor, intent/infra, intent/docs から 1 つ）に従い、ラベルを 1 つ付与してください。詳細は .claude/rules/intent-labels.md を参照。"
+  exit 1
+fi
+if [[ "$allowed_intent" -gt 1 ]]; then
+  gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
+    --body "⚠️ 複数の intent ラベル（許可 7 種のうち）が付与されています。1 Issue 1 intent ルールに従い、ラベルを 1 つに修正してください。"
+  exit 1
+fi

--- a/.github/scripts/check-plugin-version-bump-comment.sh
+++ b/.github/scripts/check-plugin-version-bump-comment.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# check-plugin-version-bump-comment.sh — bump 漏れ警告コメントを PR に投稿する
+#
+# .github/workflows/plugin-version-bump-check.yml から呼ばれる。
+# scripts/check-plugin-version-bump.sh が failure を返した場合に、利用者向けの
+# 警告コメントを PR に投稿する。本処理は warning コメントのみ・非ブロック。
+#
+# 必須 env:
+#   GH_TOKEN   GitHub CLI 認証トークン
+#   PR_NUMBER  対象 PR 番号
+#   REPO       owner/repo 形式のリポジトリ識別子
+
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN が未設定です}"
+: "${PR_NUMBER:?PR_NUMBER が未設定です}"
+: "${REPO:?REPO が未設定です}"
+
+gh pr comment "$PR_NUMBER" --repo "$REPO" \
+  --body "⚠️ \`.claude-plugin/marketplace.json\` の \`plugins[0].skills\` が変更されていますが、\`.claude-plugin/plugin.json\` の \`version\` が bump されていません。利用者は新しいスキルを取得するために version bump を必要とします（PR #459 と同種の取りこぼし防止）。マージ前に \`.claude-plugin/plugin.json\` の \`version\` を更新してください。本チェックは警告のみ・非ブロックです。"

--- a/.github/scripts/check-pr-issue-link.sh
+++ b/.github/scripts/check-pr-issue-link.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# check-pr-issue-link.sh — PR 本文に対応 Issue への参照（Refs / close / closes /
+# fix / fixes / resolve / resolves）が含まれていない場合に fail させる。
+#
+# .github/workflows/pr-issue-link-check.yml から呼ばれる。
+# Issue #469 残 #5「Issue 番号取れない PR は fail（Issue 経由起票必須）」の実装。
+# Source of Truth: docs/conventional-commits.md, .claude/rules/intent-labels.md
+#
+# 終了コード:
+#   0 — PR 本文に Issue 参照あり
+#   1 — Issue 参照なし（警告コメント投稿後 fail）
+#
+# 必須 env:
+#   GH_TOKEN   GitHub CLI 認証トークン
+#   PR_NUMBER  対象 PR 番号
+#   REPO       owner/repo 形式のリポジトリ識別子
+
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN が未設定です}"
+: "${PR_NUMBER:?PR_NUMBER が未設定です}"
+: "${REPO:?REPO が未設定です}"
+
+# PR 本文を取得し、Issue 参照キーワード（GitHub の auto-close keywords + Refs）を grep
+# close / closes / closed / fix / fixes / fixed / resolve / resolves / resolved / Refs (大小文字区別なし) + #数字
+body=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body')
+if echo "$body" | grep -qiE '(close[sd]?|fix(es|ed)?|resolve[sd]?|refs?)[[:space:]]+#[0-9]+|(close[sd]?|fix(es|ed)?|resolve[sd]?|refs?)[[:space:]]+https?://[^[:space:]]+/issues/[0-9]+'; then
+  echo "PR 本文に Issue 参照が見つかりました"
+  exit 0
+fi
+gh pr comment "$PR_NUMBER" --repo "$REPO" \
+  --body "⚠️ PR 本文に対応 Issue への参照（\`close #123\` / \`fixes #123\` / \`Refs #123\` など）が含まれていません。vibecorp は Issue 経由起票必須運用（Issue #469 残 #5）のため、PR 本文に Issue 参照を追加してから再 push してください。詳細は .claude/rules/intent-labels.md と docs/conventional-commits.md を参照。"
+exit 1

--- a/.github/scripts/check-update-pr-branches.sh
+++ b/.github/scripts/check-update-pr-branches.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# check-update-pr-branches.sh — main 更新時に全 open PR のブランチを自動更新する。
+# コンフリクトが発生した PR はスキップして続行する。
+#
+# .github/workflows/update-pr-branches.yml から呼ばれる。
+#
+# 終了コード:
+#   0 — 全 PR の更新が成功（コンフリクト・最新は許容）
+#   1 — 1 件以上の更新失敗（PAT 未設定はスキップ扱いで 0）
+#
+# 必須 env:
+#   GH_TOKEN  GitHub PAT（contents:write + pull-requests:write 権限）
+#   REPO      owner/repo 形式のリポジトリ識別子
+
+set -euo pipefail
+
+: "${REPO:?REPO が未設定です}"
+
+# PAT 未設定時はスキップ（GH_TOKEN を空文字許容のため `: "${GH_TOKEN:?...}"` は使わない）
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "::warning::PAT シークレットが未設定のためスキップします。README の「PAT セットアップ」セクションを参照してください。"
+  exit 0
+fi
+export GH_TOKEN
+
+# 全 open PR の番号を取得（ページネーション対応）
+PR_NUMBERS=$(gh api --paginate "repos/${REPO}/pulls?state=open&base=main" --jq '.[].number')
+
+if [ -z "$PR_NUMBERS" ]; then
+  echo "更新対象の open PR はありません"
+  exit 0
+fi
+
+UPDATED=0
+CONFLICT=0
+SKIPPED=0
+FAILED=0
+CONFLICT_PRS=""
+
+for PR in $PR_NUMBERS; do
+  echo "--- PR #${PR} を更新中 ---"
+  # 現在の head SHA を取得（失敗時は致命的エラー）
+  if ! HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha' 2>&1); then
+    echo "PR #${PR}: SHA 取得失敗（想定外エラー）"
+    echo "${HEAD_SHA}"
+    exit 1
+  fi
+
+  # ブランチ更新（終了コード + レスポンスボディで分岐）
+  RESPONSE=$(gh api "repos/${REPO}/pulls/${PR}/update-branch" \
+    --method PUT \
+    --field expected_head_sha="${HEAD_SHA}" 2>&1) && {
+    echo "PR #${PR}: 更新成功"
+    UPDATED=$((UPDATED + 1))
+  } || {
+    if echo "${RESPONSE}" | grep -qi "merge conflict"; then
+      echo "PR #${PR}: コンフリクトのためスキップ"
+      CONFLICT=$((CONFLICT + 1))
+      CONFLICT_PRS="${CONFLICT_PRS} #${PR}"
+    elif echo "${RESPONSE}" | grep -qi "already up to date"; then
+      echo "PR #${PR}: 既に最新"
+      SKIPPED=$((SKIPPED + 1))
+    else
+      echo "PR #${PR}: 更新失敗 — ${RESPONSE}"
+      FAILED=$((FAILED + 1))
+    fi
+  }
+done
+
+echo ""
+echo "=== 結果 ==="
+echo "更新成功: ${UPDATED} 件"
+echo "コンフリクト: ${CONFLICT} 件"
+echo "スキップ（既に最新）: ${SKIPPED} 件"
+echo "失敗: ${FAILED} 件"
+
+if [ -n "${CONFLICT_PRS}" ]; then
+  echo ""
+  echo "コンフリクト PR:${CONFLICT_PRS}"
+fi
+
+if [ "${FAILED}" -gt 0 ]; then
+  exit 1
+fi

--- a/.github/scripts/check-update-pr-branches.sh
+++ b/.github/scripts/check-update-pr-branches.sh
@@ -46,13 +46,13 @@ for PR in $PR_NUMBERS; do
     exit 1
   fi
 
-  # ブランチ更新（終了コード + レスポンスボディで分岐）
-  RESPONSE=$(gh api "repos/${REPO}/pulls/${PR}/update-branch" \
+  # ブランチ更新（終了コードで分岐、A && B || C パターンの分岐誤判定を避けるため if/else を使用 - SC2015）
+  if RESPONSE=$(gh api "repos/${REPO}/pulls/${PR}/update-branch" \
     --method PUT \
-    --field expected_head_sha="${HEAD_SHA}" 2>&1) && {
+    --field expected_head_sha="${HEAD_SHA}" 2>&1); then
     echo "PR #${PR}: 更新成功"
     UPDATED=$((UPDATED + 1))
-  } || {
+  else
     if echo "${RESPONSE}" | grep -qi "merge conflict"; then
       echo "PR #${PR}: コンフリクトのためスキップ"
       CONFLICT=$((CONFLICT + 1))
@@ -64,7 +64,7 @@ for PR in $PR_NUMBERS; do
       echo "PR #${PR}: 更新失敗 — ${RESPONSE}"
       FAILED=$((FAILED + 1))
     fi
-  }
+  fi
 done
 
 echo ""

--- a/.github/workflows/intent-label-issue-check.yml
+++ b/.github/workflows/intent-label-issue-check.yml
@@ -20,36 +20,12 @@ jobs:
     name: Issue intent ラベル必須化チェック
     runs-on: ubuntu-latest
     steps:
+      - name: チェックアウト
+        uses: actions/checkout@v4
+
       - name: 1 Issue 1 intent 厳守チェック
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
-        run: |
-          # intent/* ラベルの全体数と許可ラベル 7 種のカウントを別々に取得
-          # 全体数 != 許可数 → 未知の intent/* (intent/unknown 等) が混在 → fail
-          allowed='["intent/feature","intent/bugfix","intent/performance","intent/security","intent/refactor","intent/infra","intent/docs"]'
-          counts=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/labels" \
-            | jq --argjson allowed "$allowed" '{
-                total_intent: ([.[] | .name | select(startswith("intent/"))] | length),
-                allowed_intent: ([.[] | .name | select(IN($allowed[]))] | length)
-              }')
-          total_intent=$(jq -r '.total_intent' <<< "$counts")
-          allowed_intent=$(jq -r '.allowed_intent' <<< "$counts")
-          unknown_intent=$(( total_intent - allowed_intent ))
-
-          if [[ "$unknown_intent" -gt 0 ]]; then
-            gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
-              --body "⚠️ 許可されていない intent/* ラベルが含まれています。1 Issue 1 intent ルールに従い、許可 7 種（intent/feature, intent/bugfix, intent/performance, intent/security, intent/refactor, intent/infra, intent/docs）から 1 つだけ付与してください。"
-            exit 1
-          fi
-          if [[ "$allowed_intent" -eq 0 ]]; then
-            gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
-              --body "⚠️ intent/* ラベルが付与されていません（許可 7 種のうち 1 つを付ける必要があります）。1 Issue 1 intent ルール（intent/feature, intent/bugfix, intent/performance, intent/security, intent/refactor, intent/infra, intent/docs から 1 つ）に従い、ラベルを 1 つ付与してください。詳細は .claude/rules/intent-labels.md を参照。"
-            exit 1
-          fi
-          if [[ "$allowed_intent" -gt 1 ]]; then
-            gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
-              --body "⚠️ 複数の intent ラベル（許可 7 種のうち）が付与されています。1 Issue 1 intent ルールに従い、ラベルを 1 つに修正してください。"
-            exit 1
-          fi
+        run: .github/scripts/check-intent-label-issue.sh

--- a/.github/workflows/plugin-version-bump-check.yml
+++ b/.github/workflows/plugin-version-bump-check.yml
@@ -41,8 +41,7 @@ jobs:
         continue-on-error: true
         env:
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
-        run: |
-          bash scripts/check-plugin-version-bump.sh "$BASE_REF" "HEAD"
+        run: scripts/check-plugin-version-bump.sh "$BASE_REF" "HEAD"
 
       - name: bump 漏れ警告コメント投稿
         if: steps.bump_check.outcome == 'failure'
@@ -50,6 +49,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
-        run: |
-          gh pr comment "$PR_NUMBER" --repo "$REPO" \
-            --body "⚠️ \`.claude-plugin/marketplace.json\` の \`plugins[0].skills\` が変更されていますが、\`.claude-plugin/plugin.json\` の \`version\` が bump されていません。利用者は新しいスキルを取得するために version bump を必要とします（PR #459 と同種の取りこぼし防止）。マージ前に \`.claude-plugin/plugin.json\` の \`version\` を更新してください。本チェックは警告のみ・非ブロックです。"
+        run: .github/scripts/check-plugin-version-bump-comment.sh

--- a/.github/workflows/pr-issue-link-check.yml
+++ b/.github/workflows/pr-issue-link-check.yml
@@ -24,19 +24,12 @@ jobs:
     # Fork PR は secrets が渡らないため除外（draft も除外でコスト抑制）
     if: github.event.pull_request.head.repo.full_name == github.repository && !github.event.pull_request.draft
     steps:
+      - name: チェックアウト
+        uses: actions/checkout@v4
+
       - name: PR 本文の Issue 参照チェック
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
-        run: |
-          # PR 本文を取得し、Issue 参照キーワード（GitHub の auto-close keywords + Refs）を grep
-          # close / closes / closed / fix / fixes / fixed / resolve / resolves / resolved / Refs (大小文字区別なし) + #数字
-          body=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body')
-          if echo "$body" | grep -qiE '(close[sd]?|fix(es|ed)?|resolve[sd]?|refs?)[[:space:]]+#[0-9]+|(close[sd]?|fix(es|ed)?|resolve[sd]?|refs?)[[:space:]]+https?://[^[:space:]]+/issues/[0-9]+'; then
-            echo "PR 本文に Issue 参照が見つかりました"
-            exit 0
-          fi
-          gh pr comment "$PR_NUMBER" --repo "$REPO" \
-            --body "⚠️ PR 本文に対応 Issue への参照（\`close #123\` / \`fixes #123\` / \`Refs #123\` など）が含まれていません。vibecorp は Issue 経由起票必須運用（Issue #469 残 #5）のため、PR 本文に Issue 参照を追加してから再 push してください。詳細は .claude/rules/intent-labels.md と docs/conventional-commits.md を参照。"
-          exit 1
+        run: .github/scripts/check-pr-issue-link.sh

--- a/.github/workflows/update-pr-branches.yml
+++ b/.github/workflows/update-pr-branches.yml
@@ -14,76 +14,11 @@ jobs:
   update-branches:
     runs-on: ubuntu-latest
     steps:
+      - name: チェックアウト
+        uses: actions/checkout@v4
+
       - name: 全 open PR のブランチを更新
         env:
           GH_TOKEN: ${{ secrets.PAT }}
-        run: |
-          set -euo pipefail
-
-          # PAT 未設定時はスキップ
-          if [ -z "${GH_TOKEN}" ]; then
-            echo "::warning::PAT シークレットが未設定のためスキップします。README の「PAT セットアップ」セクションを参照してください。"
-            exit 0
-          fi
-
-          REPO="${{ github.repository }}"
-
-          # 全 open PR の番号を取得（ページネーション対応）
-          PR_NUMBERS=$(gh api --paginate "repos/${REPO}/pulls?state=open&base=main" --jq '.[].number')
-
-          if [ -z "$PR_NUMBERS" ]; then
-            echo "更新対象の open PR はありません"
-            exit 0
-          fi
-
-          UPDATED=0
-          CONFLICT=0
-          SKIPPED=0
-          FAILED=0
-          CONFLICT_PRS=""
-
-          for PR in $PR_NUMBERS; do
-            echo "--- PR #${PR} を更新中 ---"
-            # 現在の head SHA を取得（失敗時は致命的エラー）
-            if ! HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha' 2>&1); then
-              echo "PR #${PR}: SHA 取得失敗（想定外エラー）"
-              echo "${HEAD_SHA}"
-              exit 1
-            fi
-
-            # ブランチ更新（終了コード + レスポンスボディで分岐）
-            RESPONSE=$(gh api "repos/${REPO}/pulls/${PR}/update-branch" \
-              --method PUT \
-              --field expected_head_sha="${HEAD_SHA}" 2>&1) && {
-              echo "PR #${PR}: 更新成功"
-              UPDATED=$((UPDATED + 1))
-            } || {
-              if echo "${RESPONSE}" | grep -qi "merge conflict"; then
-                echo "PR #${PR}: コンフリクトのためスキップ"
-                CONFLICT=$((CONFLICT + 1))
-                CONFLICT_PRS="${CONFLICT_PRS} #${PR}"
-              elif echo "${RESPONSE}" | grep -qi "already up to date"; then
-                echo "PR #${PR}: 既に最新"
-                SKIPPED=$((SKIPPED + 1))
-              else
-                echo "PR #${PR}: 更新失敗 — ${RESPONSE}"
-                FAILED=$((FAILED + 1))
-              fi
-            }
-          done
-
-          echo ""
-          echo "=== 結果 ==="
-          echo "更新成功: ${UPDATED} 件"
-          echo "コンフリクト: ${CONFLICT} 件"
-          echo "スキップ（既に最新）: ${SKIPPED} 件"
-          echo "失敗: ${FAILED} 件"
-
-          if [ -n "${CONFLICT_PRS}" ]; then
-            echo ""
-            echo "コンフリクト PR:${CONFLICT_PRS}"
-          fi
-
-          if [ "${FAILED}" -gt 0 ]; then
-            exit 1
-          fi
+          REPO: ${{ github.repository }}
+        run: .github/scripts/check-update-pr-branches.sh

--- a/tests/test_check_workflow_scripts.sh
+++ b/tests/test_check_workflow_scripts.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# test_check_workflow_scripts.sh
+# ─────────────────────────────────────────────
+# Issue #624: check 系 4 workflow から切り出した .github/scripts/ 配下スクリプトの
+# サニティテスト（存在 / 実行権限 / shebang / set -euo pipefail / bash -n 構文検査）。
+#
+# 挙動テスト（実行結果に基づく分岐検証）は子 Issue #625 で別途追加する想定。
+# 本テストは Issue #624 の挙動不変リファクタが最低限の品質基準を満たしていることを保証する。
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/tests/lib/test_helpers.sh"
+
+SCRIPTS=(
+  ".github/scripts/check-plugin-version-bump-comment.sh"
+  ".github/scripts/check-intent-label-issue.sh"
+  ".github/scripts/check-pr-issue-link.sh"
+  ".github/scripts/check-update-pr-branches.sh"
+)
+
+echo "=== Issue #624: check 系 workflow 切り出しスクリプトのサニティテスト ==="
+
+for rel_path in "${SCRIPTS[@]}"; do
+  abs_path="${SCRIPT_DIR}/${rel_path}"
+  echo ""
+  echo "--- ${rel_path} ---"
+
+  # 1. ファイル存在
+  assert_file_exists "ファイルが存在する: ${rel_path}" "$abs_path"
+
+  # 2. 実行権限あり
+  assert_file_executable "実行権限あり: ${rel_path}" "$abs_path"
+
+  # 3. shebang が #!/usr/bin/env bash である
+  first_line=$(head -n 1 "$abs_path")
+  assert_eq "shebang は #!/usr/bin/env bash: ${rel_path}" "#!/usr/bin/env bash" "$first_line"
+
+  # 4. set -euo pipefail が含まれる
+  assert_file_contains "set -euo pipefail を含む: ${rel_path}" "$abs_path" "set -euo pipefail"
+
+  # 5. bash -n で構文エラーがない
+  if bash -n "$abs_path" 2>/dev/null; then
+    pass "bash -n で構文エラーなし: ${rel_path}"
+  else
+    fail "bash -n で構文エラーあり: ${rel_path}"
+  fi
+done
+
+echo ""
+echo "=== 各 workflow が切り出したスクリプトを呼び出している ==="
+
+# workflow と呼び出しスクリプトの対応を検証（挙動不変リファクタの構造検証）
+declare_workflows() {
+  cat <<'EOF'
+.github/workflows/plugin-version-bump-check.yml|.github/scripts/check-plugin-version-bump-comment.sh
+.github/workflows/intent-label-issue-check.yml|.github/scripts/check-intent-label-issue.sh
+.github/workflows/pr-issue-link-check.yml|.github/scripts/check-pr-issue-link.sh
+.github/workflows/update-pr-branches.yml|.github/scripts/check-update-pr-branches.sh
+EOF
+}
+
+while IFS='|' read -r workflow script; do
+  abs_workflow="${SCRIPT_DIR}/${workflow}"
+  assert_file_exists "workflow 存在: ${workflow}" "$abs_workflow"
+  assert_file_contains "workflow が ${script} を呼び出す" "$abs_workflow" "$script"
+done < <(declare_workflows)
+
+# plugin-version-bump-check.yml step 1 が既存 scripts/ 配下スクリプトを呼び出している（既存挙動維持）
+assert_file_contains \
+  "plugin-version-bump-check.yml step 1 は既存 scripts/check-plugin-version-bump.sh を呼ぶ" \
+  "${SCRIPT_DIR}/.github/workflows/plugin-version-bump-check.yml" \
+  "scripts/check-plugin-version-bump.sh"
+
+print_test_summary

--- a/tests/test_check_workflow_scripts.sh
+++ b/tests/test_check_workflow_scripts.sh
@@ -40,11 +40,11 @@ for rel_path in "${SCRIPTS[@]}"; do
   # 4. set -euo pipefail が含まれる
   assert_file_contains "set -euo pipefail を含む: ${rel_path}" "$abs_path" "set -euo pipefail"
 
-  # 5. bash -n で構文エラーがない
-  if bash -n "$abs_path" 2>/dev/null; then
+  # 5. bash -n で構文エラーがない（エラー詳細を fail メッセージに含めデバッグ容易化）
+  if error_output=$(bash -n "$abs_path" 2>&1); then
     pass "bash -n で構文エラーなし: ${rel_path}"
   else
-    fail "bash -n で構文エラーあり: ${rel_path}"
+    fail "bash -n で構文エラーあり: ${rel_path}"$'\n'"${error_output}"
   fi
 done
 

--- a/tests/test_update_pr_branches.sh
+++ b/tests/test_update_pr_branches.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-# test_update_pr_branches.sh — update-pr-branches.yml のロジックテスト
+# test_update_pr_branches.sh — update-pr-branches.yml + 切り出しスクリプトのロジックテスト
 # 使い方: bash tests/test_update_pr_branches.sh
+#
+# Issue #624 以降: ロジック本体は .github/scripts/check-update-pr-branches.sh に切り出されたため、
+# 「ワークフロー yaml レベルの構造」と「スクリプト本体のロジック」を別々に検証する。
 
 set -euo pipefail
 
@@ -8,7 +11,9 @@ TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "${TESTS_DIR}/lib/test_helpers.sh"
 
-WORKFLOW_FILE="$(cd "$(dirname "$0")/.." && pwd)/.github/workflows/update-pr-branches.yml"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORKFLOW_FILE="${REPO_ROOT}/.github/workflows/update-pr-branches.yml"
+SCRIPT_FILE="${REPO_ROOT}/.github/scripts/check-update-pr-branches.sh"
 
 assert_contains() {
   local desc="$1"
@@ -32,8 +37,7 @@ assert_not_contains() {
   fi
 }
 
-# ファイルに対して直接 grep する（大きなファイルの変数展開問題を回避）
-# --- ワークフローファイル構造テスト ---
+# --- ワークフローファイル構造テスト（workflow yaml 自体に残す責務） ---
 
 echo "=== ワークフローファイル構造テスト ==="
 
@@ -44,13 +48,6 @@ test_workflow_uses_pat() {
   assert_not_contains "GITHUB_TOKEN を使用していない" "$content" 'secrets.GITHUB_TOKEN'
 }
 
-test_workflow_has_pat_guard() {
-  local content
-  content=$(cat "$WORKFLOW_FILE")
-  assert_contains "PAT 未設定時のガードがある" "$content" 'if \[ -z "\${GH_TOKEN}"'
-  assert_contains "PAT 未設定時に warning を出力する" "$content" '::warning::'
-}
-
 test_workflow_no_include_pattern() {
   local content
   content=$(cat "$WORKFLOW_FILE")
@@ -58,58 +55,82 @@ test_workflow_no_include_pattern() {
   assert_not_contains "head -1 | awk パターンを使用していない" "$content" 'head -1 | awk'
 }
 
-test_workflow_has_conflict_category() {
+test_workflow_calls_script() {
   local content
   content=$(cat "$WORKFLOW_FILE")
+  assert_contains "切り出した check-update-pr-branches.sh を呼び出している" "$content" '.github/scripts/check-update-pr-branches.sh'
+}
+
+test_workflow_uses_pat
+test_workflow_no_include_pattern
+test_workflow_calls_script
+
+# --- 切り出しスクリプト構造テスト（ロジック本体は .github/scripts/ に移動済み） ---
+
+echo ""
+echo "=== 切り出しスクリプト（.github/scripts/check-update-pr-branches.sh）ロジックテスト ==="
+
+assert_file_exists "切り出しスクリプトが存在する" "$SCRIPT_FILE"
+assert_file_executable "切り出しスクリプトに実行権限がある" "$SCRIPT_FILE"
+
+test_script_has_pat_guard() {
+  local content
+  content=$(cat "$SCRIPT_FILE")
+  assert_contains "PAT 未設定時のガードがある" "$content" 'if \[ -z "\${GH_TOKEN'
+  assert_contains "PAT 未設定時に warning を出力する" "$content" '::warning::'
+}
+
+test_script_has_conflict_category() {
+  local content
+  content=$(cat "$SCRIPT_FILE")
   assert_contains "CONFLICT カウンタがある" "$content" 'CONFLICT='
   assert_contains "merge conflict の判定がある" "$content" 'merge conflict'
   assert_contains "CONFLICT_PRS 変数がある" "$content" 'CONFLICT_PRS'
 }
 
-test_workflow_has_skipped_category() {
+test_script_has_skipped_category() {
   local content
-  content=$(cat "$WORKFLOW_FILE")
+  content=$(cat "$SCRIPT_FILE")
   assert_contains "already up to date の判定がある" "$content" 'already up to date'
   assert_contains "SKIPPED カウンタがある" "$content" 'SKIPPED='
 }
 
-test_workflow_has_four_categories_in_summary() {
+test_script_has_four_categories_in_summary() {
   local content
-  content=$(cat "$WORKFLOW_FILE")
+  content=$(cat "$SCRIPT_FILE")
   assert_contains "サマリーに更新成功がある" "$content" '更新成功:'
   assert_contains "サマリーにコンフリクトがある" "$content" 'コンフリクト:'
   assert_contains "サマリーにスキップがある" "$content" 'スキップ'
   assert_contains "サマリーに失敗がある" "$content" '失敗:'
 }
 
-test_workflow_has_conflict_pr_list() {
+test_script_has_conflict_pr_list() {
   local content
-  content=$(cat "$WORKFLOW_FILE")
+  content=$(cat "$SCRIPT_FILE")
   assert_contains "コンフリクト PR 一覧の出力がある" "$content" 'コンフリクト PR:'
 }
 
-test_workflow_uses_pagination() {
+test_script_uses_pagination() {
   local content
-  content=$(cat "$WORKFLOW_FILE")
+  content=$(cat "$SCRIPT_FILE")
   assert_contains "PR 一覧取得でページネーションを使用している" "$content" '\-\-paginate'
 }
 
-test_workflow_uses_exit_code_pattern() {
+test_script_uses_exit_code_pattern() {
   local content
-  content=$(cat "$WORKFLOW_FILE")
-  # gh api ... && { success } || { failure } パターンを使用している
-  assert_contains "終了コードで成功/失敗を分岐している" "$content" 'RESPONSE=.*gh api'
+  content=$(cat "$SCRIPT_FILE")
+  # if RESPONSE=$(gh api ...); then ... else ... fi パターンで終了コードで分岐
+  # （旧 A && B || C パターンは SC2015 の誤判定リスクのため if/else に変更）
+  assert_contains "終了コードで成功/失敗を分岐している" "$content" 'if RESPONSE=.*gh api'
 }
 
-test_workflow_uses_pat
-test_workflow_has_pat_guard
-test_workflow_no_include_pattern
-test_workflow_has_conflict_category
-test_workflow_has_skipped_category
-test_workflow_has_four_categories_in_summary
-test_workflow_has_conflict_pr_list
-test_workflow_uses_pagination
-test_workflow_uses_exit_code_pattern
+test_script_has_pat_guard
+test_script_has_conflict_category
+test_script_has_skipped_category
+test_script_has_four_categories_in_summary
+test_script_has_conflict_pr_list
+test_script_uses_pagination
+test_script_uses_exit_code_pattern
 
 # --- docs/ai-review-auth.md PAT セクションテスト ---
 #
@@ -120,7 +141,7 @@ test_workflow_uses_exit_code_pattern
 echo ""
 echo "=== docs/ai-review-auth.md PAT セクションテスト ==="
 
-PAT_DOC_FILE="$(cd "$(dirname "$0")/.." && pwd)/docs/ai-review-auth.md"
+PAT_DOC_FILE="${REPO_ROOT}/docs/ai-review-auth.md"
 
 test_pat_section_present() {
   assert_file_contains "PAT セットアップセクションがある" "$PAT_DOC_FILE" 'PAT セットアップ'


### PR DESCRIPTION
## 何が変わるか

- ✅ 4 つの check 系 workflow に直書きされていた `run: |` ブロック計 5 箇所が `.github/scripts/check-*.sh` 呼び出しに置き換わった
- ✅ 切り出したスクリプトは shebang `#!/usr/bin/env bash` + `set -euo pipefail` + 必須 env 変数検証で防御されるようになった
- ✅ サニティテスト（`bash -n` 構文 / shebang / set -euo pipefail / 実行権限 / workflow と script の対応）が `tests/test_check_workflow_scripts.sh` に追加された

## 切り出し対応

| 旧 workflow inline shell | 新スクリプト |
|---|---|
| `plugin-version-bump-check.yml` step1 (`bash scripts/...`) | `run:` 1 行化（既存 `scripts/check-plugin-version-bump.sh` 呼び出しを維持） |
| `plugin-version-bump-check.yml` step2 (`gh pr comment ...`) | `.github/scripts/check-plugin-version-bump-comment.sh` |
| `intent-label-issue-check.yml` (jq + 3 分岐) | `.github/scripts/check-intent-label-issue.sh` |
| `pr-issue-link-check.yml` (PR 本文 grep) | `.github/scripts/check-pr-issue-link.sh` |
| `update-pr-branches.yml` (全 open PR loop) | `.github/scripts/check-update-pr-branches.sh` |

## 挙動不変性の確認

- 🔍 各 check の exit code・コメント本文・分岐条件は元のインラインシェルと同一
- 🔍 intent ラベル・PR Issue 参照・main push 時のブランチ更新は既存と同じ条件で fail/pass する
- 🔍 `tests/test_plugin_version_bump_check.sh` 等の既存テストが引き続き通る

## 関連

- 親エピック #620
- 並列: #622（`workflow-shell.md` ルール新設） / #623（release/test 系切り出し）
- 子 #625 で shellcheck CI 組込み + 挙動テスト追加予定

close #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI ワークフローを整理し、ラベル検証、PR⇄Issue参照チェック、プラグイン版上げ警告、オープンPR一括更新などのチェック処理をスクリプト化して安定化
* **Tests**
  * ワークフロースクリプトのサニティ検証を追加し、呼び出し関係や基本的な実行要件を自動で確認

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hirokimry/vibecorp/pull/627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->