### PR TITLE
🔄 refactor: install.sh の copy_rules() が self-install / user-install で分岐するようになる

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2236,16 +2236,50 @@ create_labels() {
   done
 }
 
+# 機能: .claude/rules/<rel> から SSOT rules/<rel> への相対 symlink ターゲット文字列を返す。
+# self-install（dogfooding）でファイル単位 symlink を貼り直す際に使う。
+# .claude/rules の 2 階層 + rel のサブディレクトリ深さ分だけ ".." を遡り、rules/<rel> を付ける。
+# 例: markdown.md → ../../rules/markdown.md / severity/coderabbit.md → ../../../rules/severity/coderabbit.md
+_relpath_to_rules() {
+  local rel="$1"
+  # rel に含まれる "/" の個数がサブディレクトリ深さ（トップ直下は 0）
+  local slash_count
+  slash_count=$(printf '%s' "$rel" | tr -cd '/' | wc -c | tr -d ' ')
+  # .claude/rules/ から見た遡り段数 = 2（.claude/rules）+ サブディレクトリ深さ
+  local up_levels=$((2 + slash_count))
+  local prefix=""
+  local i
+  for ((i = 0; i < up_levels; i++)); do
+    prefix="${prefix}../"
+  done
+  printf '%s' "${prefix}rules/${rel}"
+}
+
+# 機能: ディレクトリパスを symlink 解決済みの絶対パスに正規化する（realpath 非依存）。
+# realpath は古い macOS に不在で shell.md の BSD/GNU 互換要件に反するため pwd -P を使う。
+_canonical_dir() {
+  ( cd "$1" 2>/dev/null && pwd -P )
+}
+
 copy_rules() {
   # 配布元はプラグインルート rules/ が SSOT（Issue #747）。
-  # vibecorp 本体では .claude/rules/ は rules/ への symlink で dogfooding するが、
-  # 配布先には実体ファイルをコピーする（symlink は配布しない）。
+  # SCRIPT_DIR（plugin root）と REPO_ROOT が同一ディレクトリなら vibecorp 自身への
+  # install（self-install）と判定し、.claude/rules/ を rules/ への symlink で再生成する
+  # （dogfooding の symlink を破壊しない）。異なる場合は配布先への install（user-install）
+  # と判定し、実体ファイルを物理コピーで上書きする（symlink は配布しない、Issue #748）。
   local src="${SCRIPT_DIR}/rules"
   local dest="${REPO_ROOT}/.claude/rules"
   mkdir -p "$dest"
 
-  # トップレベル *.md と 1 階層下のサブディレクトリ（severity/ 等）の *.md を対象とする
-  # find -maxdepth 2 でサブディレクトリ 1 階層まで対応（深いネストは想定外）
+  local self_install=false
+  if [[ "$(_canonical_dir "$SCRIPT_DIR")" == "$(_canonical_dir "$REPO_ROOT")" ]]; then
+    self_install=true
+  fi
+
+  # トップレベル *.md と 1 階層下のサブディレクトリ（severity/ 等）の *.md を対象とする。
+  # find -maxdepth 2 でサブディレクトリ 1 階層まで対応（深いネストは想定外）。
+  # 配布物だけを列挙するため、dest 側にある配布対象外ファイル（user 固有 rule）は
+  # 両モードで一切触れられず保持される。
   while IFS= read -r rule; do
     [[ -f "$rule" ]] || continue
     local rel_path="${rule#"${src}"/}"  # 例: severity/coderabbit.md
@@ -2254,17 +2288,14 @@ copy_rules() {
     if [[ "$rel_dir" != "." ]]; then
       mkdir -p "${dest}/${rel_dir}"
     fi
-    if [[ "$UPDATE_MODE" == true ]]; then
-      merge_or_overwrite "$rule" "${dest}/${rel_path}" "rules/${rel_path}" || true
-      COPIED_RULES="${COPIED_RULES}${rel_path}"$'\n'
-    elif [[ -f "${dest}/${rel_path}" ]]; then
-      log_skip "rules/${rel_path} は既存のためスキップ"
+    if [[ "$self_install" == true ]]; then
+      # self-install: ファイル単位 symlink を貼り直す（既存 symlink / 実体は上書き）
+      ln -sfn "$(_relpath_to_rules "$rel_path")" "${dest}/${rel_path}"
     else
-      cp "$rule" "${dest}/${rel_path}"
-      save_base_snapshot "$rule" "rules/${rel_path}"
-      COPIED_RULES="${COPIED_RULES}${rel_path}"$'\n'
-      log_info "rules/${rel_path} をコピー"
+      # user-install: 3-way マージは行わず常に最新で上書きする（Issue #748）
+      cp -f "$rule" "${dest}/${rel_path}"
     fi
+    COPIED_RULES="${COPIED_RULES}${rel_path}"$'\n'
   done < <(find "$src" -maxdepth 2 -type f -name "*.md" 2>/dev/null)
 }
 

--- a/tests/test_install_preset.sh
+++ b/tests/test_install_preset.sh
@@ -245,16 +245,16 @@ echo ""
 echo "=== J. rules コピー ==="
 # ============================================
 
-# J1. 既存同名ルールはスキップ
+# J1. 既存同名ルールは user-install で常に最新に上書きされる（Issue #748、3-way マージ廃止）
 create_test_repo
 mkdir -p "$TMPDIR_ROOT/.claude/rules"
 echo "# カスタムルール" > "$TMPDIR_ROOT/.claude/rules/code-comments.md"
 bash "$INSTALL_SH" --name test-proj 2>/dev/null
 CONTENT=$(cat "$TMPDIR_ROOT/.claude/rules/code-comments.md")
 if [ "$CONTENT" = "# カスタムルール" ]; then
-  pass "既存同名ルールはスキップ"
+  fail "既存同名ルールが上書きされていない（user-install は常に上書きすべき）"
 else
-  fail "既存同名ルールはスキップ (内容が上書きされた)"
+  pass "既存同名ルールが最新で上書きされる（マージしない）"
 fi
 
 # J2. 新規ルールはコピーされる
@@ -1360,17 +1360,17 @@ TMP_BEFORE=$(mktemp)
 TMP_AFTER=$(mktemp)
 find "$TMP_SANDBOX" -maxdepth 1 -type f -name 'tmp.*' | sort > "$TMP_BEFORE"
 
-# 3-way merge 分岐に入るための条件を整える:
+# 3-way merge 分岐に入るための条件を整える（rules は #748 でマージ廃止のため CLAUDE.md で検証）:
 # 1. current_hash != base_hash（ユーザーがカスタマイズした状態）
 # 2. template_hash != base_hash（テンプレートも変更された状態）
 # まず current ファイルを改変してカスタマイズ済みにする
-echo "# ユーザーによるカスタマイズ" >> "$R/.claude/rules/code-comments.md"
+echo "# ユーザーによるカスタマイズ" >> "$R/.claude/CLAUDE.md"
 # ベーススナップショットを改変してテンプレート変更を模擬する
-echo "# 改変されたベース" > "$R/.claude/vibecorp-base/rules/code-comments.md"
+echo "# 改変されたベース" > "$R/.claude/vibecorp-base/CLAUDE.md"
 # vibecorp.lock の base_hashes を更新して current_hash != base_hash にする
-NEW_BASE_HASH=$(shasum -a 256 "$R/.claude/vibecorp-base/rules/code-comments.md" | awk '{print $1}')
+NEW_BASE_HASH=$(shasum -a 256 "$R/.claude/vibecorp-base/CLAUDE.md" | awk '{print $1}')
 LOCK_FILE="$R/.claude/vibecorp.lock"
-ORIG_HASH=$(grep 'rules/code-comments\.md:' "$LOCK_FILE" | awk '{print $2}')
+ORIG_HASH=$(grep -e 'CLAUDE\.md:' "$LOCK_FILE" | awk '{print $2}')
 sed "s/${ORIG_HASH}/${NEW_BASE_HASH}/" "$LOCK_FILE" > "${LOCK_FILE}.tmp" && mv "${LOCK_FILE}.tmp" "$LOCK_FILE"
 
 EXIT_CODE=0

--- a/tests/test_install_rules_copy.sh
+++ b/tests/test_install_rules_copy.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+# test_install_rules_copy.sh — Issue #748: copy_rules() の self-install / user-install 2 モード分岐を検証する
+# 使い方: bash tests/test_install_rules_copy.sh
+# CI: GitHub Actions で自動実行
+#
+# 検証対象:
+#   1. _relpath_to_rules がサブディレクトリ深さに応じた相対 symlink ターゲットを返す
+#   2. self-install（SCRIPT_DIR == REPO_ROOT）: .claude/rules/ が SSOT への symlink で再生成される
+#   3. user-install（SCRIPT_DIR != REPO_ROOT）: .claude/rules/ が物理コピー（実体ファイル）で配置される
+#   4. user-install: 既存のカスタム編集ファイルが 3-way マージされず常に上書きされる
+#   5. user 固有 rule（配布対象外）が両モードで保持される
+
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${TESTS_DIR}/lib/test_helpers.sh"
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# install.sh を source して copy_rules / _relpath_to_rules を直接呼べるようにする。
+# install.sh は末尾の if [[ ${BASH_SOURCE[0]} == "$0" ]] ガードで main 自動起動を抑止している。
+# shellcheck disable=SC1091
+source "${ROOT}/install.sh"
+
+TMPDIR_ROOT="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMPDIR_ROOT" || true
+}
+trap cleanup EXIT
+
+# テスト用の最小 SSOT rules/ を一時ディレクトリ配下に作る
+make_ssot() {
+  local plugin_root="$1"
+  mkdir -p "${plugin_root}/rules/severity"
+  printf 'top-rule-body\n' > "${plugin_root}/rules/markdown.md"
+  printf 'sub-rule-body\n' > "${plugin_root}/rules/severity/coderabbit.md"
+}
+
+# ============================================
+echo "=== 1. _relpath_to_rules が階層深さに応じた相対ターゲットを返す ==="
+# ============================================
+
+result=$(_relpath_to_rules "markdown.md")
+assert_eq "トップ直下 markdown.md → ../../rules/markdown.md" "../../rules/markdown.md" "$result"
+
+result=$(_relpath_to_rules "severity/coderabbit.md")
+assert_eq "severity サブ → ../../../rules/severity/coderabbit.md" "../../../rules/severity/coderabbit.md" "$result"
+
+# ============================================
+echo "=== 2. self-install: .claude/rules/ が symlink で再生成される ==="
+# ============================================
+
+self_root="${TMPDIR_ROOT}/self"
+mkdir -p "$self_root"
+make_ssot "$self_root"
+
+# self-install は SCRIPT_DIR == REPO_ROOT
+SCRIPT_DIR="$self_root" REPO_ROOT="$self_root" UPDATE_MODE=false COPIED_RULES="" copy_rules >/dev/null 2>&1
+
+self_dest="${self_root}/.claude/rules"
+
+if [[ -L "${self_dest}/markdown.md" ]]; then
+  pass "self-install: markdown.md が symlink"
+else
+  fail "self-install: markdown.md が symlink でない"
+fi
+
+if [[ -L "${self_dest}/severity/coderabbit.md" ]]; then
+  pass "self-install: severity/coderabbit.md が symlink"
+else
+  fail "self-install: severity/coderabbit.md が symlink でない"
+fi
+
+target=$(readlink "${self_dest}/markdown.md")
+assert_eq "self-install: markdown.md ターゲット" "../../rules/markdown.md" "$target"
+
+target=$(readlink "${self_dest}/severity/coderabbit.md")
+assert_eq "self-install: severity/coderabbit.md ターゲット" "../../../rules/severity/coderabbit.md" "$target"
+
+# symlink 経由で SSOT 実体と内容一致（dangling でない）
+if cmp -s "${self_dest}/markdown.md" "${self_root}/rules/markdown.md"; then
+  pass "self-install: symlink 経由で SSOT 内容に解決される"
+else
+  fail "self-install: symlink が SSOT に解決されない（dangling）"
+fi
+
+# ============================================
+echo "=== 3. user-install: .claude/rules/ が物理コピー（実体ファイル）で配置される ==="
+# ============================================
+
+plugin_root="${TMPDIR_ROOT}/plugin"
+user_root="${TMPDIR_ROOT}/user"
+mkdir -p "$plugin_root" "$user_root"
+make_ssot "$plugin_root"
+
+# user-install は SCRIPT_DIR != REPO_ROOT
+SCRIPT_DIR="$plugin_root" REPO_ROOT="$user_root" UPDATE_MODE=false COPIED_RULES="" copy_rules >/dev/null 2>&1
+
+user_dest="${user_root}/.claude/rules"
+
+if [[ -f "${user_dest}/markdown.md" && ! -L "${user_dest}/markdown.md" ]]; then
+  pass "user-install: markdown.md が実体ファイル（非 symlink）"
+else
+  fail "user-install: markdown.md が実体ファイルでない"
+fi
+
+if [[ -f "${user_dest}/severity/coderabbit.md" && ! -L "${user_dest}/severity/coderabbit.md" ]]; then
+  pass "user-install: severity/coderabbit.md が実体ファイル（非 symlink）"
+else
+  fail "user-install: severity/coderabbit.md が実体ファイルでない"
+fi
+
+if cmp -s "${user_dest}/markdown.md" "${plugin_root}/rules/markdown.md"; then
+  pass "user-install: 物理コピー内容が SSOT と一致"
+else
+  fail "user-install: 物理コピー内容が SSOT と一致しない"
+fi
+
+# ============================================
+echo "=== 4. user-install: カスタム編集ファイルが 3-way マージされず上書きされる ==="
+# ============================================
+
+overwrite_root="${TMPDIR_ROOT}/overwrite"
+mkdir -p "${overwrite_root}/.claude/rules"
+make_ssot "$plugin_root"
+# 配置先に SSOT と異なるカスタム内容を先に置く
+printf 'CUSTOM-EDITED-CONTENT\n' > "${overwrite_root}/.claude/rules/markdown.md"
+
+SCRIPT_DIR="$plugin_root" REPO_ROOT="$overwrite_root" UPDATE_MODE=false COPIED_RULES="" copy_rules >/dev/null 2>&1
+
+# 上書きされ SSOT 内容になる（カスタム内容は保持されない）
+if cmp -s "${overwrite_root}/.claude/rules/markdown.md" "${plugin_root}/rules/markdown.md"; then
+  pass "user-install: カスタム編集が SSOT で上書きされる"
+else
+  fail "user-install: カスタム編集が上書きされていない"
+fi
+
+# コンフリクトマーカーが生成されていない（3-way マージしていない証跡）
+if grep -q -e '<<<<<<<' "${overwrite_root}/.claude/rules/markdown.md"; then
+  fail "user-install: コンフリクトマーカーが混入（3-way マージが残っている）"
+else
+  pass "user-install: コンフリクトマーカーなし（3-way マージしていない）"
+fi
+
+# ============================================
+echo "=== 5. user 固有 rule（配布対象外）が両モードで保持される ==="
+# ============================================
+
+# user-install: 配布対象外ファイルを置いてから copy_rules を呼んでも残る
+keep_user_root="${TMPDIR_ROOT}/keep_user"
+mkdir -p "${keep_user_root}/.claude/rules"
+make_ssot "$plugin_root"
+printf 'user-own-rule\n' > "${keep_user_root}/.claude/rules/custom-user-rule.md"
+
+SCRIPT_DIR="$plugin_root" REPO_ROOT="$keep_user_root" UPDATE_MODE=false COPIED_RULES="" copy_rules >/dev/null 2>&1
+
+assert_file_exists "user-install: 配布対象外 custom-user-rule.md が保持される" \
+  "${keep_user_root}/.claude/rules/custom-user-rule.md"
+
+# self-install: 配布対象外ファイルを置いてから copy_rules を呼んでも残る
+keep_self_root="${TMPDIR_ROOT}/keep_self"
+mkdir -p "${keep_self_root}/.claude/rules"
+make_ssot "$keep_self_root"
+printf 'user-own-rule\n' > "${keep_self_root}/.claude/rules/custom-user-rule.md"
+
+SCRIPT_DIR="$keep_self_root" REPO_ROOT="$keep_self_root" UPDATE_MODE=false COPIED_RULES="" copy_rules >/dev/null 2>&1
+
+assert_file_exists "self-install: 配布対象外 custom-user-rule.md が保持される" \
+  "${keep_self_root}/.claude/rules/custom-user-rule.md"
+
+# ============================================
+print_test_summary

--- a/tests/test_install_update.sh
+++ b/tests/test_install_update.sh
@@ -214,7 +214,7 @@ echo ""
 echo "=== P. --update での管理ファイル強制差し替え ==="
 # ============================================
 
-# P1. hooks は plugin native 配布 (#716) に移行済のため、3-way マージは rules で検証する
+# P1. user-install では rule は 3-way マージせず常に最新で上書きする（Issue #748）
 # ユーザー独自フックは install.sh が touch しないため残ることを併せて確認する
 create_test_repo
 bash "$INSTALL_SH" --name test-proj 2>/dev/null
@@ -228,8 +228,8 @@ echo '#!/bin/bash' > "$R/.claude/hooks/my-guard.sh"
 
 bash "$INSTALL_SH" --update 2>/dev/null
 
-# テンプレート未変更のため、カスタム版が保持される
-assert_file_contains "--update でカスタム版ルールが保持される" "$R/.claude/rules/code-comments.md" "ユーザーカスタム版"
+# user-install のため rule のカスタム版は保持されず最新テンプレートで上書きされる
+assert_file_not_contains "--update でカスタム版ルールが上書きされる（マージしない）" "$R/.claude/rules/code-comments.md" "ユーザーカスタム版"
 # ユーザー独自フックは残る
 assert_file_exists "--update でユーザー独自フックは保持" "$R/.claude/hooks/my-guard.sh"
 cleanup
@@ -271,7 +271,7 @@ fi
 assert_file_exists "--update でユーザー独自スキルは保持" "$R/.claude/skills/my-deploy/SKILL.md"
 cleanup
 
-# P3. --update でカスタマイズ済みルールはテンプレート未変更ならスキップ（3-way マージ）
+# P3. user-install ではカスタマイズ済みルールも常に最新で上書きする（Issue #748、3-way マージ廃止）
 create_test_repo
 bash "$INSTALL_SH" --name test-proj 2>/dev/null
 R="$TMPDIR_ROOT"
@@ -280,8 +280,8 @@ echo "# 古いルール" > "$R/.claude/rules/code-comments.md"
 
 bash "$INSTALL_SH" --update 2>/dev/null
 
-# テンプレートが変更されていないため、カスタム版が保持される
-assert_file_contains "--update でカスタム済みルールがテンプレート未変更なら保持" "$R/.claude/rules/code-comments.md" "古いルール"
+# 3-way マージを廃止したため、カスタム版は保持されず上書きされる
+assert_file_not_contains "--update でカスタム済みルールが上書きされる（マージしない）" "$R/.claude/rules/code-comments.md" "古いルール"
 cleanup
 
 # ============================================
@@ -348,7 +348,7 @@ bash "$INSTALL_SH" --update 2>/dev/null
 assert_file_exists "AB1: rules ファイルが存在" "$R/.claude/rules/code-comments.md"
 cleanup
 
-# AB2. カスタマイズ済み & テンプレート未変更 → カスタム版を保持（rules で検証）
+# AB2. user-install では rule のカスタマイズ版も常に最新で上書きする（Issue #748）
 create_test_repo
 bash "$INSTALL_SH" --name test-proj 2>/dev/null
 R="$TMPDIR_ROOT"
@@ -358,26 +358,27 @@ echo '# ユーザーカスタム: 追加のチェック' > "$R/.claude/rules/cod
 
 bash "$INSTALL_SH" --update 2>/dev/null
 
-# テンプレートが変更されていないため、カスタム版が保持される
-assert_file_contains "AB2: カスタム版が保持される" "$R/.claude/rules/code-comments.md" "ユーザーカスタム: 追加のチェック"
+# 3-way マージを廃止したため、カスタム版は保持されず上書きされる
+assert_file_not_contains "AB2: カスタム版が上書きされる（マージしない）" "$R/.claude/rules/code-comments.md" "ユーザーカスタム: 追加のチェック"
 cleanup
 
-# AB3. ベーススナップショットが保存される（rules で確認、hooks は plugin native 配布化）
+# AB3. rules は 3-way マージ廃止によりベーススナップショットを作らない（Issue #748）
+# vibecorp-base ディレクトリ自体は他テンプレート（.gitignore 等）の snapshot 用に存在しうる
 create_test_repo
 bash "$INSTALL_SH" --name test-proj 2>/dev/null
 R="$TMPDIR_ROOT"
 
-assert_dir_exists "AB3: vibecorp-base ディレクトリ存在" "$R/.claude/vibecorp-base"
-assert_file_exists "AB3: rules のベーススナップショット" "$R/.claude/vibecorp-base/rules/code-comments.md"
+assert_file_not_exists "AB3: rules のベーススナップショットは作られない（マージ廃止）" "$R/.claude/vibecorp-base/rules/code-comments.md"
 cleanup
 
-# AB4. vibecorp.lock に base_hashes セクションが含まれる（rules で確認）
+# AB4. vibecorp.lock に base_hashes セクションが含まれる（.gitignore 等の snapshot 由来）
+# rules は 3-way マージ廃止により base_hash を持たない（Issue #748）
 create_test_repo
 bash "$INSTALL_SH" --name test-proj 2>/dev/null
 R="$TMPDIR_ROOT"
 
 assert_file_contains "AB4: lock に base_hashes セクション" "$R/.claude/vibecorp.lock" "base_hashes:"
-assert_file_contains "AB4: lock に rules ハッシュ" "$R/.claude/vibecorp.lock" "rules/code-comments.md:"
+assert_file_not_contains "AB4: lock に rules ハッシュは無い（マージ廃止）" "$R/.claude/vibecorp.lock" "rules/code-comments.md:"
 cleanup
 
 # AB5. .claude/.gitignore に vibecorp-base/ が含まれる
@@ -468,8 +469,7 @@ fi
 rm -f "$TMPBASE" "$TMPCUSTOM" "$TMPNEW"
 cleanup
 
-# AB8. 統合テスト: merge_or_overwrite がカスタム版を保持（テンプレート未変更時）
-# hooks は plugin native 配布 (#716) に移行済のため rules で検証する
+# AB8. 統合テスト: user-install では --update で rule のカスタム版を常に上書きする（Issue #748）
 create_test_repo
 bash "$INSTALL_SH" --name test-proj --preset standard 2>/dev/null
 R="$TMPDIR_ROOT"
@@ -479,7 +479,7 @@ echo '# カスタム code-comments' > "$R/.claude/rules/code-comments.md"
 
 bash "$INSTALL_SH" --update --preset standard 2>/dev/null
 
-assert_file_contains "AB8: カスタム rule が保持される" "$R/.claude/rules/code-comments.md" "カスタム code-comments"
+assert_file_not_contains "AB8: カスタム rule が上書きされる（マージしない）" "$R/.claude/rules/code-comments.md" "カスタム code-comments"
 cleanup
 
 # AB9. 統合テスト: --update で旧スタブ・旧コピーがマイグレーションされる
@@ -513,26 +513,24 @@ else
 fi
 cleanup
 
-# AB10. コンフリクト発生時に stderr に警告メッセージが出力される
+# AB10. rules は 3-way マージ廃止により、古いベーススナップショットが残っていても
+# マージを試みず常に最新で上書きする（Issue #748）
 create_test_repo
 bash "$INSTALL_SH" --name test-proj 2>/dev/null
 R="$TMPDIR_ROOT"
 
-# ベーススナップショットとは異なる内容で上書き（カスタマイズ模擬）
+# カスタマイズ模擬
 echo "# カスタム版コメントルール" > "$R/.claude/rules/code-comments.md"
 
-# テンプレートも変更（ベースと異なる新しい内容にする）
-# ベーススナップショットを直接変更して強制的にマージをトリガー
+# 古いベーススナップショットを直接配置（旧仕様ならマージをトリガーした状況を模擬）
+mkdir -p "$R/.claude/vibecorp-base/rules"
 echo "# 改変されたベース" > "$R/.claude/vibecorp-base/rules/code-comments.md"
 
-STDERR_OUTPUT=$(bash "$INSTALL_SH" --update 2>&1 >/dev/null) || true
+bash "$INSTALL_SH" --update 2>/dev/null
 
-# マージまたはスキップのログが出力されることを確認
-if echo "$STDERR_OUTPUT" | grep -q "マージ\|スキップ\|MERGE\|SKIP\|CONFLICT"; then
-  pass "AB10: マージ関連ログが出力される"
-else
-  fail "AB10: マージ関連ログが出力される (ログなし)"
-fi
+# マージせず上書きされるため、カスタム版は残らずコンフリクトマーカーも生じない
+assert_file_not_contains "AB10: カスタム版は上書きされる（マージしない）" "$R/.claude/rules/code-comments.md" "カスタム版コメントルール"
+assert_file_not_contains "AB10: コンフリクトマーカーが生じない" "$R/.claude/rules/code-comments.md" "<<<<<<<"
 cleanup
 
 # AB11. ベースハッシュなし（旧バージョン移行）の場合は上書きされる
@@ -558,71 +556,35 @@ create_test_repo
 bash "$INSTALL_SH" --name test-proj 2>/dev/null
 R="$TMPDIR_ROOT"
 
-# ファイルは変更しないが、ベーススナップショットを差し替えて「テンプレート変更」を模擬
-echo "# 古いベース" > "$R/.claude/vibecorp-base/rules/code-comments.md"
-# lock のハッシュもベースに合わせる
-OLD_HASH=$(shasum -a 256 "$R/.claude/vibecorp-base/rules/code-comments.md" | awk '{print $1}')
-CURRENT_HASH=$(shasum -a 256 "$R/.claude/rules/code-comments.md" | awk '{print $1}')
-# lock のハッシュを現在のファイルのハッシュに設定（= カスタムなし状態を作る）
-awk -v path="rules/code-comments.md" -v newhash="$CURRENT_HASH" '
-  /^  base_hashes:/ { in_hashes = 1; print; next }
-  in_hashes && /^  [a-z]/ { in_hashes = 0 }
-  in_hashes && /^[^ ]/ { in_hashes = 0 }
-  in_hashes {
-    gsub(/^[ \t]+/, "", $0)
-    split($0, parts, ": ")
-    if (parts[1] == path) {
-      print "    " path ": " newhash
-      next
-    }
-  }
-  { print }
-' "$R/.claude/vibecorp.lock" > "$R/.claude/vibecorp.lock.tmp" && mv "$R/.claude/vibecorp.lock.tmp" "$R/.claude/vibecorp.lock"
+# rules は base snapshot / base_hash を持たないため、--update でも単純に最新で上書きされる。
+# 元の SSOT 内容を控え、--update 後も SSOT と一致することを確認する。
+SRC_CONTENT=$(cat "$SCRIPT_DIR/rules/code-comments.md")
 
 bash "$INSTALL_SH" --update 2>/dev/null
 
-# テンプレート版（=元々のテンプレート）で上書きされているはず
 assert_file_exists "AB12: rules ファイルが存在" "$R/.claude/rules/code-comments.md"
+DEST_CONTENT=$(cat "$R/.claude/rules/code-comments.md")
+assert_eq "AB12: --update 後 rule が SSOT 最新と一致（上書き）" "$SRC_CONTENT" "$DEST_CONTENT"
 cleanup
 
-# AB13. --update 後のコンフリクト警告表示テスト
-# ベースと現在とテンプレートが全て異なる場合にコンフリクトが報告される
+# AB13. rules は 3-way マージ廃止により、ベース・現在・テンプレートが全て異なっても
+# コンフリクトを起こさず最新テンプレートで上書きする（Issue #748）
 create_test_repo
 bash "$INSTALL_SH" --name test-proj 2>/dev/null
 R="$TMPDIR_ROOT"
 
-# ベーススナップショットを置き換え（独立した3つの内容を作る）
+# ベーススナップショットを独立した内容で配置（旧仕様なら 3-way コンフリクトを起こした状況を模擬）
+mkdir -p "$R/.claude/vibecorp-base/rules"
 echo "ベース版の内容" > "$R/.claude/vibecorp-base/rules/code-comments.md"
-BASE_HASH=$(shasum -a 256 "$R/.claude/vibecorp-base/rules/code-comments.md" | awk '{print $1}')
-
-# lock のハッシュをベースに合わせる
-awk -v path="rules/code-comments.md" -v newhash="$BASE_HASH" '
-  /^  base_hashes:/ { in_hashes = 1; print; next }
-  in_hashes && /^  [a-z]/ { in_hashes = 0 }
-  in_hashes && /^[^ ]/ { in_hashes = 0 }
-  in_hashes {
-    gsub(/^[ \t]+/, "", $0)
-    split($0, parts, ": ")
-    if (parts[1] == path) {
-      print "    " path ": " newhash
-      next
-    }
-  }
-  { print }
-' "$R/.claude/vibecorp.lock" > "$R/.claude/vibecorp.lock.tmp" && mv "$R/.claude/vibecorp.lock.tmp" "$R/.claude/vibecorp.lock"
 
 # カスタム版に書き換え
 echo "カスタム版の内容" > "$R/.claude/rules/code-comments.md"
 
-# --update 実行（テンプレートはベースと異なる → 3-way マージ発生）
-STDERR_OUTPUT=$(bash "$INSTALL_SH" --update 2>&1 >/dev/null) || true
+bash "$INSTALL_SH" --update 2>/dev/null
 
-# MERGE または CONFLICT のログが出力される
-if echo "$STDERR_OUTPUT" | grep -q "MERGE\|CONFLICT\|マージ\|コンフリクト"; then
-  pass "AB13: コンフリクト/マージログが表示される"
-else
-  fail "AB13: コンフリクト/マージログが表示される (ログなし)"
-fi
+# マージせず上書きされるため、コンフリクトマーカーもカスタム版も残らない
+assert_file_not_contains "AB13: コンフリクトマーカーが生じない（マージ廃止）" "$R/.claude/rules/code-comments.md" "<<<<<<<"
+assert_file_not_contains "AB13: カスタム版は上書きされる" "$R/.claude/rules/code-comments.md" "カスタム版の内容"
 cleanup
 
 # ============================================


### PR DESCRIPTION
## 🎯 背景・目的

vibecorp 自身を dogfooding する環境では `.claude/rules/` がトップ `rules/` SSOT へのファイル単位 symlink になっている。これまでの `copy_rules()` は配布先と vibecorp 自身を区別せず、`install.sh` を流すと dogfooding 用の symlink を実体コピーで壊すリスクがあった。

このリファクタで、**インストール先が vibecorp 自身か配布先かを自動判定** し、それぞれに正しい配置方式を選ぶようになった（挙動変更は配布方式の確定であり、Issue #748 の明示的なゴール）。

## 🔄 Before / After

| 観点 | 🔴 Before | 🟢 After |
|------|----------|----------|
| vibecorp 自身への install | 配布先と同じ扱いで symlink を破壊しうる | `.claude/rules/` を SSOT への **ファイル単位 symlink で再生成** するようになった |
| 配布先への install | 3-way マージでカスタム版を温存しうる | **物理コピーで常に最新に上書き** するようになった |
| rule のカスタマイズ | 3-way マージ経路あり | 廃止。CEO 承認済の「常に最新で上書き」に統一 |
| user 独自 rule | 保持 | 両モードで引き続き保持される（配布物だけを列挙する自然な挙動） |

## 🧭 設計判断

- **self-install 判定**: `SCRIPT_DIR`（plugin root）と `REPO_ROOT` を **正規化して比較** する。`realpath` は古い macOS に不在で `shell.md` の BSD/GNU 互換要件に反するため、挙動等価のまま `( cd "$dir" && pwd -P )` で正規化する経路を選んだ。
- **3-way マージの扱い**: rule からの呼び出しのみ除去し、`merge_or_overwrite` 関数自体は `REVIEW.md` / `.gitignore` / 各 workflow が依然使うため残した（不要な削除でスコープを広げない）。

## 🔍 動作不変性の担保

- `intent/refactor` の必須観点として、dogfooding の symlink 構造（`.claude/rules/` 全 symlink）が壊れないことを新規テストで検証した。
- 配布方式の変更（skip/merge → overwrite）は Issue が明示的に要求した挙動変更であり、コミット・Issue 本文・PR で根拠を明示している。

## 🧪 テスト観点

- `tests/test_install_rules_copy.sh`（新規）: self-install の symlink 再生成 / user-install の物理コピー上書き / カスタム版の上書き（マージしない）/ user 固有 rule の両モード保持 / `_relpath_to_rules` の階層深さ算出を検証。
- `tests/test_install_update.sh` / `tests/test_install_preset.sh`: 旧 3-way マージ前提のアサーションを新挙動（常に上書き・rule の base snapshot 非作成）に整合させた。

## 🖼️ 位置づけ

- 親エピック #744（R4、工数 M）。依存 R3（#747）の トップ `rules/` SSOT 上に構築。
- 本 PR の base は親 feature ブランチ `feature/epic-744_rules_plugin_root_ssot`。

## 🚧 スコープ外

- テストスイート全体の再整備は R5（#749）。本 PR は copy_rules の挙動変更に直接関わるアサーションの整合のみに留めた。

## 📍 関連

- 親エピック: #744
- 設計コメント: https://github.com/hirokimry/vibecorp/issues/403#issuecomment-4545858031

Closes #748
Refs #744


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * ルール配布動作の検証テストを追加・更新しました。

* **Refactor**
  * ルール更新時の配布ロジックを改善しました。ユーザーがカスタマイズしたルールファイルは最新版で上書きされるようになります。3-way マージは廃止されました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hirokimry/vibecorp/pull/753?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->