### PR TITLE
🔄 refactor: plugin.json が利用者にコピーされなくなる

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -907,12 +907,11 @@ copy_managed_files() {
   # agents は plugin native 配布 (#737 / #735) で plugin/agents/ に一元化されたため、
   # install.sh は配置しない。利用先プロジェクトの Claude Code が plugin cache 経由で自動検出する。
 
-  # .claude-plugin/plugin.json: vibecorp 自身の .claude-plugin/plugin.json が
-  # 唯一の Source-of-Truth。templates/ 経由の二重管理は drift の原因になるため廃止 (Issue #540)
-  if [[ -f "${SCRIPT_DIR}/.claude-plugin/plugin.json" ]]; then
-    mkdir -p "${REPO_ROOT}/.claude-plugin"
-    cp "${SCRIPT_DIR}/.claude-plugin/plugin.json" "${REPO_ROOT}/.claude-plugin/plugin.json"
-  fi
+  # .claude-plugin/plugin.json は利用者 repo に配布しない (Issue #764)。
+  # プラグイン消費側は ~/.claude/plugins/cache/ から読むため利用者 repo にマニフェストは不要。
+  # #700/#737/#744 の plugin native 化で利用者 repo にプラグイン実体が無くなったため、
+  # マニフェストだけ置いても指す相手がいない。vibecorp 自身の .claude-plugin/plugin.json は
+  # 開発元の必須マニフェスト (SoT) として git 管理下で保持される。
 
   # プレースホルダー置換
   # macOS 互換: sed ... > tmp && mv tmp original（sed -i の BSD/GNU 差異を回避）

--- a/tests/test_install_plugin_version.sh
+++ b/tests/test_install_plugin_version.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
-# test_install_plugin_version.sh — Issue #540: plugin.json drift 防止
+# test_install_plugin_version.sh — Issue #764: plugin.json は利用者 repo に配布しない
 #
-# install.sh が consumer に配布する .claude-plugin/plugin.json の version が、
-# vibecorp 自身の .claude-plugin/plugin.json (Source of Truth) と完全一致することを検証する。
+# install.sh が利用者 (consumer) repo に .claude-plugin/plugin.json を配置しないことを検証する。
+# プラグイン消費側は ~/.claude/plugins/cache/ から読むため、利用者 repo にマニフェストは不要
+# (#700/#737/#744 の plugin native 化で利用者 repo にプラグイン実体が無くなったため)。
 #
-# 重複 SoT (templates/claude-plugin/plugin.json) によるダウングレード再発を防ぐ
-# 不変条件テスト。
+# vibecorp 自身の .claude-plugin/plugin.json (Source of Truth) は開発元の必須マニフェストとして
+# git 管理下で保持される — その version フィールド存在は前提として確認する。
+#
+# 旧不変条件 (Issue #540: consumer 側 version が SoT と一致) は #764 で廃止された
+# (そもそも consumer に配らなくなったため)。
 #
 # 使い方: bash tests/test_install_plugin_version.sh
 
@@ -17,7 +21,7 @@ source "${SCRIPT_DIR}/tests/lib/install_test_helpers.sh"
 
 SOT_PLUGIN="${SCRIPT_DIR}/.claude-plugin/plugin.json"
 
-# 前提: SoT が存在し、version フィールドを持つ
+# 前提: SoT が存在し、version フィールドを持つ (開発元の必須マニフェスト)
 if [[ ! -f "$SOT_PLUGIN" ]]; then
   fail "SoT (.claude-plugin/plugin.json) が存在しない"
   exit 1
@@ -34,73 +38,52 @@ if [[ -z "$SOT_VERSION" ]]; then
   exit 1
 fi
 
-extract_version() {
-  local file="$1"
-  jq -r '.version // ""' "$file"
-}
-
 # ============================================
 echo ""
-echo "=== Plugin version SoT 一致テスト (Issue #540) ==="
+echo "=== Plugin.json 利用者非配布テスト (Issue #764) ==="
 # ============================================
 
-# --- A. --name 初回 install: consumer 側 plugin.json が SoT version と一致 ---
+# --- A. --name 初回 install: consumer 側 plugin.json が配置されない ---
 
 echo ""
-echo "--- A. 初回 install で plugin.json version が SoT と一致 ---"
+echo "--- A. 初回 install で consumer に plugin.json が配置されない ---"
 
 create_test_repo
 bash "$INSTALL_SH" --name test-proj --preset minimal --language ja 2>/dev/null
 R="$TMPDIR_ROOT"
 
-CONSUMER_PLUGIN="${R}/.claude-plugin/plugin.json"
-assert_file_exists "consumer 側 .claude-plugin/plugin.json が配置される" "$CONSUMER_PLUGIN"
-
-CONSUMER_VERSION="$(extract_version "$CONSUMER_PLUGIN")"
-assert_eq "consumer plugin.json version が SoT と一致" "$SOT_VERSION" "$CONSUMER_VERSION"
+assert_file_not_exists "consumer 側 .claude-plugin/plugin.json が配置されない" "${R}/.claude-plugin/plugin.json"
 
 cleanup
 TMPDIR_ROOT=""
 
-# --- B. --update 再実行: consumer 側 plugin.json が SoT version と一致したまま ---
+# --- B. --update 再実行: consumer 側 plugin.json が配置されないまま ---
 
 echo ""
-echo "--- B. --update 再実行で plugin.json version が SoT と一致したまま ---"
+echo "--- B. --update 再実行でも consumer に plugin.json が配置されない ---"
 
 create_test_repo
 bash "$INSTALL_SH" --name test-proj --preset minimal --language ja 2>/dev/null
 R="$TMPDIR_ROOT"
-
-# consumer 側 plugin.json を意図的に古いバージョンに書き換え（drift 模擬）
-cat > "${R}/.claude-plugin/plugin.json" <<'EOF'
-{
-  "name": "vibecorp",
-  "version": "0.0.1",
-  "description": "drift simulation"
-}
-EOF
 
 # --update を実行
 bash "$INSTALL_SH" --update 2>/dev/null
 
-# SoT version に戻っていることを確認（ダウングレード/ドリフトが発生しない）
-CONSUMER_VERSION="$(extract_version "${R}/.claude-plugin/plugin.json")"
-assert_eq "--update で plugin.json version が SoT に再同期される" "$SOT_VERSION" "$CONSUMER_VERSION"
+assert_file_not_exists "--update 後も consumer に plugin.json が配置されない" "${R}/.claude-plugin/plugin.json"
 
 cleanup
 TMPDIR_ROOT=""
 
-# --- C. preset full でも同じ不変条件が保たれる ---
+# --- C. preset full でも consumer に plugin.json が配置されない ---
 
 echo ""
-echo "--- C. preset full でも plugin.json version が SoT と一致 ---"
+echo "--- C. preset full でも consumer に plugin.json が配置されない ---"
 
 create_test_repo
 bash "$INSTALL_SH" --name test-proj --preset full --language ja 2>/dev/null
 R="$TMPDIR_ROOT"
 
-CONSUMER_VERSION="$(extract_version "${R}/.claude-plugin/plugin.json")"
-assert_eq "preset full の consumer plugin.json version が SoT と一致" "$SOT_VERSION" "$CONSUMER_VERSION"
+assert_file_not_exists "preset full でも consumer に plugin.json が配置されない" "${R}/.claude-plugin/plugin.json"
 
 cleanup
 TMPDIR_ROOT=""

--- a/tests/test_plugin_structure.sh
+++ b/tests/test_plugin_structure.sh
@@ -58,8 +58,9 @@ else
   pass "install 後 skills/ が作成されていない"
 fi
 
-# B3. .claude-plugin/plugin.json がコピーされている
-assert_file_exists "install 後 .claude-plugin/plugin.json" "${R}/.claude-plugin/plugin.json"
+# B3. .claude-plugin/plugin.json は利用者 repo にコピーされない (Issue #764)
+# プラグイン消費側は ~/.claude/plugins/cache/ から読むため利用者 repo にマニフェストは不要。
+assert_file_not_exists "install 後 .claude-plugin/plugin.json が配置されない" "${R}/.claude-plugin/plugin.json"
 
 # B4. .claude/skills/ 互換スタブが生成されない（Phase 3 で廃止）
 if [[ -d "${R}/.claude/skills" ]]; then


### PR DESCRIPTION
## 🎯 背景

利用者リポジトリに `.claude-plugin/plugin.json` をコピーしていたが、プラグイン消費側は `~/.claude/plugins/cache/` から読むため利用者 repo にマニフェストは不要だった。#700/#737/#744 の plugin native 化で利用者 repo にプラグイン実体が無くなり、マニフェストだけ置いても**指す相手がいない**状態になっていた。

## 🔄 Before / After

| | Before | After |
|---|---|---|
| 利用者 repo の `.claude-plugin/plugin.json` | install.sh がコピー配置 | 配置されなくなった |
| vibecorp 自身の `.claude-plugin/plugin.json` | SoT | SoT のまま（git 管理下で保持） |

## 🧪 テスト観点

- `test_install_plugin_version.sh` を旧「consumer version が SoT と一致」検証から、新不変条件「**利用者 repo に plugin.json が配置されない**」検証へ改訂（minimal / full / --update の3経路）。
- `test_plugin_structure.sh` の B3 を consumer 配置 assert → 非配置 assert に修正（本変更で壊れるため必然的に追従）。
- vibecorp 自身の SoT が version フィールドを持つ前提チェックは保持。

## 🖼️ 位置づけ

エピック #758（templates/ 配布方式 SSOT 一本化）の子 Issue。直列実行の1件目。

Closes #764
Refs #758


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * プラグインマニフェストファイルがユーザーリポジトリに不要に配布される問題を修正しました。マニフェストはキャッシュディレクトリから直接参照されるため、ユーザーリポジトリへのコピーは行われなくなります。
  * インストール、更新、プリセット適用時の動作検証テストを更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hirokimry/vibecorp/pull/765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->