### PR TITLE
🔄 refactor: install.sh から templates/claude/lib/ 参照が消え plugin ルート lib/ を向くようになった

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -717,10 +717,11 @@ copy_managed_files() {
   mkdir -p "$hooks_dir"
 
   # lib: フック共通ユーティリティをコピー（常に最新で上書き）
+  # Issue #707 で lib/ は plugin ルートへ移動済。templates/claude/lib/ は廃止。
   local lib_dir="${REPO_ROOT}/.claude/lib"
-  if [[ -d "${SCRIPT_DIR}/templates/claude/lib" ]]; then
+  if [[ -d "${SCRIPT_DIR}/lib" ]]; then
     mkdir -p "$lib_dir"
-    for src in "${SCRIPT_DIR}/templates/claude/lib/"*.sh; do
+    for src in "${SCRIPT_DIR}/lib/"*.sh; do
       [[ -f "$src" ]] || continue
       cp "$src" "${lib_dir}/$(basename "$src")"
     done


### PR DESCRIPTION
## 💡 概要

`install.sh` から `templates/claude/lib/` 参照が削除され、`hooks/` SSOT 化が install.sh 経由でも完結するようになった。

## 📝 内容

Issue #707 で lib/ が `templates/claude/lib/` から plugin ルート `lib/` へ移動した一方、install.sh の lib コピーロジックは古いパスを参照したままだった。`templates/claude/lib/` 不在で `[[ -d ]]` チェックが false になり、コピー処理が空動作 → 利用者リポジトリの `.claude/lib/` が空になる潜在的回帰を fix する。

### 影響

- **plugin native 利用者**: `${CLAUDE_PLUGIN_ROOT}/lib/` から hook が lib を引くため影響なし
- **非 plugin native 利用者 (install.sh のみ)**: hook が `.claude/lib/common.sh` を見つけられず起動失敗していた可能性 → 本 fix で解消

## ✅ 完了条件

- [x] install.sh の lib コピー元が plugin ルート `lib/` に切り替わる
- [x] 非 plugin native 利用者の `.claude/lib/` が install.sh で正しくコピーされる
- [x] テスト緑（tests/test_install_lock.sh 38/38）

## 🔗 関連

Closes #708
Refs #700

## ⚠️ Issue #708 の残スコープ（follow-up）

Issue #708 本来のスコープのうち、本 PR で扱わなかった残りは以下:

- vibecorp.lock 形式 v2 (hooks: / lib: セクション廃止) — 後方互換のため見送り
- --update 時の旧 .claude/hooks/ 完全削除 migration — 非 plugin native 利用者保護のため見送り
- settings.json hooks ブロック完全除去 — 同上
- 同期ズレ検知 CI (#458) 削除 — 別 Issue で扱う

これらは plugin native 移行が完全に primary になるタイミングで別 Issue として扱う。
本 PR は最も重要な「install.sh 経由でも lib が正しくコピーされる」回帰防止に絞る。
