### PR TITLE
🐛 fix: vibecorp 本体に close-on-feature-merge.yml が配置され、feature ブランチマージで子 Issue が auto-close されるようになる

### DIFF
--- a/.github/workflows/close-on-feature-merge.yml
+++ b/.github/workflows/close-on-feature-merge.yml
@@ -1,0 +1,80 @@
+name: close-on-feature-merge
+
+# feature/epic-* ブランチへの PR がマージされた時、PR 本文の close キーワード
+# (Closes / Fixes / Resolves とそのバリエーション) で参照される Issue を自動 close する。
+#
+# GitHub の自動 close 仕様は default branch (main) へのマージ時のみ発火するため、
+# vibecorp のエピック運用 (feature → main の二段階マージ) では子 PR が
+# feature ブランチへマージされた時点で子 Issue が自動 close されない。
+# 本ワークフローはその制約を回避するためのもの。
+#
+# 設計:
+#   - LLM 呼び出し一切なし (決定論的 / 課金ゼロ)
+#   - 抽出対象は Closes / Fixes / Resolves とそのバリエーション (close[sd]? / fix(es|ed)? / resolve[sd]?)
+#   - Refs #N / Related to #N は対象外 (暴発防止)
+#   - 同一リポジトリの Issue のみ対象 (cross-repo 非対応)
+#   - すでに close 済みの Issue はスキップ (冪等性)
+#
+# 参照:
+#   - GitHub 公式: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
+#   - 配布判断の根拠: docs/design-philosophy.md「統合問題は配布先のデフォルト CI で担保する」
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - 'feature/epic-*'
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR 本文の close キーワードに対応する Issue を抽出して close
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          # close キーワード + 空白 + #N の形式のみを抽出。
+          # 抽出対象: close / closes / closed / fix / fixes / fixed / resolve / resolves / resolved
+          # 対象外:   refs / related to (暴発防止)
+          # GNU grep (ubuntu-latest) の -oiE で正規表現マッチを行う。
+          issues=$(
+            printf '%s\n' "${PR_BODY:-}" \
+              | grep -oiE '\b(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+#[0-9]+' \
+              | grep -oE '[0-9]+' \
+              | sort -u \
+              || true
+          )
+
+          if [[ -z "$issues" ]]; then
+            echo "::notice::PR 本文に close キーワード (Closes/Fixes/Resolves) #N が見つかりませんでした"
+            exit 0
+          fi
+
+          echo "対象 Issue 番号:"
+          echo "$issues"
+
+          # IFS 依存を排除するため while read で 1 行ずつ処理する。
+          # for issue_num in $issues は unquoted word splitting で IFS 設定に依存するため避ける。
+          while IFS= read -r issue_num; do
+            [[ -z "$issue_num" ]] && continue
+            state=$(gh issue view "$issue_num" --repo "$REPO" --json state --jq '.state')
+            if [[ "$state" == "CLOSED" ]]; then
+              echo "Issue #${issue_num} は既に close 済みのためスキップ"
+              continue
+            fi
+            gh issue close "$issue_num" \
+              --repo "$REPO" \
+              --comment "✅ feature ブランチへのマージにより自動 close (PR #${PR_NUMBER})"
+            echo "Issue #${issue_num} を close しました"
+          done <<< "$issues"


### PR DESCRIPTION
## 関連 Issue

close https://github.com/hirokimry/vibecorp/issues/607

## 🎯 背景

vibecorp 本体（このリポジトリ）の `.github/workflows/` に `close-on-feature-merge.yml` が **配置されていなかった**。配布対象テンプレートとしては `templates/.github/workflows/close-on-feature-merge.yml` が `#347` / `#556` で実装済だが、vibecorp 自身は `install.sh` を実行しないため本体には反映されない設計だった。

結果、`feature/epic-*` ブランチへの子 PR マージ時に **子 Issue が auto-close されない**。エピック #590 の子 Issue #591〜#594 がマージ後も OPEN のまま残り、手動 close が必要だった。

## 🔄 Before / After

| 観点 | Before | After |
|------|--------|-------|
| 子 PR マージ時の子 Issue | ⬜ OPEN のまま残る（手動 close 必要） | ✅ 自動で close される |
| dogfooding | ❌ 配布版にあって本体になし | ✅ 本体も配布版と同じ運用品質 |
| エピック運用の手間 | 毎エピック毎に N 件の手動 close | ゼロ |

## 🧭 設計判断

**案 A（本 PR で採用）**: `templates/.github/workflows/close-on-feature-merge.yml` と **完全に同内容** を `.github/workflows/close-on-feature-merge.yml` に配置する（コピー、symlink は git で扱いにくいので不採用）。

**却下した案 B**: `install.sh --name vibecorp --update` を本体で実行する → 配布版前提のファイル群（vibecorp-base 等）が本体構造を壊す可能性があるため見送り（Issue 本文に判断理由あり）。

## 🚧 スコープ外

- **template と body の同期維持の仕組み**（Phase 3 相当）: 別 Issue で扱う
- **`workflow-shell.md` 準拠の shell 抽出**: 本ファイルは `run: |` 内に `while` / `if` を含む 30 行超のインラインシェルを持つが、Issue #607 完了条件「templates と同内容である」を優先するため、抽出は **template + body を一括で扱う別 Issue** で対応する

## 🔍 動作不変性の担保

- `bash tests/test_install_close_on_feature_merge_workflow.sh` で 27/27 PASS（template 側 + install.sh 配布挙動の既存検証は破壊されない）
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/close-on-feature-merge.yml'))"` で YAML パース成功
- `diff templates/.github/workflows/close-on-feature-merge.yml .github/workflows/close-on-feature-merge.yml` で完全一致を確認

## 🛡️ 権限・セキュリティ

要求権限は `issues: write` / `contents: read` / `pull-requests: read` のみ。`administration: write` / `secrets: write` / `workflows: write` 等の禁止権限は要求しておらず、`autonomous-restrictions.md` §6「CI エージェント」に該当するが LLM 呼び出しゼロの決定論的ワークフローのため Issue 本文で **CISO 承認ルートを通る前提** で起票済み（CEO 手動実装ルート）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * featureブランチのPRがマージされた際、PR本文に記載された関連Issueを自動で検出してクローズするワークフローを追加しました。既にクローズされたIssueはスキップされ、クローズ時に自動コメントが付与されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hirokimry/vibecorp/pull/643?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->