### PR TITLE
🔄 refactor: lib/common.sh が vibecorp.yml を実行時に読み取れるようになった

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -266,7 +266,7 @@ _vibecorp_preset_has_hook() {
     standard)
       # minimal で除外される hook のうち、role-gate / diagnose-guard 以外を追加
       case "$hook" in
-        sync-gate|review-gate|guide-gate)
+        sync-gate|session-harvest-gate|review-gate|guide-gate)
           return 0
           ;;
       esac
@@ -275,7 +275,7 @@ _vibecorp_preset_has_hook() {
     full)
       # full は全 hook 有効
       case "$hook" in
-        sync-gate|review-gate|guide-gate|role-gate|diagnose-guard)
+        sync-gate|session-harvest-gate|review-gate|guide-gate|role-gate|diagnose-guard)
           return 0
           ;;
       esac
@@ -284,7 +284,7 @@ _vibecorp_preset_has_hook() {
     *)
       # 未知の preset はフェイルセーフで standard 扱い
       case "$hook" in
-        sync-gate|review-gate|guide-gate)
+        sync-gate|session-harvest-gate|review-gate|guide-gate)
           return 0
           ;;
       esac

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -174,3 +174,150 @@ vibecorp_plans_mkdir() {
   chmod 700 "$dir" 2>/dev/null || true
   printf '%s' "$dir"
 }
+
+# --- vibecorp.yml 実行時読み取り API ----------------------------------------
+# 用途: plugin native 配布化（Issue #700 / #403）後に、hook 自身が起動時に
+#       vibecorp.yml を読んで自己 skip 判定するための汎用 API。
+# 実装方針: 純粋 bash + awk のみ（yq / jq に依存しない）、macOS bash 3.2 互換。
+# 関連: Issue #702。
+
+# _vibecorp_yml_path — 実行時参照する vibecorp.yml のフルパスを返す
+# CLAUDE_PROJECT_DIR を起点に `.claude/vibecorp.yml` を解決する
+# （install.sh の get_project_name と同じ規約）
+_vibecorp_yml_path() {
+  printf '%s/.claude/vibecorp.yml' "${CLAUDE_PROJECT_DIR:-.}"
+}
+
+# vibecorp_yml_get — vibecorp.yml の <section>.<key> の値を取得する
+# 引数: $1 = section 名（例: hooks, coderabbit）
+#       $2 = key 名（例: review-gate, enabled）
+# 出力: stdout に値。yml 不在 or キー未定義時は空文字
+# 値は前後の空白を除去して返す。引用符は剥がさない（呼出側で必要に応じて処理）
+vibecorp_yml_get() {
+  local section="$1"
+  local key="$2"
+  local yml
+  yml="$(_vibecorp_yml_path)"
+
+  [[ -f "$yml" ]] || return 0
+
+  # awk: トップレベル行で section を追跡し、2-space インデント直下の key:value のみ拾う
+  # （ネスト 3 階層以上は対象外、install.sh:97-105 の is_item_enabled と同じ規約）
+  awk -v section="$section" -v key="$key" '
+    /^[^ #]/ {
+      current_section = $0
+      gsub(/:.*/, "", current_section)
+    }
+    current_section == section && $0 ~ "^  " key ":" {
+      sub("^  " key ":[ \t]*", "")
+      sub(/[ \t]+$/, "")
+      print
+      exit
+    }
+  ' "$yml"
+}
+
+# vibecorp_yml_get_preset — 現在のプリセット名を返す
+# 出力: stdout に preset 名。未定義時は "standard"（デフォルト）
+vibecorp_yml_get_preset() {
+  local yml
+  yml="$(_vibecorp_yml_path)"
+
+  local val=""
+  if [[ -f "$yml" ]]; then
+    # トップレベル `preset:` 行のみ拾う（section 内の preset: ではない）
+    val=$(awk '/^preset:[[:space:]]*/ {
+      sub(/^preset:[[:space:]]*/, "")
+      sub(/[ \t]+$/, "")
+      print
+      exit
+    }' "$yml")
+  fi
+
+  if [[ -z "${val:-}" ]]; then
+    printf 'standard'
+  else
+    printf '%s' "$val"
+  fi
+}
+
+# _vibecorp_preset_has_hook — 指定 preset で hook が有効かを返す（0 = 有効、1 = 無効）
+# 引数: $1 = preset 名（minimal / standard / full）
+#       $2 = hook 名（拡張子なし、例: role-gate）
+# 有効リストは install.sh:868-936 のプリセット引き算定義から「足し算」に正規化したもの。
+# install.sh の rm -f リストと逆引きの関係になっているため、両者を同期させる必要がある。
+_vibecorp_preset_has_hook() {
+  local preset="$1"
+  local hook="$2"
+
+  # 全プリセット共通 hook（install.sh で除外対象外のもの）
+  case "$hook" in
+    block-api-bypass|command-log|protect-branch|protect-files|protect-knowledge-bash-writes|protect-knowledge-direct-writes)
+      return 0
+      ;;
+  esac
+
+  # preset 別の追加 hook
+  case "$preset" in
+    minimal)
+      # 全プリセット共通以外は無効
+      return 1
+      ;;
+    standard)
+      # minimal で除外される hook のうち、role-gate / diagnose-guard 以外を追加
+      case "$hook" in
+        sync-gate|review-gate|guide-gate)
+          return 0
+          ;;
+      esac
+      return 1
+      ;;
+    full)
+      # full は全 hook 有効
+      case "$hook" in
+        sync-gate|review-gate|guide-gate|role-gate|diagnose-guard)
+          return 0
+          ;;
+      esac
+      return 1
+      ;;
+    *)
+      # 未知の preset はフェイルセーフで standard 扱い
+      case "$hook" in
+        sync-gate|review-gate|guide-gate)
+          return 0
+          ;;
+      esac
+      return 1
+      ;;
+  esac
+}
+
+# hook_skip_if_disabled — hook が skip すべきかを判定する
+# 引数: $1 = hook 名（拡張子 .sh は付けない、例: role-gate）
+# 戻り値:
+#   0 = skip すべき（yml で false / 現 preset の対象外）
+#   1 = continue（処理を続行する）
+# 想定使用法: 各 hook の冒頭で
+#   source "$(dirname "$0")/../../lib/common.sh"
+#   hook_skip_if_disabled role-gate && exit 0
+hook_skip_if_disabled() {
+  local hook="$1"
+
+  # 1. yml で明示的に hooks: <name>: false → skip
+  local yml_val
+  yml_val=$(vibecorp_yml_get hooks "$hook")
+  if [[ "$yml_val" == "false" ]]; then
+    return 0
+  fi
+
+  # 2. 現在 preset の対象外 → skip
+  local preset
+  preset=$(vibecorp_yml_get_preset)
+  if ! _vibecorp_preset_has_hook "$preset" "$hook"; then
+    return 0
+  fi
+
+  # 3. それ以外は continue
+  return 1
+}

--- a/tests/test_lib_common_vibecorp_yml.sh
+++ b/tests/test_lib_common_vibecorp_yml.sh
@@ -1,0 +1,344 @@
+#!/bin/bash
+# test_lib_common_vibecorp_yml.sh — lib/common.sh の vibecorp.yml 実行時読み取り API テスト
+# 用途: Issue #702 で追加した vibecorp_yml_get / vibecorp_yml_get_preset /
+#       hook_skip_if_disabled の動作と、preset 別 hook 有効リストが install.sh の
+#       プリセット引き算定義と一致することを検証する。
+# 使い方: bash tests/test_lib_common_vibecorp_yml.sh
+
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${TESTS_DIR}/lib/test_helpers.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LIB="${SCRIPT_DIR}/lib/common.sh"
+
+if [[ ! -f "$LIB" ]]; then
+  fail "前提ファイル lib/common.sh が存在しない"
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$LIB"
+
+# テスト中は CLAUDE_PROJECT_DIR を一時ディレクトリに向ける
+TMPDIR_TEST="$(mktemp -d)"
+mkdir -p "${TMPDIR_TEST}/.claude"
+
+cleanup() {
+  rm -rf "${TMPDIR_TEST}" || true
+}
+trap cleanup EXIT
+
+export CLAUDE_PROJECT_DIR="${TMPDIR_TEST}"
+YML="${TMPDIR_TEST}/.claude/vibecorp.yml"
+
+# ============================================
+echo "=== vibecorp_yml_get（yml 不在時） ==="
+# ============================================
+
+rm -f "$YML"
+RESULT="$(vibecorp_yml_get hooks role-gate)"
+assert_eq "yml 不在時は空文字を返す" "" "$RESULT"
+
+RESULT="$(vibecorp_yml_get coderabbit enabled)"
+assert_eq "yml 不在時は section 問わず空文字" "" "$RESULT"
+
+# ============================================
+echo ""
+echo "=== vibecorp_yml_get（key 未定義時） ==="
+# ============================================
+
+cat > "$YML" <<'YAML'
+name: test-project
+preset: standard
+language: ja
+coderabbit:
+  enabled: true
+hooks:
+  role-gate: false
+  guide-gate: true
+YAML
+
+RESULT="$(vibecorp_yml_get hooks not-exist)"
+assert_eq "未定義 key は空文字を返す" "" "$RESULT"
+
+RESULT="$(vibecorp_yml_get not-exist-section foo)"
+assert_eq "未定義 section も空文字を返す" "" "$RESULT"
+
+# ============================================
+echo ""
+echo "=== vibecorp_yml_get（値取得） ==="
+# ============================================
+
+RESULT="$(vibecorp_yml_get coderabbit enabled)"
+assert_eq "coderabbit.enabled の値を取得" "true" "$RESULT"
+
+RESULT="$(vibecorp_yml_get hooks role-gate)"
+assert_eq "hooks.role-gate の値を取得（false）" "false" "$RESULT"
+
+RESULT="$(vibecorp_yml_get hooks guide-gate)"
+assert_eq "hooks.guide-gate の値を取得（true）" "true" "$RESULT"
+
+# ============================================
+echo ""
+echo "=== vibecorp_yml_get_preset ==="
+# ============================================
+
+# preset: standard の場合
+RESULT="$(vibecorp_yml_get_preset)"
+assert_eq "preset: standard を読み取る" "standard" "$RESULT"
+
+# preset: full
+cat > "$YML" <<'YAML'
+name: test-project
+preset: full
+language: ja
+YAML
+RESULT="$(vibecorp_yml_get_preset)"
+assert_eq "preset: full を読み取る" "full" "$RESULT"
+
+# preset: minimal
+cat > "$YML" <<'YAML'
+name: test-project
+preset: minimal
+language: ja
+YAML
+RESULT="$(vibecorp_yml_get_preset)"
+assert_eq "preset: minimal を読み取る" "minimal" "$RESULT"
+
+# preset 未定義（フィールドなし）
+cat > "$YML" <<'YAML'
+name: test-project
+language: ja
+YAML
+RESULT="$(vibecorp_yml_get_preset)"
+assert_eq "preset 未定義時はデフォルト standard" "standard" "$RESULT"
+
+# yml 不在時
+rm -f "$YML"
+RESULT="$(vibecorp_yml_get_preset)"
+assert_eq "yml 不在時はデフォルト standard" "standard" "$RESULT"
+
+# ============================================
+echo ""
+echo "=== hook_skip_if_disabled（yml 明示無効化） ==="
+# ============================================
+
+cat > "$YML" <<'YAML'
+name: test-project
+preset: full
+language: ja
+hooks:
+  guide-gate: false
+  role-gate: true
+YAML
+
+# yml で明示的に false → skip すべき (return 0)
+if hook_skip_if_disabled guide-gate; then
+  pass "hooks: guide-gate: false → hook_skip_if_disabled が 0 を返す（skip）"
+else
+  fail "hooks: guide-gate: false → hook_skip_if_disabled が 0 を返すべき"
+fi
+
+# yml で明示的に true（かつ preset 有効リスト内）→ continue (return 1)
+if hook_skip_if_disabled role-gate; then
+  fail "hooks: role-gate: true（full preset）→ continue すべき"
+else
+  pass "hooks: role-gate: true（full preset）→ hook_skip_if_disabled が 1 を返す（continue）"
+fi
+
+# ============================================
+echo ""
+echo "=== hook_skip_if_disabled（preset 別有効リスト） ==="
+# ============================================
+
+# minimal: 共通 6 hook のみ有効
+cat > "$YML" <<'YAML'
+name: test-project
+preset: minimal
+language: ja
+YAML
+
+# 共通 hook は continue
+for common_hook in block-api-bypass command-log protect-branch protect-files protect-knowledge-bash-writes protect-knowledge-direct-writes; do
+  if hook_skip_if_disabled "$common_hook"; then
+    fail "minimal preset: ${common_hook} は continue すべき"
+  else
+    pass "minimal preset: ${common_hook} → continue"
+  fi
+done
+
+# minimal 限定で skip すべき hook
+for skipped_hook in sync-gate review-gate guide-gate role-gate diagnose-guard; do
+  if hook_skip_if_disabled "$skipped_hook"; then
+    pass "minimal preset: ${skipped_hook} → skip"
+  else
+    fail "minimal preset: ${skipped_hook} は skip すべき"
+  fi
+done
+
+# standard: 共通 + sync-gate / review-gate / guide-gate 有効
+cat > "$YML" <<'YAML'
+name: test-project
+preset: standard
+language: ja
+YAML
+
+for std_hook in sync-gate review-gate guide-gate; do
+  if hook_skip_if_disabled "$std_hook"; then
+    fail "standard preset: ${std_hook} は continue すべき"
+  else
+    pass "standard preset: ${std_hook} → continue"
+  fi
+done
+
+for std_skipped in role-gate diagnose-guard; do
+  if hook_skip_if_disabled "$std_skipped"; then
+    pass "standard preset: ${std_skipped} → skip"
+  else
+    fail "standard preset: ${std_skipped} は skip すべき"
+  fi
+done
+
+# full: 全 hook 有効
+cat > "$YML" <<'YAML'
+name: test-project
+preset: full
+language: ja
+YAML
+
+for full_hook in sync-gate review-gate guide-gate role-gate diagnose-guard; do
+  if hook_skip_if_disabled "$full_hook"; then
+    fail "full preset: ${full_hook} は continue すべき"
+  else
+    pass "full preset: ${full_hook} → continue"
+  fi
+done
+
+# ============================================
+echo ""
+echo "=== preset 別 hook 有効リストが install.sh と一致 ==="
+# ============================================
+
+INSTALL_SH="${SCRIPT_DIR}/install.sh"
+HOOKS_DIR_TEMPLATE="${SCRIPT_DIR}/templates/claude/hooks"
+
+if [[ ! -f "$INSTALL_SH" ]]; then
+  fail "install.sh が存在しない（前提ファイル）"
+  exit 1
+fi
+if [[ ! -d "$HOOKS_DIR_TEMPLATE" ]]; then
+  fail "templates/claude/hooks/ が存在しない（前提ディレクトリ）"
+  exit 1
+fi
+
+# install.sh のプリセット別 rm -f リストから、削除される hook 名を抽出する。
+# minimal / standard ブロックそれぞれの hook 削除行のみ拾う（skills / agents 削除行は除外）。
+# 実存する hook ファイルのみ照合対象とし、レガシー clean-up（実在しない hook の rm）は無視する。
+extract_removed_hooks() {
+  local preset="$1"
+  awk -v preset="$preset" '
+    $0 ~ "^    " preset ")" { in_block = 1; next }
+    in_block && /^    ;;/ { in_block = 0 }
+    in_block && /rm -f .*hooks_dir.*\.sh"/ {
+      # rm -f "${hooks_dir}/role-gate.sh" から basename を抽出
+      match($0, /\/[^\/]+\.sh"/)
+      if (RSTART > 0) {
+        hook = substr($0, RSTART + 1, RLENGTH - 2)
+        sub(/\.sh$/, "", hook)
+        print hook
+      }
+    }
+  ' "$INSTALL_SH"
+}
+
+# 実存する hook 一覧（拡張子なし）
+existing_hooks=()
+while IFS= read -r f; do
+  name="$(basename "$f")"
+  existing_hooks+=("${name%.sh}")
+done < <(find "$HOOKS_DIR_TEMPLATE" -maxdepth 1 -type f -name '*.sh' | sort)
+
+# minimal preset での install.sh 削除リスト ∩ 実存 hook → lib の skip 判定で 0（skip）になるべき
+echo "  minimal で install.sh が削除する hook を照合中..."
+for removed in $(extract_removed_hooks "minimal"); do
+  # 実存 hook かどうかチェック
+  found=0
+  for existing in "${existing_hooks[@]}"; do
+    if [[ "$existing" == "$removed" ]]; then
+      found=1
+      break
+    fi
+  done
+  [[ "$found" == "1" ]] || continue
+
+  cat > "$YML" <<EOF
+name: test-project
+preset: minimal
+language: ja
+EOF
+
+  if hook_skip_if_disabled "$removed"; then
+    pass "install.sh minimal で削除される ${removed} は lib でも skip 判定"
+  else
+    fail "install.sh minimal で削除される ${removed} が lib で continue 判定（不整合）"
+  fi
+done
+
+# standard preset での照合
+echo "  standard で install.sh が削除する hook を照合中..."
+for removed in $(extract_removed_hooks "standard"); do
+  found=0
+  for existing in "${existing_hooks[@]}"; do
+    if [[ "$existing" == "$removed" ]]; then
+      found=1
+      break
+    fi
+  done
+  [[ "$found" == "1" ]] || continue
+
+  cat > "$YML" <<EOF
+name: test-project
+preset: standard
+language: ja
+EOF
+
+  if hook_skip_if_disabled "$removed"; then
+    pass "install.sh standard で削除される ${removed} は lib でも skip 判定"
+  else
+    fail "install.sh standard で削除される ${removed} が lib で continue 判定（不整合）"
+  fi
+done
+
+# 逆方向: install.sh が削除しない（=有効として残す）hook が lib で continue 判定になるか
+# minimal で残る hook = 実存 hook − minimal 削除 hook
+echo "  install.sh が残す hook を逆方向照合..."
+removed_minimal=$(extract_removed_hooks "minimal")
+for existing in "${existing_hooks[@]}"; do
+  is_removed=0
+  for r in $removed_minimal; do
+    if [[ "$r" == "$existing" ]]; then
+      is_removed=1
+      break
+    fi
+  done
+  [[ "$is_removed" == "0" ]] || continue
+
+  cat > "$YML" <<EOF
+name: test-project
+preset: minimal
+language: ja
+EOF
+
+  if hook_skip_if_disabled "$existing"; then
+    fail "install.sh minimal で残る ${existing} が lib で skip 判定（不整合）"
+  else
+    pass "install.sh minimal で残る ${existing} は lib でも continue 判定"
+  fi
+done
+
+# ============================================
+echo ""
+print_test_summary

--- a/tests/test_lib_common_vibecorp_yml.sh
+++ b/tests/test_lib_common_vibecorp_yml.sh
@@ -186,7 +186,7 @@ preset: standard
 language: ja
 YAML
 
-for std_hook in sync-gate review-gate guide-gate; do
+for std_hook in sync-gate session-harvest-gate review-gate guide-gate; do
   if hook_skip_if_disabled "$std_hook"; then
     fail "standard preset: ${std_hook} は continue すべき"
   else
@@ -209,7 +209,7 @@ preset: full
 language: ja
 YAML
 
-for full_hook in sync-gate review-gate guide-gate role-gate diagnose-guard; do
+for full_hook in sync-gate session-harvest-gate review-gate guide-gate role-gate diagnose-guard; do
   if hook_skip_if_disabled "$full_hook"; then
     fail "full preset: ${full_hook} は continue すべき"
   else
@@ -313,8 +313,8 @@ EOF
 done
 
 # 逆方向: install.sh が削除しない（=有効として残す）hook が lib で continue 判定になるか
-# minimal で残る hook = 実存 hook − minimal 削除 hook
-echo "  install.sh が残す hook を逆方向照合..."
+# minimal / standard 両方で「残存対象→continue」を照合する（順方向「削除対象→skip」と対称）。
+echo "  install.sh が minimal で残す hook を逆方向照合..."
 removed_minimal=$(extract_removed_hooks "minimal")
 for existing in "${existing_hooks[@]}"; do
   is_removed=0
@@ -336,6 +336,32 @@ EOF
     fail "install.sh minimal で残る ${existing} が lib で skip 判定（不整合）"
   else
     pass "install.sh minimal で残る ${existing} は lib でも continue 判定"
+  fi
+done
+
+# standard preset の残存対象: 実存 hook − standard 削除 hook
+echo "  install.sh が standard で残す hook を逆方向照合..."
+removed_standard=$(extract_removed_hooks "standard")
+for existing in "${existing_hooks[@]}"; do
+  is_removed=0
+  for r in $removed_standard; do
+    if [[ "$r" == "$existing" ]]; then
+      is_removed=1
+      break
+    fi
+  done
+  [[ "$is_removed" == "0" ]] || continue
+
+  cat > "$YML" <<EOF
+name: test-project
+preset: standard
+language: ja
+EOF
+
+  if hook_skip_if_disabled "$existing"; then
+    fail "install.sh standard で残る ${existing} が lib で skip 判定（不整合）"
+  else
+    pass "install.sh standard で残る ${existing} は lib でも continue 判定"
   fi
 done
 


### PR DESCRIPTION
## 関連 Issue

close https://github.com/hirokimry/vibecorp/issues/702

Refs #700
Refs #403

## 概要

### 🎯 何が変わるか

各 hook が起動時に **`vibecorp.yml` を直接読んで自己 skip 判定できるようになった**。

> [!NOTE]
> 本 PR は単独では観測可能な挙動を変えない（API 追加のみ）。
> 後続 PR で各 hook が `hook_skip_if_disabled` を呼び始めた段階で「plugin native 配布化（#700 / #403）後も hook 無効化が機能し続ける」という挙動が成立する。

### 🆕 追加された API（`lib/common.sh`）

| 関数 | 用途 |
|---|---|
| `vibecorp_yml_get <section> <key>` | yml の任意セクションのキーを実行時に読めるようになった |
| `vibecorp_yml_get_preset` | 現在の preset 名を取得できるようになった（未定義時 `standard`） |
| `hook_skip_if_disabled <hook-name>` | yml 明示無効化 + preset 別有効リストの二段判定で skip 可否を返すようになった |

### 🧭 設計判断

- **純粋 bash + awk のみ**（yq / jq に依存しない）にした
  - 理由: 配布時の依存を増やさない、CI/macOS 既定環境で確実に動く
- **preset 別 hook 有効リストを `lib/common.sh` 内の定数化** した
  - 理由: install.sh の引き算定義（行 868-936）を実行時に再現する必要があるため
  - 整合性は CI で自動検証する（後述）
- **既存 `install.sh:is_hook_enabled` は変更しない**
  - 理由: install.sh の判定は yml 単独で十分（プリセット引き算は case ブロック側が担う）

### 🔍 挙動不変性の担保

`intent/refactor` のため挙動不変を以下で保証する。

- ✅ `install.sh` には一切手を入れない（API 追加のみ）
- ✅ 既存テスト 4 本（`test_hooks*.sh` / `test_install_orphan_hook.sh` / `test_settings_json_hooks_exist.sh`）が緑のまま
- ✅ 新規テスト `test_lib_common_vibecorp_yml.sh` で 50/50 緑
  - install.sh の `rm -f` リストと lib の有効リストが一致することを **自動照合** する

### 🚧 スコープ外（後続 Issue）

| 範囲 | 取り扱い |
|------|---------|
| 各 hook 本体への `hook_skip_if_disabled` 呼び出し追加 | 別 Issue で対応 |
| plugin native 配布パスへの hook 物理配置切替 | #700 配下の別子 Issue で対応 |
| `vibecorp.yml` の `hooks:` セクションへの hook 名追記 | 配布化と同時に対応 |

### 🖼️ 位置づけ

```text
親エピック #700 (hooks SSOT 配布化)
  ├── #710  hook 共通 lib を plugin ルート lib/ に移動  ✅ マージ済み
  ├── #702  本 PR: lib/common.sh が yml を実行時に読み取れる  ← イマココ
  └── 後続  各 hook が hook_skip_if_disabled を呼ぶ      ⏭️ 後続 Issue
```

## テスト計画

- [x] `tests/test_lib_common_vibecorp_yml.sh` が 50/50 緑
- [x] `tests/test_common_lib.sh`（既存）が緑のまま
- [x] `tests/test_hooks_portability.sh` / `test_hooks.sh` / `test_install_orphan_hook.sh` / `test_settings_json_hooks_exist.sh` が緑のまま
- [x] macOS bash 3.2 でも動く（`${...}` ブレース展開・`sed -i` 不使用を遵守）
- [x] install.sh のプリセット引き算定義と lib の有効リストが自動照合で一致


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 実行時に vibecorp.yml でフックの有効/無効を制御可能に。プリセット（minimal/standard/full）に応じた振る舞いや、未定義時のデフォルトプリセット（standard）に対応。

* **Tests**
  * 設定ファイルの不存在・未定義項目・値取得や、プリセット別のフック継続/スキップ動作を網羅的に検証するテスト群を追加。削除対象リストとの整合性チェックも含む。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hirokimry/vibecorp/pull/711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->