### PR TITLE
📖 docs: Bot 通知テンプレが comment-writing.md 基準の構造化通知として整形される

### DIFF
--- a/.github/workflows/messages/notify-plugin-version-bump-missing.md
+++ b/.github/workflows/messages/notify-plugin-version-bump-missing.md
@@ -1,1 +1,21 @@
-⚠️ `.claude-plugin/marketplace.json` の `plugins[0].skills` が変更されていますが、`.claude-plugin/plugin.json` の `version` が bump されていません。利用者は新しいスキルを取得するために version bump を必要とします（PR #459 と同種の取りこぼし防止）。マージ前に `.claude-plugin/plugin.json` の `version` を更新してください。本チェックは警告のみ・非ブロックです。
+⚠️ プラグインの `version` bump 漏れを検知しました
+
+## 🎯 検知内容
+
+- `.claude-plugin/marketplace.json` の `plugins[0].skills` が変更されました
+- `.claude-plugin/plugin.json` の `version` は据え置かれています
+- このままでは利用者が新しいスキルを取得できなくなります
+
+## 🛠️ 必要な対応
+
+マージ前に `.claude-plugin/plugin.json` の `version` を bump してください。
+
+| 操作 | 内容 |
+|------|------|
+| 編集 | `.claude-plugin/plugin.json` の `version` を SemVer で 1 段上げる |
+| 再 push | 同一ブランチに force push 不要、通常 push で本チェックが再実行される |
+
+## 📍 根拠
+
+- 取りこぼし防止の経緯: PR #459
+- 本チェックの位置づけ: 警告のみ・非ブロック（マージ自体は阻害しません）

--- a/.github/workflows/messages/notify-pr-issue-link-missing.md
+++ b/.github/workflows/messages/notify-pr-issue-link-missing.md
@@ -1,1 +1,28 @@
-⚠️ PR 本文に対応 Issue への参照（`close #123` / `fixes #123` / `Refs #123` など）が含まれていません。vibecorp は Issue 経由起票必須運用（Issue #469 残 #5）のため、PR 本文に Issue 参照を追加してから再 push してください。詳細は .claude/rules/intent-labels.md と docs/conventional-commits.md を参照。
+⚠️ PR 本文に対応 Issue への参照が見つかりませんでした
+
+## 🎯 検知内容
+
+- PR 本文を走査しましたが、Issue 参照キーワードが含まれていませんでした
+- vibecorp は Issue 経由起票必須の運用です
+- このままでは PR がマージできません
+
+## 🛠️ 必要な対応
+
+PR 本文に対応 Issue を参照するキーワードを 1 行以上追加し、再 push してください。
+
+受理されるキーワードは以下のとおりです。
+
+| キーワード | 例 | 動作 |
+|------------|------|------|
+| `Closes #N` | `Closes #123` | マージ時に Issue を auto-close する |
+| `Fixes #N` / `Fixed #N` | `Fixes #123` | マージ時に Issue を auto-close する |
+| `Resolves #N` / `Resolved #N` | `Resolves #123` | マージ時に Issue を auto-close する |
+| `Refs #N` | `Refs #123` | 参照のみ（auto-close しない） |
+
+GitHub Issue URL 形式（`Closes https://github.com/<owner>/<repo>/issues/N`）も受理されます。
+
+## 📍 根拠
+
+- 運用判断: Issue #469 残 #5（Issue 経由起票必須）
+- intent ラベル定義: `.claude/rules/intent-labels.md`
+- CC prefix 厳格定義: `docs/conventional-commits.md`

--- a/.github/workflows/messages/notify-pr-issue-link-missing.md
+++ b/.github/workflows/messages/notify-pr-issue-link-missing.md
@@ -23,6 +23,6 @@ GitHub Issue URL 形式（`Closes https://github.com/<owner>/<repo>/issues/N`）
 
 ## 📍 根拠
 
-- 運用判断: Issue #469 残 #5（Issue 経由起票必須）
+- 運用判断: Issue #469（Issue 経由起票必須化の決定元）
 - intent ラベル定義: `.claude/rules/intent-labels.md`
 - CC prefix 厳格定義: `docs/conventional-commits.md`


### PR DESCRIPTION
## 📌 概要

`.github/workflows/messages/*.md` 配下の Bot 通知テンプレ 2 ファイルが、`comment-writing.md` の Bot 通知節 + MUST 6 項目に従って書き直されたことで、CEO が 30 秒スキャンで「何が起きたか / 次に何をすればよいか」を即座に掴める構造化通知になった。

## 🔄 Before / After

| 観点 | 🔴 Before | 🟢 After |
|------|----------|---------|
| 構造 | 1 段落に複数論点を詰め込んだ長文 | `## 🎯 検知内容` / `## 🛠️ 必要な対応` / `## 📍 根拠` の節立て |
| 主語 | コード参照寄り（`marketplace.json` の `skills` が変更されていますが…） | 動作主語（〜を検知しました／〜できるようになります／〜してください） |
| 30 秒スキャン性 | CEO が読み切るのに時間がかかる | 冒頭 1 行 + テーブルで一目で把握できる |
| 受理キーワード提示 | 例の羅列のみ | テーブルで `Closes` / `Fixes` / `Resolves` / `Refs` を整理し、`auto-close` の有無も明示 |

## 🛠️ 変更ファイル

- `.github/workflows/messages/notify-plugin-version-bump-missing.md`
- `.github/workflows/messages/notify-pr-issue-link-missing.md`

## 🧪 機械生成テンプレ例外節該当判定

`comment-writing.md` の機械生成テンプレ例外節は「短文の構造化通知（例: `coverage: 87.3%`）」を対象とする。本 PR が扱う 2 ファイルは警告 + 修正指示 + 根拠リンクを含む人手設計テンプレのため **例外節該当ではない** と判定し、MUST 6 項目を適用した。

## ✅ 挙動不変性確認

- `.github/workflows/*.yml` 本体は変更していない
- `.github/scripts/check-plugin-version-bump-comment.sh` / `check-pr-issue-link.sh` 本体は変更していない
- 通知の発火条件・宛先・権限・テンプレ参照パスは変わっていない
- 不可領域 6（CI エージェント / `permissions` / `secrets` / `triggers`）には触れていない
- `tests/test_plugin_version_bump_check.sh` が引き続き 5/5 PASS

## 🔗 関連

- 親エピック: Refs #629
- 兄弟 PR の経緯: Refs #634（残スコープ 4 領域の別 Issue 化判断元）
- 外部ファイル化の前段: #636（CLOSED）
- 同パターンの先行例: PR #657（`templates/claude/hooks/**`）

Closes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * プラグインバージョン更新通知メッセージを、検知内容・対応手順・根拠を持つMarkdown形式に整理し、利用者向けの具体的案内（例：SemVerでのバージョン上げ、通常pushでの再実行可など）を追加しました
  * PRのIssue参照欠落通知メッセージを、検知結果・具体的操作手順・受理されるキーワード一覧や運用参照先を明示する項目化された形式に改善しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hirokimry/vibecorp/pull/663?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->