### PR TITLE
🔒 fix: CISO 監査記録に plugin native 配布化の 8 観点評価が残るようになった

### DIFF
--- a/.claude/knowledge/ciso/decisions-index.md
+++ b/.claude/knowledge/ciso/decisions-index.md
@@ -4,6 +4,7 @@
 関連する過去判断を特定したら `decisions/YYYY-QN.md` を追加で Read する。
 
 ## エントリ
+- 2026-05-23 — plugin native 配布化のセキュリティ最終審査（#705 / 親エピック #700）— 条件付き承認: 8 観点全評価完了、新規脆弱性なし、子 #707 実装の絶対条件として 4 必須対策（marketplace.json 限定 / plugin cache chmod 推奨 / ユーザー独自フックは settings.local.json / fail-closed 起動）を付記
 - 2026-05-16 — Issue #310 Linux bwrap 隔離レイヤ実装 メタレビュー #2 — 承認: symlink チェック修正確認済み、全件修正済みマージ可、新規脆弱性なし（CR-001 / Issue #311 と整合）
 - 2026-05-16 — Issue #310 Linux bwrap 隔離レイヤ実装 メタレビュー #1 — 差し戻し: 全会一致ルール適用（analyst #3 = High）。source 前の symlink チェック（-L）欠如による Link Following 脆弱性（任意シェルコード実行経路）を検出
 - 2026-05-10 — 不可領域チェック: ship が Issue チェックボックスをマージ後に自動検証し未完了項目を再帰実装するようになる（skills/ship/SKILL.md 拡張）— 条件付き OK（6分類非該当。再帰深度上限・安全弁・ヘッドレス呼び出し追加禁止の実装時条件 3 点を付記）

--- a/.claude/knowledge/ciso/decisions/2026-Q2.md
+++ b/.claude/knowledge/ciso/decisions/2026-Q2.md
@@ -1,5 +1,66 @@
 # CISO 判断記録 2026-Q2
 
+## 2026-05-23 — plugin native 配布化のセキュリティ最終審査（#705 / 親エピック #700）
+
+### 判定
+
+**条件付き承認**（4 必須対策の遵守を子 #707 実装の絶対条件とする）
+
+### 対象
+
+- `templates/claude/hooks/protect-files.sh` → `${CLAUDE_PLUGIN_ROOT}/hooks/protect-files.sh` への配布経路変更
+- `templates/claude/hooks/diagnose-guard.sh` → `${CLAUDE_PLUGIN_ROOT}/hooks/diagnose-guard.sh` への配布経路変更
+- 関連: `.claude/settings.json` の `hooks` ブロックから `$CLAUDE_PROJECT_DIR/.claude/hooks/` 参照を撤去し、`hooks/hooks.json` + `plugin.json:hooks` 経由の plugin native 配布に統一する設計
+
+### 背景
+
+- 親エピック #700 で hooks 配布 SSOT 化（templates ⇄ source 二重管理の解消）が承認済み（CEO 設計承認: [#403 コメント](https://github.com/hirokimry/vibecorp/issues/403#issuecomment-4465217986)）
+- 子 #707 が実装本体（不可領域 4「ガードレール」該当のため CEO override で起票）
+- 本 #705 は子 #707 着手前に必須の **正式 CISO 監査記録**
+
+### 8 観点評価
+
+| # | 観点 | 評価結果 | 根拠 |
+|---|------|---------|------|
+| 1 | 配布経路の改変可能性 | 🟢 攻撃面非増加 | plugin cache（`${CLAUDE_PLUGIN_ROOT}`）配下は Claude Code が管理する読み取り専用領域。書き換えるには `~/.cache/` 配下への書込権限が必要だが、これは現状の `.claude/hooks/` 直書きでも同等条件（むしろローカル `.claude/` の方が誤書き換えしやすい） |
+| 2 | hook ファイルの整合性検証 | 🟡 plugin marketplace 経由の SHA 検証なし（残存リスク） | Claude Code plugin marketplace は現時点で `marketplace.json` ベース配布で個別ファイルの hash 検証 / 署名検証を行わない。**必須対策①** で plugin install 経路を marketplace.json 経由に限定し、第三者 fork からの install を README で警告する |
+| 3 | `${CLAUDE_PLUGIN_ROOT}` 環境変数の信頼性 | 🟢 信頼可 | Claude Code 公式が hook 実行前に注入する環境変数。ユーザープロンプトや tool_input 由来ではないため injection 経路にならない。`diagnose-guard.sh` は既に `HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"` で自己解決しており、`${CLAUDE_PLUGIN_ROOT}` 不在時も `BASH_SOURCE` で代替可能（#703 で対応済み） |
+| 4 | symlink / path traversal 攻撃面 | 🟢 既存対策で塞いだ | `diagnose-guard.sh` 内で `_pkw_normalize_path`（realpath / python3 経由）が原文 / 正規化後の両方を deny 判定対象にしており、`skillz -> skills` のような symlink bypass を塞いでいる。plugin cache 配下に置いても同ロジックがそのまま機能する |
+| 5 | install 時の TOCTOU | 🟡 plugin install〜hook 実行までの時間窓は理論上存在（残存リスク） | 攻撃経路: `~/.cache/claude/plugins/.../hooks/protect-files.sh` を install 後に差し替え。前提条件として **ローカル file system 書込権限が必要** であり、その時点で `.claude/settings.local.json` 直書き等の上位経路が既に成立。新規攻撃面の追加なし。**必須対策②** で plugin cache の chmod 推奨を README に明記する |
+| 6 | ユーザー編集の喪失影響 | 🟡 ユーザーが追加した防御層が plugin update で消える可能性（残存リスク） | 現状の `.claude/hooks/` は install.sh の 3-way マージで保護されている。plugin native 配布では plugin update がディレクトリ全体を置き換えるため、ユーザー独自フック追加経路が消失する。**必須対策③** で「ユーザー独自フックは `.claude/settings.local.json` の `hooks` ブロックで追加する」運用を SECURITY.md に明記する |
+| 7 | hook 自身の無効化経路 | 🟢 vibecorp.yml レベルの disable は既存仕様 | `vibecorp.yml: hooks.protect_files: false` で OFF にできる挙動は plugin native 配布前後で変わらない。これはユーザーが明示的に自己制約を緩める正当な経路（#704 で各 hook 自身が yml/preset disable を自己判定する設計）。bypass 経路の新規追加なし |
+| 8 | hook ファイル削除耐性（fail-safe） | 🟢 fail-closed 設計を踏襲 | plugin cache から hook ファイルが消えた場合、Claude Code 側で hook 実行がスキップされて settings.json で定義した PreToolUse 連鎖が壊れる。**必須対策④** で「plugin が見つからない」を起動時 `SessionStart` で検知し、明示エラーで停止する fail-closed 起動を子 #707 で実装する |
+
+### 必須対策（子 #707 実装の絶対条件）
+
+1. **plugin 配布経路の限定**: install / update は vibecorp 公式 `marketplace.json` 経由のみ。第三者 fork からの直接 install は README で警告。
+2. **plugin cache 権限の推奨**: SECURITY.md に「plugin cache 配下を `chmod -R go-w` 推奨」を明記し、TOCTOU 経路を物理的に塞ぐ運用ガイドを残す。
+3. **ユーザー独自フック追加経路の明示**: 「`.claude/settings.local.json` の `hooks` ブロックでユーザー独自フックを追加する」運用を SECURITY.md に明記。plugin update で消える領域とユーザー編集領域を分離する。
+4. **fail-closed 起動**: plugin が見つからない場合、`SessionStart` hook で検知して明示エラーで停止する（hook が無音で実行されない状態を作らない）。子 #707 の DoD に含める。
+
+### 過去判断との一貫性
+
+- 2026-04-18「プリセット別安全性評価」の「`protect-files.sh` / `diagnose-guard.sh` は削除不可最低ライン」と整合する（本変更は **配布経路の変更のみで削除ではない**）。
+- 2026-05-06 Issue #360「diagnose-guard.sh REGEX_PATTERN 末尾アンカー追加」の「CEO 承認済み人間承認ルート通過」判定と同型（本件も親エピック #700 + #403 で CEO 設計承認済み）。
+
+### 脅威評価
+
+- 深刻度: **低**（既存攻撃面と同等、新規脆弱性なし）
+- 攻撃チェーン: ローカル file system 書込権限を奪取済みの攻撃者が plugin cache 配下を差し替える経路は理論上存在するが、その時点で `.claude/settings.local.json` 直書き等の上位経路が成立しており、本件で新規攻撃面は追加されない。
+- 影響範囲: `protect-files.sh` / `diagnose-guard.sh` の配布経路のみ。認証・credential・課金構造に波及なし。
+
+### 残存リスク（受容）
+
+- 観点 #2: plugin marketplace の hash 検証は Claude Code 公式の今後の機能追加待ち。現時点では marketplace.json 経由配布の信頼に依存する（必須対策① で緩和）。
+- 観点 #5: plugin install 後の差し替え TOCTOU 窓は塞げないが、新規攻撃面ではない（必須対策② で運用緩和）。
+- 観点 #6: ユーザー独自フック追加経路の運用変更が必要（必須対策③ で明示化）。
+
+### 最終判断
+
+**条件付き承認**: 4 必須対策を子 #707 実装の絶対条件とし、SECURITY.md 更新を伴うこと。本記録を子 #707 / #708 が依存できる前提条件として明文化する。
+
+---
+
 ## 2026-05-10 — 不可領域チェック: ship が Issue チェックボックスをマージ後に自動検証し未完了項目を再帰実装するようになる（skills/ship/SKILL.md 拡張）
 
 ### 判定


### PR DESCRIPTION
## 💡 概要

CISO 監査記録に plugin native 配布化（親エピック #700）のセキュリティ最終審査が `knowledge/ciso/decisions/2026-Q2.md` に残るようになった。

## 📝 内容

8 観点評価 + 4 必須対策 + 残存リスク受容を含む CISO 決定エントリを追加:

- 配布経路の改変可能性
- hook ファイル整合性検証
- `${CLAUDE_PLUGIN_ROOT}` 信頼性
- symlink / path traversal
- TOCTOU
- ユーザー編集喪失影響
- 自己無効化経路
- fail-safe

**判定**: 条件付き承認

### 子 #707 実装時の必須 4 対策

1. marketplace.json 限定の配布経路
2. plugin cache chmod 推奨
3. ユーザー独自フックは settings.local.json 経由
4. fail-closed 起動

## ✅ 完了条件

- [x] `knowledge/ciso/decisions/2026-Q2.md` に最終審査エントリ追記
- [x] `knowledge/ciso/decisions-index.md` に 1 行サマリ追加
- [x] 判定（条件付き承認）と 4 必須対策が明文化

## 🔗 関連

Closes #705
Refs #700


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * セキュリティレビュー記録を更新しました。条件付きで承認された機能に関する評価結果と実装要件を文書化しています。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hirokimry/vibecorp/pull/714?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->