### PR TITLE
📖 docs: 通知文・長めのプロンプトの個別ファイル切り出しルールが `.claude/rules/notification-prompt-extraction.md` で確立される

### DIFF
--- a/.claude/rules/notification-prompt-extraction.md
+++ b/.claude/rules/notification-prompt-extraction.md
@@ -5,8 +5,6 @@ paths:
   - ".github/workflows/**/*.yaml"
   - "hooks/**/*.sh"
   - "skills/**/SKILL.md"
-  - ".claude/vibecorp-base/skills/**/SKILL.md"
-  - "templates/claude/agents/**/*.md"
 ---
 
 > [!IMPORTANT]

--- a/.claude/rules/notification-prompt-extraction.md
+++ b/.claude/rules/notification-prompt-extraction.md
@@ -16,7 +16,7 @@ paths:
 
 `.github/workflows/**/*.yml` の `--body "..."` で投稿される **CEO 向け Bot 通知文**、`skills/**/SKILL.md` 内のエージェント呼出プロンプトテンプレ、`hooks/**/*.sh` の長めのエラーメッセージを **個別 `.md` ファイルに切り出す** ことで以下を達成する。
 
-- 規範対象ファイルが明確化（個別 `.md` = `comment-writing.md` / `prompt-writing.md` の管轄）
+- 規範対象ファイルが明確化（個別 `.md` = `document-writing.md` / `prompt-writing.md` の管轄）
 - 既存書き換え動線（`/vibecorp:docs-rewrite-all` / `/vibecorp:prompts-rewrite-all`）が切り出された `.md` を自然に拾える
 - yml / SKILL.md / sh 自体は構造のみ残り、規範チェックの対象が狭まる
 
@@ -38,7 +38,7 @@ paths:
 
 ## 📏 切り出し閾値
 
-**行数軸 + 用途軸の両方**で判定する。**どちらか一方を満たせば切り出し対象**。
+**行数軸と用途軸を併用して判定し、いずれか（OR）を満たせば切り出し対象**とする。
 
 ### 行数軸
 

--- a/.claude/rules/notification-prompt-extraction.md
+++ b/.claude/rules/notification-prompt-extraction.md
@@ -1,0 +1,279 @@
+---
+description: 通知文・長めのプロンプトテンプレを yaml / SKILL.md / hook 内に embed せず、個別 .md ファイルに切り出すための規範ルール（閾値 + 配置先 + 命名規約 + 例外）
+paths:
+  - ".github/workflows/**/*.yml"
+  - ".github/workflows/**/*.yaml"
+  - "hooks/**/*.sh"
+  - "skills/**/SKILL.md"
+  - ".claude/vibecorp-base/skills/**/SKILL.md"
+  - "templates/claude/agents/**/*.md"
+---
+
+> [!IMPORTANT]
+> 通知文・長めのプロンプトテンプレは yaml / SKILL.md / hook 内に **embed しない**。
+> 個別 `.md` ファイルに切り出して規定パスに配置する。
+> 本ルールは **テキスト本体の切り出し** を扱う（yaml 内シェルコードの切り出しは兄弟ルール `workflow-shell.md` の管轄）。
+
+# 📖 通知文・プロンプト切り出し基準
+
+`.github/workflows/**/*.yml` の `--body "..."` で投稿される **CEO 向け Bot 通知文**、`skills/**/SKILL.md` 内のエージェント呼出プロンプトテンプレ、`hooks/**/*.sh` の長めのエラーメッセージを **個別 `.md` ファイルに切り出す** ことで以下を達成する。
+
+- 規範対象ファイルが明確化（個別 `.md` = `comment-writing.md` / `prompt-writing.md` の管轄）
+- 既存書き換え動線（`/vibecorp:docs-rewrite-all` / `/vibecorp:prompts-rewrite-all`）が切り出された `.md` を自然に拾える
+- yml / SKILL.md / sh 自体は構造のみ残り、規範チェックの対象が狭まる
+
+挙動不変が前提（文面の意味・動作を変えずに配置のみ分離する）。
+
+## 🎯 対象範囲
+
+本ルールは frontmatter の `paths` で対象を絞る。
+
+- 対象: yaml workflow / SKILL.md / hook シェルスクリプトのうち、**テキスト本体を embed しているもの**。
+- 読込タイミング: 対象ファイル編集時に lazy-load。
+- 公式仕様: https://code.claude.com/docs/en/memory#path-specific-rules
+
+| 対象種別 | embed されがちな箇所 |
+|---------|------------------|
+| **🤖 GHA workflow** | `gh issue comment --body "..."`, `gh pr comment --body "..."`, `actions/github-script` の `script:` 等 |
+| **⚙️ スキル本体** | エージェント呼出プロンプトテンプレ（` ```text ` ブロック）、長めの利用例 |
+| **🪝 hook シェル** | `echo` / `cat <<EOF` で出力する CEO 向けエラー・警告文 |
+
+## 📏 切り出し閾値
+
+**行数軸 + 用途軸の両方**で判定する。**どちらか一方を満たせば切り出し対象**。
+
+### 行数軸
+
+| 種別 | 閾値 | 根拠 |
+|---|---|---|
+| **通知文（CEO が GitHub UI で読む文面）** | 行数 3 行以上 | `workflow-shell.md` の「3 行以上で切り出し」と整合 |
+| **プロンプトテンプレ（エージェント呼出 / 長めの指示）** | 行数 5 行以上 | プロンプトはコード行より文章行が長いため閾値を緩める |
+| **hook の CEO 向けエラー・警告文** | 行数 3 行以上 | 通知文と同じ扱い |
+
+「行数」はコメント行・空行を除き、実際の文字を持つ行数で数える。
+
+### 用途軸
+
+行数閾値を満たさなくても、**用途**で切り出し対象になる場合がある。
+
+| 用途 | 判定 | 例 |
+|---|---|---|
+| **CEO 通知文（GHA `--body`）** | 行数を問わず切り出し対象 | `gh issue comment --body "⚠️ intent ラベルが付与されていません..."` |
+| **エージェント呼出プロンプトテンプレ** | 行数を問わず切り出し対象 | `Task tool で以下を依頼する: 「以下の計画をレビューしてください...」` |
+| **再利用される定型文** | 2 箇所以上で使われる場合は切り出し対象 | 複数の workflow / SKILL で同じ文面が現れる |
+
+### 判定の優先順位
+
+1. 用途軸（CEO 通知文 / エージェント呼出 / 再利用定型文）に該当するか確認する
+2. 該当しない場合は行数軸で判定する
+3. **両軸とも非該当** であれば embed のまま許容する（例外節を参照）
+
+## 📂 配置先パスの規約
+
+切り出した `.md` ファイルは以下のパスに配置する。
+
+| 用途 | 配置先 | 拾われる動線 |
+|---|---|---|
+| **GHA workflow から呼ぶ通知文** | `.github/workflows/messages/<name>.md` | `/vibecorp:docs-rewrite-all`（`document-writing.md` paths 拡張） |
+| **スキルから呼ぶエージェント呼出プロンプト** | `skills/<skill>/prompts/<name>.md` | `/vibecorp:prompts-rewrite-all`（`prompt-writing.md` paths 拡張） |
+| **hook から呼ぶ CEO 向け文** | `hooks/messages/<name>.md` | `/vibecorp:docs-rewrite-all`（`document-writing.md` paths 拡張） |
+
+### 参照方法
+
+| ファイル種別 | 参照方法 |
+|---|---|
+| **yaml workflow** | `gh issue comment --body-file .github/workflows/messages/<name>.md` |
+| **SKILL.md** | スキル本文内で「以下のプロンプトは `skills/<skill>/prompts/<name>.md` を参照」のように相対パス記述 |
+| **hook シェル** | `cat "${SCRIPT_DIR}/messages/<name>.md"`（`SCRIPT_DIR` は `dirname "${BASH_SOURCE[0]}"` で解決） |
+
+## 📝 命名規約
+
+切り出し先ファイル名は **用途プレフィックス + 内容スラッグ** の組合せ。
+
+| プレフィックス | 用途 | 例 |
+|---|---|---|
+| `notify-` | CEO 通知文（GHA / hook） | `notify-intent-label-missing.md`, `notify-pr-issue-link-missing.md` |
+| `agent-call-` | エージェント呼出プロンプトテンプレ | `agent-call-cpo.md`, `agent-call-ciso.md` |
+| `error-` | エラーメッセージ（hook 等） | `error-permission-denied.md`, `error-config-not-found.md` |
+
+### スラッグの書き方
+
+- kebab-case（小文字 + ハイフン区切り）
+- 2〜4 語
+- 内容が一目で分かる名詞句（動詞起点ではない）
+- 拡張子は `.md` 固定
+
+### 命名例
+
+```text
+.github/workflows/messages/notify-intent-label-missing.md
+.github/workflows/messages/notify-pr-issue-link-missing.md
+.github/workflows/messages/notify-plugin-version-bump-missing.md
+skills/plan/prompts/agent-call-plan-architect.md
+skills/ship/prompts/agent-call-cpo-issue-check.md
+hooks/messages/error-permission-denied.md
+hooks/messages/notify-guide-gate-required.md
+```
+
+## 🚧 例外（切り出さない対象）
+
+以下は **embed のまま許容** する。
+
+| 例外 | 理由 | 例 |
+|---|---|---|
+| **1〜2 行の単純通知** | 切り出すと逆に追跡が困難 | `gh issue comment --body "✅ approved"` |
+| **動的生成文** | 実行時に値を埋め込む文面はテンプレ化が難しい | `echo "Issue #${num} を更新しました"` のみで完結する 1〜2 行 |
+| **文脈依存で意味が変わる文** | 周辺コードと一体で意味を成すもの | エラーハンドリング内の 1 行 `echo "rate limit"` |
+| **エージェントログ・デバッグ出力** | CEO 向けではない開発者向け出力 | `echo "[DEBUG] start" >&2` |
+| **ファイル全体が文面のみで構成されるテンプレ** | 既に `.md` 単体で存在するもの | `README.md` / `CHANGELOG.md` / `docs/**/*.md`（`document-writing.md` の管轄） |
+
+### 例外判定の優先順位
+
+1. 上記例外のいずれかに該当するか確認する
+2. 該当する場合は embed のまま維持し、必要に応じてコード内コメントで「短文のため embed 維持」と明記する
+3. 該当しない場合は切り出し対象とする
+
+## 🔄 Before / After
+
+### 通知文の例（GHA workflow）
+
+#### Before（NG）
+
+```yaml
+- name: intent ラベル不在通知
+  run: |
+    gh issue comment "${ISSUE_NUMBER}" --body "⚠️ intent/* ラベルが付与されていません（許可 7 種のうち 1 つを付ける必要があります）。1 Issue 1 intent ルール（intent/feature, intent/bugfix, intent/performance, intent/security, intent/refactor, intent/infra, intent/docs から 1 つ）に従い、ラベルを 1 つ付与してください。詳細は .claude/rules/intent-labels.md を参照。"
+```
+
+#### After（OK）
+
+```yaml
+- name: intent ラベル不在通知
+  run: gh issue comment "${ISSUE_NUMBER}" --body-file .github/workflows/messages/notify-intent-label-missing.md
+```
+
+切り出し先 `.github/workflows/messages/notify-intent-label-missing.md` には CEO 向け通知文をそのまま配置する。
+
+### プロンプトの例（SKILL.md）
+
+#### Before（NG）
+
+```markdown
+### エージェント起動
+
+Task tool で以下を実行する:
+
+\`\`\`text
+.claude/agents/plan-architect.md の指示に従い、以下の計画をレビューしてください。
+計画ファイル: {plan_content}
+Issue 完了条件: {completion_criteria}
+プロジェクトの既存コード構造: {code_overview}
+\`\`\`
+```
+
+#### After（OK）
+
+```markdown
+### エージェント起動
+
+Task tool で以下を実行する。プロンプトは `skills/plan-review-loop/prompts/agent-call-plan-architect.md` を参照する。
+```
+
+切り出し先 `skills/plan-review-loop/prompts/agent-call-plan-architect.md` には text ブロックの中身をそのまま配置する。
+
+## ✅ 指針（MUST）
+
+1. 📏 **閾値を満たしたら切り出す**
+   - 行数軸（通知文 3 行 / プロンプト 5 行 / hook エラー 3 行）または用途軸（CEO 通知 / エージェント呼出 / 再利用定型文）のいずれか該当で切り出す。
+   - 例外節に該当する場合のみ embed を許容する。
+
+2. 📂 **規定パスに配置する**
+   - `.github/workflows/messages/<name>.md` / `skills/<skill>/prompts/<name>.md` / `hooks/messages/<name>.md`。
+   - 規定外パスは禁止（書き換え動線が拾えなくなる）。
+
+3. 📝 **命名規約に従う**
+   - 用途プレフィックス（`notify-` / `agent-call-` / `error-`）+ kebab-case のスラッグ 2〜4 語。
+   - 拡張子は `.md` 固定。
+
+4. 🔄 **挙動不変を守る**
+   - 切り出し前後で文面の意味・実行時挙動を変えない。
+   - 文言調整が必要な場合は別 Issue で扱う。
+
+5. 🔗 **参照元から参照先が辿れる**
+   - yaml 側は `--body-file <path>` で参照する。
+   - SKILL.md / hook 側はファイル本文で「以下のプロンプトは `<path>` を参照」のように記述する。
+
+## ❌ 禁止パターン
+
+- ❌ **3 行以上の通知文を `--body "..."` に直接 embed する**
+  - CEO 向け文面の所在が不明瞭になる。
+- ❌ **5 行以上のプロンプトテンプレを SKILL.md 内に embed する**
+  - 規範対象（`prompt-writing.md`）の管轄が混在する。
+- ❌ **規定外パス（例: `.github/workflows/*.txt` / `skills/<skill>/prompts.txt`）に切り出す**
+  - 書き換え動線が拾えなくなる。
+- ❌ **命名規約を無視した名前（例: `body1.md` / `prompt.md`）**
+  - 用途が一目で判別不能になる。
+- ❌ **切り出し時に文面を変更する**
+  - 挙動不変の前提を破る。文言調整は別 Issue で扱う。
+- ❌ **動的生成文（実行時に値を埋め込む 1〜2 行）を無理に切り出す**
+  - テンプレ化困難で逆に追跡コストが上がる。
+
+## 🧪 テスト可能性
+
+ルール本体は `tests/test_notification_prompt_extraction_rule.sh` で静的検証する。
+
+- 確認対象: 中核セクション存在を grep で検出できること。
+
+### 静的検証で確認すること
+
+- ルールファイル本体の存在。
+- frontmatter の `description` / `paths` キー存在。
+- `paths` に `.github/workflows/**` / `hooks/**` / `skills/**/SKILL.md` が含まれること。
+- 中核セクション見出し（切り出し閾値 / 配置先 / 命名規約 / 例外 / 禁止パターン）の存在。
+- 規定パス文字列（`.github/workflows/messages/` / `skills/<skill>/prompts/` / `hooks/messages/`）の存在。
+- 命名プレフィックス（`notify-` / `agent-call-` / `error-`）の存在。
+- 兄弟ルール `workflow-shell.md` への相互参照の存在。
+
+### shell.md 整合
+
+- `grep -q -e` でパターン終端を明示。
+  - 理由: `-` 始まりパターン対策。
+- `set -euo pipefail` 下で前提ファイル不在時は `fail` 後に `exit 1`。
+  - 理由: 後続テスト無効化防止。
+- `sed -i` 不使用。
+  - 理由: Bash 互換性確保。
+
+## 🔗 兄弟ルール（workflow-shell.md との関係）
+
+`workflow-shell.md` と本ルールは **対象が異なる兄弟ルール** であり競合しない。
+
+| ルール | 対象 | 切り出し先 |
+|---|---|---|
+| `workflow-shell.md` | yaml `run:` ブロックの **シェルコード** | `.github/scripts/*.sh` |
+| `notification-prompt-extraction.md`（本ルール） | yaml `--body` / SKILL.md / hook の **テキスト本体** | `.github/workflows/messages/*.md` / `skills/<skill>/prompts/*.md` / `hooks/messages/*.md` |
+
+### 両ルールの併用例
+
+`.github/workflows/intent-label-issue-check.yml` で 3 行以上のシェル処理が `gh issue comment --body "..."` を呼ぶ場合:
+
+1. `workflow-shell.md` に従ってシェル本体を `.github/scripts/intent-label-check.sh` に切り出す。
+2. 本ルールに従って `gh issue comment --body-file .github/workflows/messages/notify-intent-label-missing.md` に切り出す。
+3. workflow yaml 側には 1〜2 行の呼び出しのみ残る。
+
+両者を併用することで yaml は **構造のみ** が残り、コード本体は `.sh`、テキスト本体は `.md` に分離される。
+
+## 🔗 関連ルール
+
+- 兄弟ルール（コード切り出し）: `workflow-shell.md`
+- ベース基準（全 .md 共通）: `document-writing.md`
+- プロンプト系拡張: `prompt-writing.md`
+- CEO 向け文面規約: `communication.md`
+- 配置・言語規約: `documentation.md`
+- マークダウン規約（フェンスコードブロック言語指定義務）: `markdown.md`
+
+## 📂 関連ファイル
+
+- `tests/test_notification_prompt_extraction_rule.sh`（本ルールの静的検証）
+- `.github/workflows/messages/`（切り出し先、子3 #640 で本体セルフ適応）
+- `skills/<skill>/prompts/`（切り出し先、子4 #642 で本体セルフ適応）
+- `hooks/messages/`（切り出し先、子3 #640 で本体セルフ適応）

--- a/tests/test_notification_prompt_extraction_rule.sh
+++ b/tests/test_notification_prompt_extraction_rule.sh
@@ -33,7 +33,12 @@ fi
 echo "=== frontmatter で paths が複数指定されている ==="
 # ============================================
 
-assert_file_contains "ファイル先頭が --- で始まる frontmatter" "$NPE_RULE" "^---$"
+FIRST_LINE="$(head -n1 "$NPE_RULE")"
+if [[ "$FIRST_LINE" == "---" ]]; then
+  pass "ファイル先頭が --- で始まる frontmatter"
+else
+  fail "ファイル先頭が --- ではありません（先頭: ${FIRST_LINE}）"
+fi
 assert_file_contains "description キーが存在" "$NPE_RULE" "^description:"
 assert_file_contains "paths キーが存在" "$NPE_RULE" "^paths:"
 # 必須エントリ群（対象範囲: yaml workflow / hook / SKILL.md）

--- a/tests/test_notification_prompt_extraction_rule.sh
+++ b/tests/test_notification_prompt_extraction_rule.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# test_notification_prompt_extraction_rule.sh — 通知文・プロンプト切り出しルール（Issue #637）の整合性テスト
+# 使い方: bash tests/test_notification_prompt_extraction_rule.sh
+# CI: GitHub Actions で自動実行
+
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${TESTS_DIR}/lib/test_helpers.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+NPE_RULE="${SCRIPT_DIR}/.claude/rules/notification-prompt-extraction.md"
+COMM_RULE="${SCRIPT_DIR}/.claude/rules/communication.md"
+DOC_RULE="${SCRIPT_DIR}/.claude/rules/document-writing.md"
+PW_RULE="${SCRIPT_DIR}/.claude/rules/prompt-writing.md"
+
+# ============================================
+echo "=== .claude/rules/notification-prompt-extraction.md が存在する ==="
+# ============================================
+
+assert_file_exists ".claude/rules/notification-prompt-extraction.md が存在する" "$NPE_RULE"
+
+if [[ ! -f "$NPE_RULE" ]]; then
+  # 前提ファイル不在 → 後続テストは全て無意味なので即終了（testing.md 規約）
+  echo ""
+  echo "=== 結果: ${PASSED}/${TOTAL} passed, ${FAILED} failed ==="
+  echo "notification-prompt-extraction.md が存在しないため後続テストを中止します"
+  exit 1
+fi
+
+# ============================================
+echo "=== frontmatter で paths が複数指定されている ==="
+# ============================================
+
+assert_file_contains "ファイル先頭が --- で始まる frontmatter" "$NPE_RULE" "^---$"
+assert_file_contains "description キーが存在" "$NPE_RULE" "^description:"
+assert_file_contains "paths キーが存在" "$NPE_RULE" "^paths:"
+# 必須エントリ群（対象範囲: yaml workflow / hook / SKILL.md）
+assert_file_contains "paths に .github/workflows/**/*.yml が含まれる" "$NPE_RULE" '"\.github/workflows/\*\*/\*\.yml"'
+assert_file_contains "paths に .github/workflows/**/*.yaml が含まれる" "$NPE_RULE" '"\.github/workflows/\*\*/\*\.yaml"'
+assert_file_contains "paths に hooks/**/*.sh が含まれる" "$NPE_RULE" '"hooks/\*\*/\*\.sh"'
+assert_file_contains "paths に skills/**/SKILL.md が含まれる" "$NPE_RULE" '"skills/\*\*/SKILL\.md"'
+
+# ============================================
+echo "=== 冒頭 IMPORTANT コールアウトに本ルールの主旨が含まれる ==="
+# ============================================
+
+assert_file_contains "冒頭に > [!IMPORTANT] コールアウト" "$NPE_RULE" "^> \[!IMPORTANT\]"
+assert_file_contains "通知文を切り出す主旨が明記されている" "$NPE_RULE" "通知文"
+assert_file_contains "プロンプトテンプレを切り出す主旨が明記されている" "$NPE_RULE" "プロンプトテンプレ"
+assert_file_contains "兄弟ルール workflow-shell.md への言及" "$NPE_RULE" "workflow-shell\.md"
+
+# ============================================
+echo "=== 中核セクション（切り出し閾値 / 配置先 / 命名規約 / 例外 / 禁止パターン）が揃っている ==="
+# ============================================
+
+assert_file_contains "「対象範囲」セクション" "$NPE_RULE" "^## 🎯 対象範囲"
+assert_file_contains "「切り出し閾値」セクション" "$NPE_RULE" "^## 📏 切り出し閾値"
+assert_file_contains "「配置先パスの規約」セクション" "$NPE_RULE" "^## 📂 配置先パス"
+assert_file_contains "「命名規約」セクション" "$NPE_RULE" "^## 📝 命名規約"
+assert_file_contains "「例外」セクション" "$NPE_RULE" "^## 🚧 例外"
+assert_file_contains "「Before / After」セクション" "$NPE_RULE" "^## 🔄 Before / After"
+assert_file_contains "「指針（MUST）」セクション" "$NPE_RULE" "^## ✅ 指針"
+assert_file_contains "「禁止パターン」セクション" "$NPE_RULE" "^## ❌ 禁止パターン"
+assert_file_contains "「テスト可能性」セクション" "$NPE_RULE" "^## 🧪 テスト可能性"
+assert_file_contains "「兄弟ルール」セクション" "$NPE_RULE" "^## 🔗 兄弟ルール"
+
+# ============================================
+echo "=== 切り出し閾値（行数軸 + 用途軸）が定義されている ==="
+# ============================================
+
+assert_file_contains "行数軸の言及" "$NPE_RULE" "行数軸"
+assert_file_contains "用途軸の言及" "$NPE_RULE" "用途軸"
+assert_file_contains "通知文 3 行以上の閾値" "$NPE_RULE" "3 行以上"
+assert_file_contains "プロンプトテンプレ 5 行以上の閾値" "$NPE_RULE" "5 行以上"
+assert_file_contains "CEO 通知文の用途軸該当" "$NPE_RULE" "CEO 通知"
+assert_file_contains "エージェント呼出プロンプトの用途軸該当" "$NPE_RULE" "エージェント呼出"
+
+# ============================================
+echo "=== 規定パス（messages/*.md / prompts/*.md / hooks/messages/*.md）が定義されている ==="
+# ============================================
+
+assert_file_contains "GHA workflow 通知文の規定パス" "$NPE_RULE" "\.github/workflows/messages/"
+assert_file_contains "スキルプロンプトの規定パス" "$NPE_RULE" "skills/<skill>/prompts/"
+assert_file_contains "hook 通知文の規定パス" "$NPE_RULE" "hooks/messages/"
+
+# ============================================
+echo "=== 命名プレフィックス（notify- / agent-call- / error-）が定義されている ==="
+# ============================================
+
+assert_file_contains "命名プレフィックス notify-" "$NPE_RULE" "notify-"
+assert_file_contains "命名プレフィックス agent-call-" "$NPE_RULE" "agent-call-"
+assert_file_contains "命名プレフィックス error-" "$NPE_RULE" "error-"
+assert_file_contains "命名例 notify-intent-label-missing.md" "$NPE_RULE" "notify-intent-label-missing\.md"
+assert_file_contains "命名例 agent-call-cpo.md" "$NPE_RULE" "agent-call-cpo\.md"
+
+# ============================================
+echo "=== 例外節（切り出さない対象）が明示されている ==="
+# ============================================
+
+assert_file_contains "1〜2 行の単純通知が例外として明示" "$NPE_RULE" "1〜2 行"
+assert_file_contains "動的生成文が例外として明示" "$NPE_RULE" "動的生成"
+assert_file_contains "デバッグ出力が例外として明示" "$NPE_RULE" "デバッグ"
+
+# ============================================
+echo "=== 指針（MUST）が 5 項目ある ==="
+# ============================================
+
+MUST_COUNT=$(awk '/^## ✅ 指針/{flag=1; next} /^## /{flag=0} flag && /^[0-9]+\. /' "$NPE_RULE" | wc -l | tr -d ' ')
+if [[ "$MUST_COUNT" -ge 5 ]]; then
+  pass "指針（MUST）が 5 項目以上ある（${MUST_COUNT} 個検出）"
+else
+  fail "指針（MUST）が 5 項目未満（${MUST_COUNT} 個検出、5 個以上必要）"
+fi
+
+# ============================================
+echo "=== 禁止パターンが 5 項目以上ある ==="
+# ============================================
+
+FORBID_COUNT=$(awk '/^## ❌ 禁止パターン/{flag=1; next} /^## /{flag=0} flag && /^- ❌/' "$NPE_RULE" | wc -l | tr -d ' ')
+if [[ "$FORBID_COUNT" -ge 5 ]]; then
+  pass "禁止パターンが 5 項目以上ある（${FORBID_COUNT} 個検出）"
+else
+  fail "禁止パターンが 5 項目未満（${FORBID_COUNT} 個検出、5 個以上必要）"
+fi
+
+# ============================================
+echo "=== 関連ルールへの整合宣言（communication.md / document-writing.md / prompt-writing.md） ==="
+# ============================================
+
+assert_file_contains "communication.md への参照" "$NPE_RULE" "communication\.md"
+assert_file_contains "document-writing.md への参照" "$NPE_RULE" "document-writing\.md"
+assert_file_contains "prompt-writing.md への参照" "$NPE_RULE" "prompt-writing\.md"
+assert_file_contains "workflow-shell.md への参照（兄弟ルール）" "$NPE_RULE" "workflow-shell\.md"
+
+# ============================================
+echo "=== 関連ルールが実在する（前提整合） ==="
+# ============================================
+
+assert_file_exists "communication.md が実在する" "$COMM_RULE"
+assert_file_exists "document-writing.md が実在する" "$DOC_RULE"
+assert_file_exists "prompt-writing.md が実在する" "$PW_RULE"
+# 注: workflow-shell.md は本 base ブランチ（feature/epic-636）には未取り込み（main 由来）。
+# 将来 main 取り込み or リリース時に解決される前提のため、ここでは存在チェックを行わない。
+
+# ============================================
+echo "=== Markdown フェンスに言語指定がある（markdown.md 整合） ==="
+# ============================================
+
+# 開きフェンス（奇数番目の ``` 行）に言語指定があるかを確認
+# 閉じフェンスは ``` 単独で正常。1, 3, 5... 番目が開きフェンス
+NAKED_OPEN=$(awk '
+  /^```/ {
+    count++
+    if (count % 2 == 1 && $0 == "```") { bad++ }
+  }
+  END { print bad+0 }
+' "$NPE_RULE")
+if [[ "$NAKED_OPEN" -eq 0 ]]; then
+  pass "全開きフェンスに言語指定がある"
+else
+  fail "言語指定なしの開きフェンスが ${NAKED_OPEN} 箇所ある"
+fi
+
+# ============================================
+echo "=== 結果サマリ ==="
+# ============================================
+
+print_test_summary


### PR DESCRIPTION
## 🎯 背景・目的

エピック #636 の **子1**。

`.github/workflows/**/*.yml` の `gh issue comment --body "..."` 経由で投稿される **CEO 向け Bot 通知文** や、`skills/**/SKILL.md` の中に embed されている **長めのエージェント呼出プロンプトテンプレ** を、個別 `.md` ファイルに切り出すための **規範ルール** が確立される。

これにより、CEO がレビューする通知文と、エージェント呼出プロンプトの所在が明確化し、既存の書き換え動線（`/vibecorp:docs-rewrite-all` 等）が切り出された `.md` を自然に拾えるようになる。

挙動不変（規範ドキュメントとテストの新設のみ。実行時挙動は一切変えない）。

## 🔄 Before / After

| 観点 | 🔴 Before | 🟢 After |
|------|----------|---------|
| 切り出し基準 | 無し（書き手の判断） | `notification-prompt-extraction.md` で行数 + 用途の両軸で MUST 定義 |
| 配置先 | 各 yml / SKILL.md / .sh 内に embed | `.github/workflows/messages/*.md` / `skills/<skill>/prompts/*.md` / `hooks/messages/*.md` の規定パス |
| 命名規約 | 無し | `notify-` / `agent-call-` / `error-` の用途プレフィックス + kebab-case スラッグ |
| 例外（切り出さない対象） | 不明 | 1〜2 行通知・動的生成文・デバッグ出力等を明示 |

## 🆕 確立されるルールの中身

- 📏 **切り出し閾値**: 通知文 3 行以上 / プロンプト 5 行以上 / 用途軸（CEO 通知・エージェント呼出・再利用定型文）に該当
- 📂 **規定パス**: `.github/workflows/messages/*.md`, `skills/<skill>/prompts/*.md`, `hooks/messages/*.md`
- 📝 **命名プレフィックス**: `notify-<slug>.md`, `agent-call-<slug>.md`, `error-<slug>.md`
- 🚧 **例外**: 短い通知・動的生成文・文脈依存文・デバッグ出力は embed 維持
- 🔗 **兄弟ルール**: `workflow-shell.md`（yaml 内シェル切り出し）との棲み分けを `🔗 兄弟ルール` セクションで整理

## 🧭 設計判断

- **行数軸 + 用途軸の併用**: 行数だけだと「3 行未満の CEO 通知」が取りこぼされ、用途だけだと「5 行未満のプロンプト」が取りこぼされる。両軸 OR で判定することで漏れを防ぐ
- **配置先パスの規約化**: 切り出し先パスを規定することで、後続の書き換え動線（`/vibecorp:docs-rewrite-all` / `/vibecorp:prompts-rewrite-all`）が glob で拾える
- **命名プレフィックス 3 種**: `notify-` / `agent-call-` / `error-` の 3 種で用途を即座に判別可能にする
- **例外節を必ず設ける**: 動的に値を埋め込む通知や、文脈依存で意味が変わる短文は embed 維持。過剰切り出しを防ぐ

## 🔍 動作不変性の担保

- ルール本体と静的検証テストの新設のみで、ランタイムコード・workflow yaml・hooks スクリプト・SKILL.md 本体は一切変更していない
- 新規テスト `tests/test_notification_prompt_extraction_rule.sh` が 49 アサーション全件 PASS
- 隣接ルールテスト 3 件（`test_prompt_writing_rule.sh` / `test_document_writing_rule.sh` / `test_communication_rule.sh`）が引き続き全件 PASS（副作用なし）

## 🚧 スコープ外

| 領域 | 担当 Issue |
|------|----------|
| 配布対応（`.claude/vibecorp-base/rules/` + `templates/claude/rules/` への配置） | 子2 #638 |
| migration skill 新設（`/notifications-extract-all` + `/prompts-extract-all`） | 子5 #645 |
| vibecorp 本体の通知文セルフ適応 | 子3 #640 |
| vibecorp 本体のプロンプトセルフ適応 | 子4 #642 |
| `workflow-shell.md` 本体の改修 | 別 Issue（main 由来、本 base ブランチに未取り込み） |

## 🖼️ 位置づけ

```text
[本 PR] 子1 #637（切り出しルール確立） ← イマココ
   └─ 子2 #638（配布）
        └─ 子5 #645（migration skill 新設）
             ├─ 子3 #640（本体: 通知文セルフ適応）
             └─ 子4 #642（本体: プロンプトセルフ適応）
```

## 📍 base ブランチ依存の注意

- 本 PR の base は `feature/epic-636_notification_prompt_extraction`
- 兄弟ルール `workflow-shell.md`（main 由来）は base に未取り込みのため、本ルール内の相互参照リンクは将来の main 取り込み or リリース時に解決される前提
- 既存テスト `tests/test_workflow_shell_rule.sh` も base には未存在（main にのみ存在）

close https://github.com/hirokimry/vibecorp/issues/637


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 通知メッセージと長めプロンプトの切り出しルールを追加しました。対象パス、命名プレフィックス、行数基準、配置先、例外・禁止パターン、Before/After例などの運用指針を規定します。

* **Tests**
  * ルールの静的整合性を自動検証するテストを追加しました。frontmatter・見出し・閾値・例数・関連文書参照・コードブロック表記などをチェックします。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hirokimry/vibecorp/pull/646?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->