### PR TITLE
📖 docs: 隔離起動時に doctor が出す Keychain 書込不可警告が「意図的な副作用」と分かるようになる

### DIFF
--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -744,6 +744,31 @@ macOS sandbox-exec プロファイルの許可・拒否境界は `.claude/sandbo
 
 本セクションは設計思想の記述であり、個々のパス・ルールを逐次列挙するスコープではない。
 
+### 🩺 既知の挙動: 隔離時の Keychain 警告
+
+> [!NOTE]
+> 隔離を有効化すると `claude doctor` が「Keychain is not writable (-60005)」を出すようになる。
+> これは **意図的な deny の副作用** であり、環境は壊れていない。実害はない。
+
+隔離レイヤは `~/Library/Keychains` への書込を **意図的に拒否** する（秘匿ファイル保護のため、`~/.ssh` / `~/.aws` と同列の deny）。一方 `claude doctor` は自己診断で Keychain へテスト書込を試みる。両者が衝突して警告が出る。
+
+| 観点 | 内容 |
+|------|------|
+| 🔍 何が起きるか | `claude doctor` の Keychain 書込テストが deny され `-60005 authorization denied` が表示される |
+| ✅ 実害があるか | ない。認証は OAuth トークンを `~/.claude.json`（書込許可済み）で扱い、Keychain は使わない |
+| 🔒 なぜ deny を外さないか | Keychain 書込を許可すると秘匿ファイル保護という隔離の目的を自壊させるため |
+
+#### ⚙️ 再現条件
+
+| 設定 | 警告 |
+|------|------|
+| `VIBECORP_ISOLATION=1`（隔離有効） | ⚠️ 出る |
+| `VIBECORP_ISOLATION=0`（passthrough） | ✅ 出ない |
+
+警告を消したい場合は `VIBECORP_ISOLATION=0` で隔離を無効化できるが、隔離の保護を失うため **非推奨**。警告は無視してよい。
+
+📍 根拠: `.claude/sandbox/claude.sb` の deny コメント（#756）。
+
 ## 🗂️ ゲートスタンプ・一時ファイルの保存先
 
 ### 📂 `.claude/` 外への切り出し

--- a/templates/claude/sandbox/claude.sb
+++ b/templates/claude/sandbox/claude.sb
@@ -13,6 +13,12 @@
 ;;              ~/.gitconfig, ~/.config/gh, ~/.npm, ~/.local/share/claude
 ;;   ioctl   : /dev 配下（TTY raw mode 切替に必須）
 ;;   拒否    : ~/.ssh, ~/.aws, ~/.gnupg, ~/Library/Keychains（deny default で自動）
+;;              ※ ~/Library/Keychains の deny は意図的（秘匿ファイル保護）。
+;;                この結果 `claude doctor` の Keychain 書込テストが拒否され
+;;                「Keychain is not writable (-60005)」警告が出るが実害はない。
+;;                認証は OAuth トークンを ~/.claude.json（書込許可済み）で扱い
+;;                Keychain を使わないため。詳細は docs/design-philosophy.md
+;;                「既知の挙動: 隔離時の Keychain 警告」/ #756 を参照。
 ;;   ネット  : 全許可（host allowlist は将来検討）
 ;;   プロセス : fork / exec は許可
 ;;


### PR DESCRIPTION
## 関連 Issue

Closes #756

## 概要

> [!NOTE]
> 隔離（`VIBECORP_ISOLATION=1`）を有効にすると `claude doctor` が「Keychain is not writable (-60005)」を出すようになっている。利用者がこれを「環境が壊れた」と誤解しなくなった。

🎯 **背景**

隔離レイヤは `~/Library/Keychains` を意図的に deny する（秘匿ファイル保護）。一方 `claude doctor` は自己診断で Keychain へテスト書込を試みる。両者が衝突して警告が出ていた。

🔄 **Before / After**

| | 状態 |
|---|---|
| 🔴 Before | 警告だけ見た利用者が「壊れている」と誤解する |
| 🟢 After | docs と sandbox コメントで「意図的な副作用・実害なし」と確認できるようになった |

📖 **何を追記したか**

- `docs/design-philosophy.md` の隔離セクションに「既知の挙動: 隔離時の Keychain 警告」小節を追加した
- 警告(-60005)の因果・実害なしの根拠（認証は `~/.claude.json` 経由で Keychain 不使用）を明記した
- 再現条件（`VIBECORP_ISOLATION=1` で出る / `=0` で消える、隔離無効化は非推奨）を記載した
- `.claude/sandbox/claude.sb`（SSOT は `templates/` 配下）の Keychain deny コメントに doctor 警告との因果を追記した

🧭 **設計判断**

警告を消すには Keychain 書込を許可するしかないが、それは隔離の目的を自壊させる。よって **deny は維持し「既知の副作用」として明文化** する方針を採った（`intent/docs`・挙動不変）。

🔍 **挙動不変性の担保**

- `claude.sb` の追記は **コメント行のみ**。`(deny default)` / allow 群のルール本体は diff ゼロ
- `test_sandbox_ssot_symlink.sh`（16/16）・`test_isolation_macos.sh`（26/26）が通過

🚧 **スコープ外**

- 警告そのものを消す対応（Claude Code 本体側 doctor の挙動）は本 PR の範囲外
- bwrap（Linux）側の同種警告は本 Issue の完了条件（macOS Keychain）外

## テスト計画

- [x] `test_sandbox_ssot_symlink.sh` が通過する（symlink SSOT 整合）
- [x] `test_isolation_macos.sh` が通過する（sandbox プロファイル本体不変）
- [x] `claude.sb` の allow/deny 行に diff がないことを確認した（コメント行のみ）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * 隔離モード有効時に表示されるKeychain警告の既知の動作について、その詳細と対処方法を文書化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->