### PR TITLE
🔄 refactor: install.sh --update で既存 settings.json から hooks ブロックが自動除去されるようになった

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -640,7 +640,25 @@ migrate_legacy_layout() {
     rmdir "${REPO_ROOT}/.claude/vibecorp-base" 2>/dev/null || true
   fi
 
-  [[ $removed -eq 0 ]] || log_info "Issue #708: plugin native 移行に伴う旧レイアウト migration 完了"
+  # 機能: 既存 .claude/settings.json から hooks ブロックを物理除去（Issue #721）
+  # plugin native 配布 (#716) 後は plugin/hooks/hooks.json が唯一の登録元。settings.json 側に
+  # 古い hooks ブロックが残っていると hook が二重発火する可能性があるため migration する。
+  local settings_json="${REPO_ROOT}/.claude/settings.json"
+  if [[ -f "$settings_json" ]] && command -v jq >/dev/null 2>&1; then
+    if jq -e '.hooks' "$settings_json" >/dev/null 2>&1; then
+      local tmp_settings
+      tmp_settings="$(mktemp "$(dirname "$settings_json")/.settings.json.XXXXXX")"
+      if jq 'del(.hooks)' "$settings_json" > "$tmp_settings"; then
+        mv "$tmp_settings" "$settings_json"
+        log_info "migration: 既存 .claude/settings.json から hooks ブロックを除去（plugin native 配布に統一）"
+        removed=1
+      else
+        rm -f "$tmp_settings"
+      fi
+    fi
+  fi
+
+  [[ $removed -eq 0 ]] || log_info "Issue #708 / #721: plugin native 移行に伴う旧レイアウト migration 完了"
 }
 
 remove_managed_files() {

--- a/tests/test_install_legacy_migration.sh
+++ b/tests/test_install_legacy_migration.sh
@@ -136,6 +136,98 @@ rm -rf "$TMPDIR_TEST"
 TMPDIR_TEST=""
 
 echo ""
+echo "=== Test 4: 既存 settings.json から hooks ブロックが除去される (#721) ==="
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "  SKIP: jq が利用不可な環境のため migration テストをスキップ"
+else
+  TMPDIR_TEST="$(mktemp -d)"
+  mkdir -p "${TMPDIR_TEST}/.claude"
+  SETTINGS_BEFORE="${TMPDIR_TEST}/.claude/settings.json"
+  cat > "$SETTINGS_BEFORE" <<'JSON'
+{
+  "permissions": {
+    "allow": ["Read(*)", "Bash(git status:*)"],
+    "ask": ["WebFetch(*)"]
+  },
+  "enabledPlugins": {
+    "vibecorp@vibecorp": true
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          { "type": "command", "command": "bash .claude/hooks/protect-files.sh" }
+        ]
+      }
+    ]
+  }
+}
+JSON
+
+  bash -c "
+    REPO_ROOT='$TMPDIR_TEST'
+    UPDATE_MODE=true
+    log_info() { :; }
+    $(awk '/^migrate_legacy_layout\(\)/,/^}/' "$INSTALL_SH")
+    migrate_legacy_layout
+  "
+
+  if jq -e '.hooks' "$SETTINGS_BEFORE" >/dev/null 2>&1; then
+    fail "settings.json から hooks ブロックが除去されていない"
+  else
+    pass "settings.json から hooks ブロックが除去された"
+  fi
+
+  if jq -e '.permissions.allow' "$SETTINGS_BEFORE" >/dev/null 2>&1; then
+    pass "permissions ブロックが保持されている"
+  else
+    fail "permissions ブロックが消失した（migration 過剰）"
+  fi
+
+  if jq -e '.enabledPlugins' "$SETTINGS_BEFORE" >/dev/null 2>&1; then
+    pass "enabledPlugins ブロックが保持されている"
+  else
+    fail "enabledPlugins ブロックが消失した（migration 過剰）"
+  fi
+
+  rm -rf "$TMPDIR_TEST"
+  TMPDIR_TEST=""
+
+  # hooks ブロック不在時は冪等
+  TMPDIR_TEST="$(mktemp -d)"
+  mkdir -p "${TMPDIR_TEST}/.claude"
+  SETTINGS_CLEAN="${TMPDIR_TEST}/.claude/settings.json"
+  cat > "$SETTINGS_CLEAN" <<'JSON'
+{
+  "permissions": {
+    "allow": ["Read(*)"]
+  }
+}
+JSON
+  CHECKSUM_BEFORE="$(shasum "$SETTINGS_CLEAN" | awk '{print $1}')"
+
+  bash -c "
+    REPO_ROOT='$TMPDIR_TEST'
+    UPDATE_MODE=true
+    log_info() { :; }
+    $(awk '/^migrate_legacy_layout\(\)/,/^}/' "$INSTALL_SH")
+    migrate_legacy_layout
+  "
+
+  CHECKSUM_AFTER="$(shasum "$SETTINGS_CLEAN" | awk '{print $1}')"
+  if [[ "$CHECKSUM_BEFORE" == "$CHECKSUM_AFTER" ]]; then
+    pass "hooks ブロック不在時は settings.json を変更しない（冪等性）"
+  else
+    fail "hooks ブロック不在時に settings.json が変更された（冪等性違反）"
+  fi
+
+  rm -rf "$TMPDIR_TEST"
+  TMPDIR_TEST=""
+fi
+
+echo ""
 echo "==========================="
 echo "結果: ${PASSED}/${TOTAL} 成功, ${FAILED} 失敗"
 echo "==========================="


### PR DESCRIPTION
## 💡 概要

plugin native 配布 (#716) で hooks の登録元が plugin/hooks/hooks.json に一元化された後、利用者の `.claude/settings.json` に残った hooks ブロックを `--update` で物理除去できるようになった。これにより plugin と settings.json の二重登録による hook 二重発火リスクが完全に解消される。

## 📝 変更内容

### install.sh
- `migrate_legacy_layout()` に settings.json hooks ブロック除去ロジックを追加
- `jq 'del(.hooks)'` で hooks のみ除去（permissions / enabledPlugins / marketplaces 等は保持）
- jq 未インストール環境では migration をスキップ
- 冪等性確保: hooks ブロック不在時は settings.json を変更しない

### tests/test_install_legacy_migration.sh
- Test 4 追加: hooks ブロック除去 / 他フィールド保持 / 冪等性 の 4 ケース
- 11/11 ローカル緑

## ✅ 完了条件 (#721)

- [x] generate_settings_json が hooks ブロックを生成しない (PR #724 で済)
- [x] --update で既存 settings.json から hooks ブロック除去（他フィールド保持）
- [x] test_install_*.sh が緑

## 🔗 関連

Closes #721
Refs #700

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **バグ修正**
  * セットアップ時に旧設定ファイルから廃止された設定要素が自動的に検出・削除されるようになりました。

* **テスト**
  * 設定移行処理が正常に動作し、何度実行しても安定することを確認するテストが追加されました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hirokimry/vibecorp/pull/725?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->