### PR TITLE
🔄 refactor: vibecorp 本体の通知文が個別ファイルに切り出され、`.github/workflows/messages/*.md` 等から参照される

### DIFF
--- a/.github/workflows/messages/notify-plugin-version-bump-missing.md
+++ b/.github/workflows/messages/notify-plugin-version-bump-missing.md
@@ -1,0 +1,1 @@
+⚠️ `.claude-plugin/marketplace.json` の `plugins[0].skills` が変更されていますが、`.claude-plugin/plugin.json` の `version` が bump されていません。利用者は新しいスキルを取得するために version bump を必要とします（PR #459 と同種の取りこぼし防止）。マージ前に `.claude-plugin/plugin.json` の `version` を更新してください。本チェックは警告のみ・非ブロックです。

--- a/.github/workflows/messages/notify-pr-issue-link-missing.md
+++ b/.github/workflows/messages/notify-pr-issue-link-missing.md
@@ -1,0 +1,1 @@
+⚠️ PR 本文に対応 Issue への参照（`close #123` / `fixes #123` / `Refs #123` など）が含まれていません。vibecorp は Issue 経由起票必須運用（Issue #469 残 #5）のため、PR 本文に Issue 参照を追加してから再 push してください。詳細は .claude/rules/intent-labels.md と docs/conventional-commits.md を参照。

--- a/.github/workflows/plugin-version-bump-check.yml
+++ b/.github/workflows/plugin-version-bump-check.yml
@@ -52,4 +52,4 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           gh pr comment "$PR_NUMBER" --repo "$REPO" \
-            --body "⚠️ \`.claude-plugin/marketplace.json\` の \`plugins[0].skills\` が変更されていますが、\`.claude-plugin/plugin.json\` の \`version\` が bump されていません。利用者は新しいスキルを取得するために version bump を必要とします（PR #459 と同種の取りこぼし防止）。マージ前に \`.claude-plugin/plugin.json\` の \`version\` を更新してください。本チェックは警告のみ・非ブロックです。"
+            --body-file .github/workflows/messages/notify-plugin-version-bump-missing.md

--- a/.github/workflows/pr-issue-link-check.yml
+++ b/.github/workflows/pr-issue-link-check.yml
@@ -24,6 +24,13 @@ jobs:
     # Fork PR は secrets が渡らないため除外（draft も除外でコスト抑制）
     if: github.event.pull_request.head.repo.full_name == github.repository && !github.event.pull_request.draft
     steps:
+      - name: チェックアウト（通知文ファイル参照のため）
+        uses: actions/checkout@v4
+        with:
+          # 通知文 .md のみ必要なので sparse-checkout で最小化
+          sparse-checkout: .github/workflows/messages
+          sparse-checkout-cone-mode: false
+
       - name: PR 本文の Issue 参照チェック
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -38,5 +45,5 @@ jobs:
             exit 0
           fi
           gh pr comment "$PR_NUMBER" --repo "$REPO" \
-            --body "⚠️ PR 本文に対応 Issue への参照（\`close #123\` / \`fixes #123\` / \`Refs #123\` など）が含まれていません。vibecorp は Issue 経由起票必須運用（Issue #469 残 #5）のため、PR 本文に Issue 参照を追加してから再 push してください。詳細は .claude/rules/intent-labels.md と docs/conventional-commits.md を参照。"
+            --body-file .github/workflows/messages/notify-pr-issue-link-missing.md
           exit 1

--- a/install.sh
+++ b/install.sh
@@ -753,6 +753,18 @@ copy_managed_files() {
     fi
   done
 
+  # hooks/messages: hook が参照する CEO 向け通知文ファイルを配布（常に最新で上書き）
+  # .claude/rules/notification-prompt-extraction.md に基づき hook から外部化された通知文。
+  # protect-knowledge-direct-writes.sh / protect-knowledge-bash-writes.sh 等が cat で読み込む。
+  if [[ -d "${SCRIPT_DIR}/templates/claude/hooks/messages" ]]; then
+    local messages_dir="${hooks_dir}/messages"
+    mkdir -p "$messages_dir"
+    for src in "${SCRIPT_DIR}/templates/claude/hooks/messages/"*.md; do
+      [[ -f "$src" ]] || continue
+      cp "$src" "${messages_dir}/$(basename "$src")"
+    done
+  fi
+
   # --update: テンプレートから廃止された hook（lock 記載 + templates 不在）を削除
   if [[ "$UPDATE_MODE" == true ]]; then
     remove_orphan_hooks

--- a/templates/claude/hooks/messages/notify-knowledge-bash-write-denied.md
+++ b/templates/claude/hooks/messages/notify-knowledge-bash-write-denied.md
@@ -1,0 +1,11 @@
+検出パス: {{DETECTED}}
+
+.claude/knowledge/{role}/decisions/ や {role}/audit-log/ への Bash 経由直書きは禁止です（>, >>, tee, cp, mv, sed -i, awk -i inplace を含む）。
+
+復旧手順:
+1. . .claude/lib/knowledge_buffer.sh
+2. knowledge_buffer_ensure
+3. BUFFER_DIR={{BUFFER}}
+4. コマンドの宛先を ${BUFFER_DIR}/.claude/knowledge/... に置き換えて再実行
+
+書込みは Bash redirect ではなく Edit/Write/MultiEdit ツールを使うことを推奨します（hook が deny を確実に検出できます）。

--- a/templates/claude/hooks/messages/notify-knowledge-direct-write-denied.md
+++ b/templates/claude/hooks/messages/notify-knowledge-direct-write-denied.md
@@ -1,0 +1,10 @@
+.claude/knowledge/{role}/decisions/ や {role}/audit-log/ は knowledge/buffer worktree 経由で更新してください。
+
+復旧手順:
+1. . .claude/lib/knowledge_buffer.sh
+2. knowledge_buffer_ensure
+3. BUFFER_DIR=$(knowledge_buffer_worktree_dir)
+4. ファイルパスを ${BUFFER_DIR}/.claude/knowledge/... に置き換えて再実行
+
+スキル経由の場合: /vibecorp:session-harvest, /vibecorp:sync-edit, /vibecorp:audit-cost, /vibecorp:audit-security のいずれかを使用
+詳細: docs/specification.md の「自動反映フロー」節

--- a/templates/claude/hooks/protect-knowledge-bash-writes.sh
+++ b/templates/claude/hooks/protect-knowledge-bash-writes.sh
@@ -124,14 +124,16 @@ fi
 
 buffer_label="${buffer_dir:-（未取得・knowledge_buffer_ensure を実行してください）}"
 
-jq -n \
-  --arg detected "$detected_path" \
-  --arg buffer "$buffer_label" \
-  '{
-    "hookSpecificOutput": {
-      "hookEventName": "PreToolUse",
-      "permissionDecision": "deny",
-      "permissionDecisionReason": ("検出パス: " + $detected + "\n\n.claude/knowledge/{role}/decisions/ や {role}/audit-log/ への Bash 経由直書きは禁止です（>, >>, tee, cp, mv, sed -i, awk -i inplace を含む）。\n\n復旧手順:\n1. . .claude/lib/knowledge_buffer.sh\n2. knowledge_buffer_ensure\n3. BUFFER_DIR=" + $buffer + "\n4. コマンドの宛先を ${BUFFER_DIR}/.claude/knowledge/... に置き換えて再実行\n\n書込みは Bash redirect ではなく Edit/Write/MultiEdit ツールを使うことを推奨します（hook が deny を確実に検出できます）。")
-    }
-  }'
+# 通知文テンプレートを外部 .md から読み込み、bash 文字列置換でプレースホルダを展開
+template=$(cat "${HOOK_DIR}/messages/notify-knowledge-bash-write-denied.md")
+reason="${template//\{\{DETECTED\}\}/$detected_path}"
+reason="${reason//\{\{BUFFER\}\}/$buffer_label}"
+
+jq -n --arg reason "$reason" '{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": $reason
+  }
+}'
 exit 0

--- a/templates/claude/hooks/protect-knowledge-direct-writes.sh
+++ b/templates/claude/hooks/protect-knowledge-direct-writes.sh
@@ -86,12 +86,13 @@ fi
 # 仕様: スタンプは knowledge/{role}/{topic}.md のような decisions/audit-log 以外への直書き許可専用。
 # decisions/ や {role}/audit-log/ は C*O 判断記録 / 監査の責務領域であり、スタンプ通過対象から除外する。
 
-# deny を返却
-jq -n '{
+# deny を返却（通知文本体は外部 .md ファイルから読み込む）
+reason=$(cat "${HOOK_DIR}/messages/notify-knowledge-direct-write-denied.md")
+jq -n --arg reason "$reason" '{
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
     "permissionDecision": "deny",
-    "permissionDecisionReason": ".claude/knowledge/{role}/decisions/ や {role}/audit-log/ は knowledge/buffer worktree 経由で更新してください。\n\n復旧手順:\n1. . .claude/lib/knowledge_buffer.sh\n2. knowledge_buffer_ensure\n3. BUFFER_DIR=$(knowledge_buffer_worktree_dir)\n4. ファイルパスを ${BUFFER_DIR}/.claude/knowledge/... に置き換えて再実行\n\nスキル経由の場合: /vibecorp:session-harvest, /vibecorp:sync-edit, /vibecorp:audit-cost, /vibecorp:audit-security のいずれかを使用\n詳細: docs/specification.md の「自動反映フロー」節"
+    "permissionDecisionReason": $reason
   }
 }'
 exit 0


### PR DESCRIPTION
## 関連 Issue

close https://github.com/hirokimry/vibecorp/issues/640

## 🎯 背景・目的

エピック #636 の **子3**。子1〜2 (#646, #647) で確立した切り出しルールと、子5 (#648) で新設した `/notifications-extract-all` skill を使い、vibecorp 本体の **通知文** にセルフ適応する。

挙動不変リファクタ（文字列の切り出しのみ。通知文面・実行時挙動の変化なし）。

## 🔄 Before / After

| 観点 | 🔴 Before | 🟢 After |
|------|---------|---------|
| Bot 通知文の所在 | yml の `--body \"...\"` に embed | `.github/workflows/messages/*.md` から参照 |
| hooks エラーメッセージ | `.sh` 内に長文 jq reason | `templates/claude/hooks/messages/*.md` から読み込み |
| 規範対象 | yml / sh が混在し読みづらい | 個別 `.md` が `comment-writing.md` 管轄、yml / sh は構造のみ |

## 🧱 切り出し対象（本 PR）

### GHA workflows (2 件)

| 由来 | 切り出し先 |
|------|---------|
| `.github/workflows/plugin-version-bump-check.yml` の `--body` 通知文 | `.github/workflows/messages/notify-plugin-version-bump-missing.md` |
| `.github/workflows/pr-issue-link-check.yml` の `--body` 通知文 | `.github/workflows/messages/notify-pr-issue-link-missing.md` |

### hooks (2 件)

| 由来 | 切り出し先 |
|------|---------|
| `templates/claude/hooks/protect-knowledge-direct-writes.sh` の長文 deny メッセージ（7 行） | `templates/claude/hooks/messages/notify-knowledge-direct-write-denied.md` |
| `templates/claude/hooks/protect-knowledge-bash-writes.sh` の長文 deny メッセージ（プレースホルダで `\$detected`/\$buffer\` を実行時展開） | `templates/claude/hooks/messages/notify-knowledge-bash-write-denied.md` |

### install.sh

`templates/claude/hooks/messages/*.md` を `.claude/hooks/messages/` に配布するようになった（hook 本体と同じディレクトリ階層を維持）。

## 🧭 設計判断

### intent-label-issue-check.yml は本 PR スコープ外

`.github/workflows/intent-label-issue-check.yml` の 3 件の通知文は **本 PR スコープ外**。理由:

- `--body-file` を使うには workflow に `actions/checkout` ステップが必要
- 現状の intent-label-issue-check.yml には checkout がなく、追加には `permissions.contents: read` の追加が必要
- Issue #640 本文「permissions / secrets / triggers は触れない」の制約に従う

➡️ 別 Issue で permissions 拡張込みの対応を行う（子3 内で「1 PR を試験してから残りに展開」という Issue 設計判断と整合）。

### 例外節該当の通知文は embed 維持

短文（1〜2 行）・動的展開のみの `protect-files.sh` / `role-gate.sh` / `sync-gate.sh` 等の jq reason は skill 例外節該当で **embed 維持**。

### bash-write 通知文のプレースホルダ展開

`protect-knowledge-bash-writes.sh` の通知文は `\$detected_path` / `\$buffer_label` の動的展開を含むため、`.md` ファイルに `{{DETECTED}}` / `{{BUFFER}}` プレースホルダを置き、hook 内で bash 文字列置換（\`\${template//\\{\\{DETECTED\\}\\}/\$detected_path}\`）で展開する方式を採用。`sed` の区切り文字パース問題（パス内の `|` 文字混入）を避けるため bash native の置換を選択。

## 🔒 除外保護（autonomous-restrictions.md §6 遵守）

- ✅ permissions / secrets / triggers は触れていない
- ✅ `actions/checkout` 追加は read-only かつ既存パターン（plugin-version-bump-check.yml で既使用）
- ✅ pr-issue-link-check.yml は元から `contents: read` 権限あり（sparse-checkout で最小化）

## 🔍 挙動不変性の担保

1. **文字列層厳密一致検証**: 切り出し前後で whitespace 含めて厳密一致を検証スクリプトで確認

   | 通知文 | 検証結果 |
   |--------|---------|
   | direct-write deny | ✅ PASS（厳密一致） |
   | bash-write deny（プレースホルダ展開後） | ✅ PASS（厳密一致） |
   | pr-issue-link missing | ✅ PASS（厳密一致） |
   | plugin-version-bump missing | ✅ PASS（厳密一致） |

2. **テスト層**: 関連テスト全件通過

   | テスト | 結果 |
   |--------|------|
   | test_protect_knowledge_bash_writes.sh | ✅ 32/32 |
   | test_protect_knowledge_direct_writes.sh | ✅ 24/24 |
   | test_notification_prompt_extraction_rule.sh | ✅ 49/49 |
   | test_notifications_extract_all_skill.sh | ✅ 68/68 |
   | test_plugin_version_bump_check.sh | ✅ 5/5 |
   | test_intent_labels_rule_sync.sh | ✅ 3/3 |
   | test_install_orphan_hook.sh | ✅ 9/9 |
   | test_install_update.sh | ✅ 62/62 |
   | test_install_plugin_version.sh | ✅ 4/4 |

## 🚧 スコープ外

- `.github/workflows/intent-label-issue-check.yml` の 3 件の通知文（permissions 拡張が必要、別 Issue で対応）
- `notification-prompt-extraction.md` の中身の改修（子1 #646 で完了）
- 配布対応（子2 #647 で完了）
- migration skill 新設（子5 #648 で完了）
- プロンプト切り出し（子4 #642 で並行実装中）
- 書き換え動線の拡張（epic #629 子3 #633）

## 🖼️ 位置づけ

```text
epic #636 通知文・プロンプト個別ファイル切り出し
  ├── 子1 #646 ✅ 切り出しルール確立
  ├── 子2 #647 ✅ ルール配布
  ├── 子3 #640 ⬅️ 本 PR（vibecorp 本体の通知文セルフ適応）
  ├── 子4 #642 🚧 並行（SKILL.md プロンプト切り出し）
  └── 子5 #648 ✅ migration skill 新設
```

## テスト計画

- [x] 切り出し前後の通知文が whitespace 含めて厳密一致
- [x] 関連テスト全件通過（256/256）
- [ ] CI で全 workflow テストが通過する
- [ ] CodeRabbit レビューで挙動不変性が承認される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * 通知メッセージテンプレートを外部ファイル化し、ユーザーへのエラー案内や警告文を改善しました。プラグイン版バージョン未更新時、PR本文のIssue参照欠落時、知識領域への不正書込み検出時など、各場面での通知内容が充実しました。

* **Chores**
  * ワークフロー処理とインストールスクリプトを調整し、通知テンプレート配布とメッセージ読み込みに対応しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hirokimry/vibecorp/pull/649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->