### PR TITLE
🐛 fix: install.sh migration が同名ユーザーフックを誤削除しなくなった + lock 形式テストが v2 に追従

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -669,17 +669,24 @@ migrate_legacy_layout() {
     zombie_agent.sh
   )
 
+  # content 一致確認: vibecorp 配布物と完全に同一内容のファイルだけを削除する。
+  # 同名でも内容が異なるファイル（= ユーザー独自フック / ユーザー改変フック）は保持する。
+  # これにより同名ユーザーフックを誤削除しない（regression 防止: PR #727 後の test 失敗修正）。
   if [[ -d "$legacy_hooks" ]]; then
     local removed_legacy_hook=0
-    local hook_basename
+    local hook_basename plugin_hook legacy_hook
     for hook_basename in "${vibecorp_hook_basenames[@]}"; do
-      if [[ -f "${legacy_hooks}/${hook_basename}" ]]; then
-        rm -f "${legacy_hooks}/${hook_basename}"
-        removed_legacy_hook=1
+      legacy_hook="${legacy_hooks}/${hook_basename}"
+      plugin_hook="${SCRIPT_DIR}/hooks/${hook_basename}"
+      if [[ -f "$legacy_hook" && -f "$plugin_hook" ]]; then
+        if cmp -s "$legacy_hook" "$plugin_hook"; then
+          rm -f "$legacy_hook"
+          removed_legacy_hook=1
+        fi
       fi
     done
     if [[ $removed_legacy_hook -eq 1 ]]; then
-      log_info "migration: 旧 .claude/hooks/ から vibecorp 配布フックを削除"
+      log_info "migration: 旧 .claude/hooks/ から vibecorp 配布フックを削除（content 一致のみ）"
       removed=1
     fi
     rmdir "$legacy_hooks" 2>/dev/null || true
@@ -687,15 +694,19 @@ migrate_legacy_layout() {
 
   if [[ -d "$legacy_lib" ]]; then
     local removed_legacy_lib=0
-    local lib_basename
+    local lib_basename plugin_lib legacy_lib_file
     for lib_basename in "${vibecorp_lib_basenames[@]}"; do
-      if [[ -f "${legacy_lib}/${lib_basename}" ]]; then
-        rm -f "${legacy_lib}/${lib_basename}"
-        removed_legacy_lib=1
+      legacy_lib_file="${legacy_lib}/${lib_basename}"
+      plugin_lib="${SCRIPT_DIR}/lib/${lib_basename}"
+      if [[ -f "$legacy_lib_file" && -f "$plugin_lib" ]]; then
+        if cmp -s "$legacy_lib_file" "$plugin_lib"; then
+          rm -f "$legacy_lib_file"
+          removed_legacy_lib=1
+        fi
       fi
     done
     if [[ $removed_legacy_lib -eq 1 ]]; then
-      log_info "migration: 旧 .claude/lib/ から vibecorp 配布 lib を削除"
+      log_info "migration: 旧 .claude/lib/ から vibecorp 配布 lib を削除（content 一致のみ）"
       removed=1
     fi
     rmdir "$legacy_lib" 2>/dev/null || true

--- a/tests/test_install_legacy_migration.sh
+++ b/tests/test_install_legacy_migration.sh
@@ -255,14 +255,15 @@ echo "=== Test 6: 旧 .claude/hooks/ / .claude/lib/ の vibecorp 配布物が物
 TMPDIR_TEST="$(mktemp -d)"
 mkdir -p "${TMPDIR_TEST}/.claude/hooks"
 mkdir -p "${TMPDIR_TEST}/.claude/lib"
-echo "old protect-files" > "${TMPDIR_TEST}/.claude/hooks/protect-files.sh"
-echo "old command-log" > "${TMPDIR_TEST}/.claude/hooks/command-log.sh"
-echo "old common" > "${TMPDIR_TEST}/.claude/lib/common.sh"
+cp "$SCRIPT_DIR/hooks/protect-files.sh" "${TMPDIR_TEST}/.claude/hooks/protect-files.sh"
+cp "$SCRIPT_DIR/hooks/command-log.sh" "${TMPDIR_TEST}/.claude/hooks/command-log.sh"
+cp "$SCRIPT_DIR/lib/common.sh" "${TMPDIR_TEST}/.claude/lib/common.sh"
 echo "user custom hook" > "${TMPDIR_TEST}/.claude/hooks/my-custom-hook.sh"
 echo "user custom lib" > "${TMPDIR_TEST}/.claude/lib/my-custom.sh"
 
 bash -c "
   REPO_ROOT='$TMPDIR_TEST'
+  SCRIPT_DIR='$SCRIPT_DIR'
   UPDATE_MODE=true
   log_info() { :; }
   $(awk '/^migrate_legacy_layout\(\)/,/^}/' "$INSTALL_SH")
@@ -305,11 +306,12 @@ TMPDIR_TEST=""
 TMPDIR_TEST="$(mktemp -d)"
 mkdir -p "${TMPDIR_TEST}/.claude/hooks"
 mkdir -p "${TMPDIR_TEST}/.claude/lib"
-echo "old" > "${TMPDIR_TEST}/.claude/hooks/protect-files.sh"
-echo "old" > "${TMPDIR_TEST}/.claude/lib/common.sh"
+cp "$SCRIPT_DIR/hooks/protect-files.sh" "${TMPDIR_TEST}/.claude/hooks/protect-files.sh"
+cp "$SCRIPT_DIR/lib/common.sh" "${TMPDIR_TEST}/.claude/lib/common.sh"
 
 bash -c "
   REPO_ROOT='$TMPDIR_TEST'
+  SCRIPT_DIR='$SCRIPT_DIR'
   UPDATE_MODE=true
   log_info() { :; }
   $(awk '/^migrate_legacy_layout\(\)/,/^}/' "$INSTALL_SH")

--- a/tests/test_install_preset.sh
+++ b/tests/test_install_preset.sh
@@ -38,8 +38,8 @@ EXPECTED_VERSION=$(git -C "$(dirname "$INSTALL_SH")" describe --tags --abbrev=0 
 EXPECTED_VERSION="${EXPECTED_VERSION#v}"
 assert_file_contains "vibecorp.lock に version" "$R/.claude/vibecorp.lock" "version: ${EXPECTED_VERSION}"
 
-# E7. vibecorp.lock にマニフェスト（hooks は plugin native 移行で空リスト）
-assert_file_contains "vibecorp.lock に hooks 空リスト" "$R/.claude/vibecorp.lock" "hooks: \[\]"
+# E7. vibecorp.lock にマニフェスト (#722 で v2 形式: hooks: / lib: セクション廃止 + format_version: 2)
+assert_file_contains "vibecorp.lock が v2 形式 (format_version: 2)" "$R/.claude/vibecorp.lock" "format_version: 2"
 assert_file_contains "vibecorp.lock に skills マニフェスト" "$R/.claude/vibecorp.lock" "review"
 assert_file_contains "vibecorp.lock に rules マニフェスト" "$R/.claude/vibecorp.lock" "code-comments.md"
 


### PR DESCRIPTION
## 💡 概要

PR #727 と #726 マージ後に発生した CI failure 2 件を修正する。

## 🐛 修正対象の regression

### regression 1: 同名ユーザーフックの誤削除 (#727 後)

`migrate_legacy_layout()` の hooks / lib 削除を **basename 一致** から **content (cmp -s) 一致** に変更。

| 変更前 | 変更後 |
|--------|--------|
| 既知 basename と一致するファイルを全削除 | vibecorp 配布物と完全に同一内容のファイルのみ削除 |
| ユーザー独自フック (同名) が誤削除される | ユーザー独自フック / ユーザー改変フックは保持 |

これにより `test_install_preset.sh` T6_skill の「同名ユーザーフックは保持される」「ユーザーフックの内容が維持される」 が緑になる。

### regression 2: lock v2 形式に未追従テスト (#726 後)

`test_install_preset.sh` E7 が削除済み `hooks: []` を期待していたため、v2 形式 (`format_version: 2`) を期待するように更新。

## 📝 変更ファイル

- `install.sh`: `migrate_legacy_layout()` を content-based に変更
- `tests/test_install_legacy_migration.sh` Test 6: setup を plugin 実コンテンツコピーに追従 + SCRIPT_DIR を bash subshell に渡す
- `tests/test_install_preset.sh` E7: `hooks: []` → `format_version: 2` に追従

## ✅ ローカル検証

- `test_install_legacy_migration.sh`: **20/20 緑**
- `test_install_preset.sh`: **238/239 緑** (残 1 = 既存 `gh 未インストール時` 問題、本 PR 範囲外)

## 🔗 関連

Closes #708
Refs #700

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * レガシー設定の移行処理を改善し、ユーザーが変更したフックやライブラリの誤削除を防止しました。

* **Tests**
  * インストール関連のテストを改善し、設定ファイルのバージョン形式の検証を強化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hirokimry/vibecorp/pull/728?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->