### PR TITLE
🔄 refactor: tests/ コメント内の templates/claude/{hooks,lib}/ 参照が plugin ルートに統一されるようになった

### DIFF
--- a/tests/lib/hook_fixtures.sh
+++ b/tests/lib/hook_fixtures.sh
@@ -4,8 +4,8 @@
 # 同じく plugin ルートの lib/ を ${HOOK_DIR}/../lib/ で参照するため、テスト時に
 # lib を別途 staging する必要はなくなった。
 #
-# 過去の sync_lib_for_hook_tests は templates/claude/lib/ に lib を staging していたが、
-# templates/claude/hooks/ が消えた今は不要のため no-op として維持する（既存テストの
+# 過去の sync_lib_for_hook_tests は lib/ に lib を staging していたが、
+# hooks/ が消えた今は不要のため no-op として維持する（既存テストの
 # 後方互換のため呼び出しシグネチャは残す）。
 
 # 機能: 後方互換のため残す no-op 関数（Issue #707 以降は不要）

--- a/tests/test_block_api_bypass.sh
+++ b/tests/test_block_api_bypass.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "${TESTS_DIR}/lib/test_helpers.sh"
-# Issue #704: hook が ${HOOK_DIR}/../lib/ で lib を解決するようになり、hooks/ から実行する経路では templates/claude/lib/ に lib が必要になる（plugin native 配布後の runtime 配置と同じ構造を再現する）
+# Issue #704: hook が ${HOOK_DIR}/../lib/ で lib を解決するようになり、hooks/ から実行する経路では lib/ に lib が必要になる（plugin native 配布後の runtime 配置と同じ構造を再現する）
 # shellcheck disable=SC1091
 source "${TESTS_DIR}/lib/hook_fixtures.sh"
 sync_lib_for_hook_tests

--- a/tests/test_diagnose_guard.sh
+++ b/tests/test_diagnose_guard.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "${TESTS_DIR}/lib/test_helpers.sh"
-# Issue #703: hook が ${HOOK_DIR}/../lib/ で lib を解決するようになり、hooks/ から実行する経路では templates/claude/lib/ に lib が必要になる（plugin native 配布後の runtime 配置と同じ構造を再現する）
+# Issue #703: hook が ${HOOK_DIR}/../lib/ で lib を解決するようになり、hooks/ から実行する経路では lib/ に lib が必要になる（plugin native 配布後の runtime 配置と同じ構造を再現する）
 # shellcheck disable=SC1091
 source "${TESTS_DIR}/lib/hook_fixtures.sh"
 sync_lib_for_hook_tests

--- a/tests/test_guide_gate.sh
+++ b/tests/test_guide_gate.sh
@@ -11,7 +11,7 @@ source "${TESTS_DIR}/lib/test_helpers.sh"
 # shellcheck disable=SC1091
 source "${TESTS_DIR}/lib/hook_fixtures.sh"
 # Issue #701: lib/ を plugin ルートに移動した後も hook テストが ${HOOK_DIR}/../lib/
-# を引けるよう、テスト中だけ templates/claude/lib/ に lib をコピーする
+# を引けるよう、テスト中だけ lib/ に lib をコピーする
 sync_lib_for_hook_tests
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -10,7 +10,7 @@ source "${TESTS_DIR}/lib/test_helpers.sh"
 # shellcheck disable=SC1091
 source "${TESTS_DIR}/lib/hook_fixtures.sh"
 # Issue #701: lib/ を plugin ルートに移動した後も hook テストが ${HOOK_DIR}/../lib/
-# を引けるよう、テスト中だけ templates/claude/lib/ に lib をコピーする
+# を引けるよう、テスト中だけ lib/ に lib をコピーする
 sync_lib_for_hook_tests
 
 HOOKS_DIR="$(cd "$(dirname "$0")/../hooks" && pwd)"

--- a/tests/test_protect_branch.sh
+++ b/tests/test_protect_branch.sh
@@ -10,7 +10,7 @@ source "${TESTS_DIR}/lib/test_helpers.sh"
 # shellcheck disable=SC1091
 source "${TESTS_DIR}/lib/hook_fixtures.sh"
 # Issue #701: lib/ を plugin ルートに移動した後も hook テストが ${HOOK_DIR}/../lib/
-# を引けるよう、テスト中だけ templates/claude/lib/ に lib をコピーする
+# を引けるよう、テスト中だけ lib/ に lib をコピーする
 sync_lib_for_hook_tests
 
 HOOKS_DIR="$(cd "$(dirname "$0")/../hooks" && pwd)"

--- a/tests/test_review_gate.sh
+++ b/tests/test_review_gate.sh
@@ -11,7 +11,7 @@ source "${TESTS_DIR}/lib/test_helpers.sh"
 # shellcheck disable=SC1091
 source "${TESTS_DIR}/lib/hook_fixtures.sh"
 # Issue #701: lib/ を plugin ルートに移動した後も hook テストが ${HOOK_DIR}/../lib/
-# を引けるよう、テスト中だけ templates/claude/lib/ に lib をコピーする
+# を引けるよう、テスト中だけ lib/ に lib をコピーする
 sync_lib_for_hook_tests
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"

--- a/tests/test_sync_gate.sh
+++ b/tests/test_sync_gate.sh
@@ -11,7 +11,7 @@ source "${TESTS_DIR}/lib/test_helpers.sh"
 # shellcheck disable=SC1091
 source "${TESTS_DIR}/lib/hook_fixtures.sh"
 # Issue #701: lib/ を plugin ルートに移動した後も hook テストが ${HOOK_DIR}/../lib/
-# を引けるよう、テスト中だけ templates/claude/lib/ に lib をコピーする
+# を引けるよう、テスト中だけ lib/ に lib をコピーする
 sync_lib_for_hook_tests
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"


### PR DESCRIPTION
## 💡 概要

#710 / #707 で hooks/ lib/ が plugin ルートへ移動した後も、tests/ 8 ファイルのコメント説明文に旧パス参照が残っていた。grep が 0 件になるよう一括置換する。

## ✅ 完了条件

- [x] grep -rn 'templates/claude/hooks' tests/ が 0 件
- [x] grep -rn 'templates/claude/lib' tests/ が 0 件
- [x] 全 hook 関連テスト緑（27/27 + 13/13 + 36/36 + 38/38 + 47/47 + 10/10 + 48/48 + 19/19 + 12/12 + 13/13 + 61/61）

## 🔗 関連

Closes #706
Refs #700

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * テスト環境での库パス解決に関するドキュメンテーションを統一。複数のテストファイルのコメントを更新し、テスト実行時のライブラリコピー方針を明確化。テスト動作自体に変更なし。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hirokimry/vibecorp/pull/718?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->