### PR TITLE
🐛 fix: CodeRabbit が review-observations.md の観点で正しくレビューできるようになり、stale な path_instructions が解消される

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -24,14 +24,18 @@ reviews:
         PRが対応するIssueの要件を全て満たしているかを必ずチェックすること。
         PRの説明やブランチ名からIssue番号を特定し、そのIssueの「やること」に記載された全項目が実装されているか確認する。
         未対応の要件がある場合は明確に指摘すること。
-    - path: "templates/claude/hooks/**"
+    # path 基準の観点チェックリスト（intent 非依存で全 PR に適用）。
+    # intent × severity の捌きは review-fix（pr-fix / review-loop）の責務（rules/review-handling.md）。
+    # path は vibecorp 自身の repo 構造（plugin 開発元）に対応する。配布元 templates/coderabbit.yaml.tpl は
+    # generic な "**" のみで、hooks/skills は plugin 配布のため利用者 repo root には存在しない（Issue #757）。
+    - path: "hooks/**"
       instructions: |
         シェルスクリプトのレビュー。以下をチェック:
         - set -euo pipefail が設定されているか
         - jq による JSON パースが正しいか
         - エッジケース（空入力、ファイル不在）が考慮されているか
         - セキュリティ上の問題（インジェクション等）がないか
-    - path: "templates/claude/skills/**"
+    - path: "skills/**"
       instructions: |
         スキル定義のレビュー。以下をチェック:
         - YAML frontmatter の name / description が内容と一致しているか

--- a/rules/review-observations.md
+++ b/rules/review-observations.md
@@ -2,18 +2,34 @@
 
 > [!IMPORTANT]
 > 各 intent の重視軸に対応するレビュー観点（observation_points）を定義する。
-> `.coderabbit.yaml` と `REVIEW.md`（claude-code-action のプロンプト）の両方が本ファイルを Source of Truth として参照する。
+> **reviewer は intent によらず観点を surfacing する**。intent × severity の捌き（修正対象判定）は review-fix（`pr-fix` / `review-loop`）と claude-action の責務（`review-handling.md`）。
+> 本ファイルを Source of Truth として参照するのは `REVIEW.md`（claude-code-action のプロンプト）。`.coderabbit.yaml` は **path 基準の別軸**であり本ファイルを参照しない。
 > `intent/refactor` / `intent/infra` / `intent/docs` は **挙動不変性の確認** を必ず行う。
 
-本ルールは PR レビュー時の観点リストを intent 別に提供する。
+本ルールは PR レビューの観点リストを intent 別に整理して提供する。intent 別の見出しは **捌き側が参照する分類**であって、reviewer が surfacing 時に選ぶ軸ではない。
 
 ## 🎯 役割
 
 本ルールは CodeRabbit / claude-code-action による PR レビューの観点定義を担う。
 
-- 適用対象: CodeRabbit / claude-code-action による PR レビュー。
-- 参照経路: `.coderabbit.yaml` と `REVIEW.md`（claude-code-action のプロンプト）の両方が本ファイルを Source of Truth として参照する。
+- 適用対象: CodeRabbit / claude-code-action による PR レビュー（観点の surfacing は intent 非依存）。
+- 参照経路: `REVIEW.md`（claude-code-action のプロンプト）が本ファイルを Source of Truth として参照する。claude-action は自分で approve / request_changes を発行するため、intent 別の観点分類を捌きにも用いる。
+- 別軸: `.coderabbit.yaml` は **path 基準**の観点チェックリストを持つ（本ファイルとは別軸）。CodeRabbit は PR の intent ラベルを読めないため本ファイルを参照しない。CodeRabbit が出した指摘の intent × severity の捌きは review-fix（`pr-fix` / `review-loop`）が担う。
 - 関連: `.claude/rules/review-handling.md`（捌き基準、intent × severity の掛け合わせ）。
+
+## 🧭 surfacing（reviewer）と捌き（review-fix）の責務分離
+
+> [!NOTE]
+> reviewer は観点を **intent によらず** surfacing する。intent × severity で「直すか否か」を判定するのは捌き側。
+
+| 役割 | 主体 | intent の扱い |
+|------|------|--------------|
+| surfacing（観点で指摘を出す） | CodeRabbit / claude-action | **intent 非依存**（観点を全適用） |
+| 捌き（修正対象を判定する） | `pr-fix` / `review-loop`、claude-action（自己発行時） | **intent × severity**（`review-handling.md`） |
+
+- CodeRabbit は path 基準（`.coderabbit.yaml`）で観点を適用し、severity 付き指摘を出す。intent は読まない。
+- claude-action（`REVIEW.md`）は approve / request_changes を自分で発行するため、本ファイルの intent 別分類を捌きにも用いる。
+- 本ファイルの intent 別整理は **捌き側の参照用**。reviewer に「この intent だけ見ろ」と指示するものではない。
 
 ## 📋 intent 別レビュー観点
 

--- a/tests/test_coderabbit_path_instructions.sh
+++ b/tests/test_coderabbit_path_instructions.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# test_coderabbit_path_instructions.sh — Issue #757: .coderabbit.yaml の path_instructions の
+# 参照先パスが repo 内に実在することを検証する（stale path の再発防止）。
+# 使い方: bash tests/test_coderabbit_path_instructions.sh
+# CI: GitHub Actions で自動実行
+#
+# 背景: plugin native 移行（#700 / #358）で hooks/skills が repo root へ移動した後も
+# `.coderabbit.yaml` の path_instructions に旧パス（templates/claude/hooks 等）が残り、
+# シェル/スキル観点が二度と発火しなくなった（#757）。本テストは path_instructions の
+# 各 path のベースディレクトリが実在することを確認し、再 stale 化を機械的に検知する。
+
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${TESTS_DIR}/lib/test_helpers.sh"
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CODERABBIT_YAML="${ROOT}/.coderabbit.yaml"
+
+# 前提ファイル不在は後続テストを無意味にするため即終了する（testing.md 準拠）。
+if [[ -f "$CODERABBIT_YAML" ]]; then
+  pass ".coderabbit.yaml が存在する"
+else
+  fail ".coderabbit.yaml が存在しない"
+  exit 1
+fi
+
+# ============================================
+echo "=== path_instructions の path がベースディレクトリ実在を満たす ==="
+# ============================================
+
+# path_instructions の各エントリは `- path: "<glob>"` 形式。
+# awk -F'"' で最初のダブルクォート間の値を抜き出す（path_filters の `- "!..."` は path: を持たないため対象外）。
+paths=$(awk -F'"' '/^[[:space:]]*- path:/ {print $2}' "$CODERABBIT_YAML")
+
+if [[ -z "$paths" ]]; then
+  fail "path_instructions の path エントリを 1 つも抽出できなかった（書式変更 or パース失敗）"
+  exit 1
+fi
+
+checked=0
+while IFS= read -r p; do
+  [[ -z "$p" ]] && continue
+  checked=$((checked + 1))
+
+  # "**" 単独は repo ルート全体を指すため常に有効（実在判定の対象外）。
+  if [[ "$p" == "**" ]]; then
+    pass "path \"**\"（repo ルート）は常に有効"
+    continue
+  fi
+
+  # glob 末尾（/** や /*）と末尾スラッシュを剥がしてベースディレクトリを得る。
+  base="${p%/\*\*}"   # hooks/** → hooks
+  base="${base%/\*}"  # foo/*    → foo
+  base="${base%/}"    # 末尾スラッシュ除去
+
+  if [[ -e "${ROOT}/${base}" ]]; then
+    pass "path_instructions \"${p}\" の参照先 \"${base}\" は実在する"
+  else
+    fail "path_instructions \"${p}\" の参照先 \"${base}\" が実在しない（stale path・Issue #757 再発）"
+  fi
+done <<<"$paths"
+
+if [[ "$checked" -eq 0 ]]; then
+  fail "path エントリを 1 件も検査しなかった"
+  exit 1
+fi
+
+print_test_summary


### PR DESCRIPTION
## 🎯 背景・目的

CodeRabbit の **シェル/スキル観点が二度と発火しなくなっていた**。plugin native 移行（#700 / #358）で hooks/skills が repo root へ移動した後も、`.coderabbit.yaml` の path_instructions が旧パス（`templates/claude/hooks/**` / `templates/claude/skills/**`）を指したままだったため。

あわせて実装前のドキュメント精査で、当初 Issue の懸念2・懸念4 が**誤前提に立っていた**ことが判明し、設計に忠実な形へ方針を確定した（CEO 承認済み）。

## 🔄 Before / After

| 観点 | 🔴 Before | 🟢 After |
|------|----------|---------|
| シェル/スキル観点 | 旧パス指定で**発火しない** | `hooks/**` / `skills/**` で**再び発火する** |
| review-observations の説明 | 「`.coderabbit.yaml` が参照する」と過剰主張 | reviewer は intent 非依存で surfacing・捌きは review-fix の責務、と正しく説明 |
| 再 stale 化 | 検知できない | CI で参照先実在を**自動検知する** |

## 🧭 設計判断（当初 Issue の誤前提を是正）

> [!IMPORTANT]
> 「reviewer は intent によらず観点を surfacing し、intent × severity の捌き（修正対象判定）は review-fix（`pr-fix` / `review-loop`）の責務」が正しい設計（`intent-labels.md` / `review-handling.md` に明記）。

- **懸念2（CodeRabbit を intent-aware にする実装）→ 不採用**。reviewer は intent 非依存が正。CodeRabbit が path 基準で intent を読めないのは設計通りで、intent-aware 化はむしろ設計違反。
- **懸念4（template と vibecorp 自身の drift 解消で観点を揃える）→ 不採用**。hooks/skills は plugin 経由配布で**利用者 repo root には存在しない**。template=generic・vibecorp 自身=開発元 repo 固有 path を持つ乖離は**設計上正しい**。template に `hooks/**` を足すと利用者側に stale path を再生産する。

## 🔍 懸念5 検証結果（コード変更なし・記録）

REVIEW.md（claude-action）が参照する 4 rules が `claude_action.enabled: true` な利用先で解決することを確認した。

- 参照先: `severity/claude-action.md` / `review-observations.md` / `review-handling.md` / `intent-labels.md`
- 配布: `copy_rules`（`install.sh:2358` の `find -maxdepth 2`）が severity/ サブディレクトリ含め `.claude/rules/` に配置する
- カバレッジ: 既存テスト `test_install_rules_copy.sh` / `test_install_rules_new_structure.sh` が severity/ サブ配布を両モードで検証済み

## 🧪 テスト

- `tests/test_coderabbit_path_instructions.sh` を追加。`.coderabbit.yaml` の path_instructions の各 path のベースディレクトリが repo 内に実在することを検証する（5/5 PASS）。再 stale 化すると CI が fail する。
- shellcheck 指摘なし。既存 `test_install_review_md.sh` 40/40 PASS で非回帰を確認。

## 🚧 スコープ外

- `templates/coderabbit.yaml.tpl` は **変更しない**（generic のままが正しい）。
- `templates/REVIEW.md.tpl` は **変更しない**（claude-action の intent 捌き挙動は維持）。

Closes #757

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * コードレビュー設定のパス指定を更新し、より一般的なディレクトリ構造に対応しました。

* **Documentation**
  * レビューガイドラインドキュメントを整理し、責務分離と参照元を明確化しました。

* **Tests**
  * コードレビュー設定の検証テストを新規追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->