### PR TITLE
🔄 refactor: vibecorp.lock の hooks: / lib: セクションが廃止されて v2 形式になった

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1862,8 +1862,9 @@ generate_vibecorp_lock() {
 
   local files_block=""
   # $() は末尾改行を除去するため、各セクション連結時に明示的に改行を補う
-  # hooks セクションは plugin native 配布 (#716) 後も後方互換のため空リストを維持
-  files_block+="$(_lock_list_section "hooks" "")"$'\n'
+  # v2 形式 (#722): hooks: / lib: セクションは plugin native 配布 (#716) で plugin/hooks/hooks.json に
+  # 一元化されたため、新規 lock では一切書き込まない。read_lock_list は v1 形式の hooks: / lib: も
+  # 引き続き読めるため後方互換は維持される（test_install_legacy_migration.sh で検証済）。
   files_block+="$(_lock_list_section "skills" "$skills_list")"$'\n'
   files_block+="$(_lock_list_section "agents" "$agents_list")"$'\n'
   files_block+="$(_lock_list_section "rules" "$rules_list")"$'\n'
@@ -1874,6 +1875,8 @@ generate_vibecorp_lock() {
 
   cat > "$lock" <<YAML
 # vibecorp.lock — 自動生成、手動編集禁止
+# format_version: 2 は hooks: / lib: セクション廃止後の lock 形式 (#722)
+format_version: 2
 version: ${VIBECORP_VERSION}
 installed_at: ${installed_at}
 preset: ${PRESET}

--- a/tests/test_install_legacy_migration.sh
+++ b/tests/test_install_legacy_migration.sh
@@ -228,6 +228,28 @@ JSON
 fi
 
 echo ""
+echo "=== Test 5: 新規 lock は v2 形式で hooks: / lib: セクションを書かない (#722) ==="
+
+# generate_lock_file 関数の hooks: 出力削除を直接検証
+if grep -q '_lock_list_section "hooks"' "$INSTALL_SH"; then
+  fail "generate_lock_file が依然として hooks: セクションを出力している（v2 形式違反）"
+else
+  pass "generate_lock_file が hooks: セクションを出力しなくなった"
+fi
+
+if grep -q '_lock_list_section "lib"' "$INSTALL_SH"; then
+  fail "generate_lock_file が lib: セクションを出力している（v2 形式違反）"
+else
+  pass "generate_lock_file が lib: セクションを出力しない（v2 形式準拠）"
+fi
+
+if grep -q "^format_version: 2$" "$INSTALL_SH" || grep -q 'format_version: 2' "$INSTALL_SH"; then
+  pass "lock ヘッダに format_version: 2 が追加された"
+else
+  fail "lock ヘッダに format_version: 2 が追加されていない"
+fi
+
+echo ""
 echo "==========================="
 echo "結果: ${PASSED}/${TOTAL} 成功, ${FAILED} 失敗"
 echo "==========================="

--- a/tests/test_install_lock.sh
+++ b/tests/test_install_lock.sh
@@ -344,14 +344,14 @@ R="$TMPDIR_ROOT"
 LOCK="$R/.claude/vibecorp.lock"
 
 if [ -f "$LOCK" ]; then
-  # 空リスト時は "hooks: []" のような表記であること（null ではない）
-  if grep -q 'hooks: \[\]' "$LOCK"; then
-    pass "AH1: 空リスト時に hooks: [] が出力される"
+  # v2 形式 (#722): hooks: セクションは廃止、skills: で空リスト表記を確認
+  if grep -q 'skills: \[\]' "$LOCK"; then
+    pass "AH1: 空リスト時に YAML 明示的空リスト表記 [] が出力される（v2 形式は skills で検証）"
   else
-    fail "AH1: 空リスト時に hooks: [] が出力される"
+    fail "AH1: 空リスト時に YAML 明示的空リスト表記 [] が出力される"
   fi
 else
-  fail "AH1: 空リスト時に hooks: [] が出力される (lock ファイルが存在しない)"
+  fail "AH1: 空リスト時に YAML 明示的空リスト表記 [] が出力される (lock ファイルが存在しない)"
 fi
 
 # テンプレート復元


### PR DESCRIPTION
## 💡 概要

plugin native 配布 (#716) で hooks / lib の登録元が plugin/hooks/hooks.json に完全移行した後の lock 形式整理。新規生成される `vibecorp.lock` からは `hooks:` / `lib:` セクションが完全に消え、`format_version: 2` で v2 形式を明示するようになる。v1 lock (#719 以前) は `read_lock_list` の汎用パーサーが引き続き読めるため後方互換は維持される。

## 📝 変更内容

### install.sh
- `generate_lock_file` の `hooks:` 出力行を削除（`lib:` は元から書いていなかった）
- lock ヘッダに `format_version: 2` を追加して v2 形式を明示

### tests/test_install_legacy_migration.sh
- Test 5 追加: `hooks:` / `lib:` セクション不在 + `format_version: 2` の 3 ケース
- 14/14 ローカル緑

### tests/test_install_lock.sh
- AH1 を v2 形式に追従: `hooks: []` → `skills: []` で空リスト表記を検証
- 36/36 ローカル緑

### test_install_update.sh
- 既存 59/59 が引き続き緑（v1 lock 後方互換維持を確認）

## ✅ 完了条件 (#722)

- [x] 新規 lock に hooks: / lib: が書かれない
- [x] v1 lock 読み込みが引き続き動作（test_install_legacy_migration.sh Test 3 で検証済）
- [x] test_install_lock.sh が緑（AH1 を v2 形式に追従）

## 🔗 関連

Closes #722
Refs #700

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ロックファイルのフォーマットをバージョン2にアップグレード
  * 生成されるロックファイルから hooks/lib セクションを削除
  * 新フォーマットの仕様準拠を検証するテストを追加

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hirokimry/vibecorp/pull/726?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->