### PR TITLE
⏪ revert: PR #774（README 開発者ファースト再編）を全面差し戻す

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,22 @@
 # vibecorp
 
-Claude Code を「**判断の履歴を引き継ぐ AI 開発組織**」に変えるプラグイン。
-Issue を渡すと、COO が意図を解釈して領分を判定する。
-担当する専門役へ割り振り、実装 → PR → auto-merge まで進める。
-各役職の判断は「判例」として残り、次の判断時に読み戻される。
-
-- 🛠️ **対象**: Claude Code を使う開発者・チーム
-- 🎯 **解く課題**: AI への指示が毎回その場限りで、判断基準が蓄積されない
-- ⚡ **最短導入**: `install.sh --name your-project` → `/plugin install`（2 コマンド）
+🤖 **AI エージェントを組織化してプロダクト開発を回すプラグイン**
 
 > [!IMPORTANT]
 > このドキュメントは **外部 OSS 読者・導入開発者** 向けの入口ガイドです。
+> どのリポジトリにも 2 コマンドで導入でき、Issue 駆動の開発ループを AI に委譲できます。
 > 詳細仕様は [`docs/specification.md`](docs/specification.md) を参照してください。
+
+どのリポジトリにも導入できる。
+Claude Code の skills / hooks / agents / rules を一括セットアップする。
+Issue 駆動の開発ループを AI に委譲する。
+ブランチ作成から PR の auto-merge まで一気通貫で実行する。
+
+| 何ができる？ | どう動く？ |
+|------------|----------|
+| 🚀 `/vibecorp:ship <Issue URL>` 1 行で Issue を実装・PR 化・auto-merge まで全自動 | スキル → エージェント → フック が連動して計画 → 実装 → レビュー → マージを進める |
+| 🎁 プリセット 3 段階（minimal / standard / full）で個人 → チーム → AI 企業まで段階導入 | 上位は下位の機能を全包含。`install.sh --preset full` で AI 企業組織モード |
+| 🔒 ガードレール（保護系・ゲート系・API バイパス防止系・ログ系）が常時稼働 | `vibecorp.yml` でも無効化できない必須 hook で品質ゲートを担保 |
 
 ---
 
@@ -58,56 +63,6 @@ path/to/vibecorp/install.sh --name your-project
 | `--update` | 既存インストールを更新（`vibecorp.yml` から設定を読む） |
 
 `--name` と `--update` は同時指定不可。全オプション一覧と詳細仕様は [`docs/configuration.md`](docs/configuration.md) を参照。
-
----
-
-## 🎁 何ができる？
-
-| できること | 動線 |
-|------------|----------|
-| 🚀 Issue を実装・PR 化・auto-merge まで全自動 | `/vibecorp:ship <Issue URL>` の 1 行 |
-| 🎁 個人 → チーム → AI 企業まで段階導入 | プリセット 3 段階（minimal / standard / full） |
-| 🔒 品質ゲートが常時稼働 | `vibecorp.yml` でも無効化できない必須 hook |
-
-機能レベルで「〜できるようにしたい」と Issue を渡すだけでよい。
-COO が意図を解釈し、適切な担当へ割り振る。
-技術は CTO、コストは CFO、安全は CISO、法務は CLO。
-
----
-
-## ✨ 何がユニークか
-
-標準的な AI コーディング支援との違いは一点。
-**判断が「判例」として組織に残り、次の判断に効く**、その一点にある。
-
-- 各役職は判断のたびに、結論・根拠・却下した代替案を記録する。
-- 次に呼ばれたとき、その判例を読み戻してから判断する。
-- 判例は役職別・時系列で蓄積される。
-- 標準メモリーの個人・上書き型の記憶とは別物。
-
-実際にこのリポジトリに蓄積されている判例の一部:
-
-| 役職 | 残っている判断（実物） |
-|---|---|
-| 🧑‍🔬 CTO | Docker 隔離を撤回し sandbox-exec / bwrap へ転換（却下案: Hyper-V / Firejail） |
-| 🔒 CISO | 「攻撃成立にはリポジトリ改ざんが前提」→ High を Minor に格下げ（Issue #318 と一貫） |
-| 💰 CFO | `max_issues_per_run` を「3 へ」→ 再判断で「7 へ」自己撤回（月 $840 試算付き） |
-| ⚖️ CLO | 「CodeRabbit 完全網羅」表現は廃棄を条件に可と裁定（著作権法 2 条・不正競争防止法 2 条 1 項 3 号） |
-| 📋 CPO | Pro プラン新設を No-Go（4 段目は「導入の手軽さ」バリューに反する） |
-| 🏃 SM | 7 件の同時並列は不可、最大 3 件並列が安全な上限（install.sh 競合を検出） |
-
-> 📖 仕組みの詳細（役職別 knowledge の構造・読み戻し動線）は [`docs/ai-organization.md`](docs/ai-organization.md) / [`docs/design-philosophy.md`](docs/design-philosophy.md) を参照。
-> vibecorp 自身の改善も vibecorp で回しており、上の判例はその過程で各役職が書き残したもの。
-
----
-
-## 🛡️ 安全に手を離せる土台
-
-自律で動くからこそ、暴走を構造で封じている。詳細は各リンク先を参照。
-
-- ⚠️ **触れてはいけない領域は機械的に締め出す** — 認証 / 暗号 / 課金 / ガードレール / MVV / CI 権限の 6 領域は自律実行の対象外（[`docs/SECURITY.md`](docs/SECURITY.md)）
-- 🚦 **意志力に頼らないゲート** — レビュー前の PR 作成・未整合の push を必須 hook が自動で止める（[🪝 フック概要](#-フック概要)）
-- 💰 **コスト上限の明文化** — `max_issues_per_run` 等の上限を CFO が監査し証跡を残す（[`docs/cost-analysis.md`](docs/cost-analysis.md)）
 
 ---
 


### PR DESCRIPTION
## 🎯 目的

CEO の明示許可なく PR #774 を auto-merge してしまったため、**PR #774 全体を差し戻す**。

## ⚠️ 前回 revert（#775）の誤りを修正

| | 戻した範囲 | 結果 |
|---|---|---|
| 🔴 #775（クローズ済み） | 今セッションの再編分のみ | 最初の README 書き換えが残存し revert 未完了 |
| 🟢 本 PR | **PR #774 全体（squash commit a3be32b）** | README が **真の元版**（`AI エージェントを組織化してプロダクト開発を回すプラグイン`）に完全復元 |

`git diff eed2bbd HEAD -- README.md` = **差分 0**（PR #774 マージ直前の状態と一致）。

## 🔒 マージ方針

- この PR には **auto-merge を付けていない**。
- CEO が精査して **自分でマージ** する。
- この revert がマージされたら、**同一内容の再適用 PR**（README 開発者ファースト再編）を**未マージ**で作成し、CEO が精査・マージする。

Refs #773

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * README の導入部を更新し、Vibecorp の機能説明を簡潔化
  * 機能比較表を新たに追加
  * ドキュメント構成を再構成してわかりやすく整理

<!-- end of auto-generated comment: release notes by coderabbit.ai -->