### PR TITLE
🔧 ci: setup-rulesets.sh が既存 ruleset を冪等に更新できるようになった

### DIFF
--- a/setup-rulesets.sh
+++ b/setup-rulesets.sh
@@ -166,8 +166,8 @@ build_ruleset_index() {
   ids=$(printf '%s' "$list" | jq -r '.[] | select(.target == "branch") | .id')
   while IFS= read -r id; do
     [[ -z "$id" ]] && continue
-    # 詳細取得失敗時は安全側（has_status:false で adopt 除外）に倒すが、
-    # 取りこぼしによる重複作成を運用で検知できるよう warn を残す（silent にしない）。
+    # 詳細取得失敗時はその ruleset を冪等判定からスキップする（continue）。
+    # 取りこぼしで重複作成が起きうるため warn で可視化する（silent にしない）。
     if ! detail=$(gh api "repos/${REPO_FULL}/rulesets/${id}" 2>/dev/null); then
       log_warn "ruleset 詳細の取得に失敗しました (ID: ${id})。冪等判定から除外します（重複作成の可能性）。"
       continue

--- a/setup-rulesets.sh
+++ b/setup-rulesets.sh
@@ -166,7 +166,12 @@ build_ruleset_index() {
   ids=$(printf '%s' "$list" | jq -r '.[] | select(.target == "branch") | .id')
   while IFS= read -r id; do
     [[ -z "$id" ]] && continue
-    detail=$(gh api "repos/${REPO_FULL}/rulesets/${id}" 2>/dev/null || printf '{}')
+    # 詳細取得失敗時は安全側（has_status:false で adopt 除外）に倒すが、
+    # 取りこぼしによる重複作成を運用で検知できるよう warn を残す（silent にしない）。
+    if ! detail=$(gh api "repos/${REPO_FULL}/rulesets/${id}" 2>/dev/null); then
+      log_warn "ruleset 詳細の取得に失敗しました (ID: ${id})。冪等判定から除外します（重複作成の可能性）。"
+      detail='{}'
+    fi
     out=$(printf '%s' "$out" | jq --argjson d "$detail" '. + [{
       id: $d.id,
       name: $d.name,

--- a/setup-rulesets.sh
+++ b/setup-rulesets.sh
@@ -148,7 +148,7 @@ select_managed_ruleset_id() {
   if [[ "$count" -gt 1 ]]; then
     return 3
   fi
-  printf '%s' "$(printf '%s' "$json" | jq -r "${filter}[0].id")"
+  printf '%s' "$json" | jq -r "${filter}[0].id"
   return 0
 }
 
@@ -170,7 +170,7 @@ build_ruleset_index() {
     # 取りこぼしによる重複作成を運用で検知できるよう warn を残す（silent にしない）。
     if ! detail=$(gh api "repos/${REPO_FULL}/rulesets/${id}" 2>/dev/null); then
       log_warn "ruleset 詳細の取得に失敗しました (ID: ${id})。冪等判定から除外します（重複作成の可能性）。"
-      detail='{}'
+      continue
     fi
     out=$(printf '%s' "$out" | jq --argjson d "$detail" '. + [{
       id: $d.id,

--- a/setup-rulesets.sh
+++ b/setup-rulesets.sh
@@ -4,10 +4,13 @@
 set -euo pipefail
 
 RULESET_NAME="vibecorp-protection"
+# create/update 経路で解決した既存 ruleset の ID（adopt 時は別名 ruleset の ID）。空なら新規作成。
+EXISTING_RULESET_ID=""
 
 # ── ユーティリティ ─────────────────────────────────────
 
 log_info()  { printf '\033[32m[INFO]\033[0m  %s\n' "$*" >&2; }
+log_warn()  { printf '\033[33m[WARN]\033[0m  %s\n' "$*" >&2; }
 log_error() { printf '\033[31m[ERROR]\033[0m %s\n' "$*" >&2; }
 
 usage() {
@@ -109,34 +112,126 @@ generate_ruleset_json() {
 JSON
 }
 
-# ── 既存ルールセット検索 ───────────────────────────────
+# ── 既存ルールセット検索（冪等化の核心） ───────────────
 
-find_existing_ruleset_id() {
-  # vibecorp-protection ルールセットの ID を返す。見つからなければ空文字
-  gh api --paginate "repos/${REPO_FULL}/rulesets" \
-    --jq '.[] | select(.name == "'"${RULESET_NAME}"'") | .id' \
-    2>/dev/null || true
+# 採用すべき ruleset の ID を決定する純粋関数（API 非依存・テスト可能）。
+# 入力: stdin に正規化済み ruleset 配列 JSON（各要素 {id,name,target,enforcement,include,exclude,has_status}）。
+# 出力/終了コード:
+#   - 名前一致 or 単一の vibecorp gate 相当 ruleset → その ID を stdout、exit 0
+#   - 該当なし → 空出力、exit 0（新規作成へ）
+#   - vibecorp gate 相当が複数 → return 3（曖昧・中断シグナル。誤った上書きを防ぐ）
+select_managed_ruleset_id() {
+  local json by_name filter count
+  json=$(cat)
+
+  # 1) 名前一致（このスクリプトが作成した ruleset）を最優先
+  by_name=$(printf '%s' "$json" | jq -r --arg n "$RULESET_NAME" \
+    '[.[] | select(.name == $n) | .id] | .[0] // empty')
+  if [[ -n "$by_name" ]]; then
+    printf '%s' "$by_name"
+    return 0
+  fi
+
+  # 2) vibecorp gate 相当の候補のみ adopt（重複作成を回避）。
+  #    安全弁: exclude 空（除外設定を消さない）+ required_status_checks 保有（別目的 ruleset を乗っ取らない）。
+  filter='[.[] | select(
+            .target == "branch"
+            and .enforcement == "active"
+            and ((.include // []) | index("~ALL") != null)
+            and ((.exclude // []) | length == 0)
+            and (.has_status == true)
+          )]'
+  count=$(printf '%s' "$json" | jq "${filter} | length")
+  if [[ "$count" -eq 0 ]]; then
+    return 0
+  fi
+  if [[ "$count" -gt 1 ]]; then
+    return 3
+  fi
+  printf '%s' "$(printf '%s' "$json" | jq -r "${filter}[0].id")"
+  return 0
+}
+
+# 名前完全一致の ID のみを返す純粋関数（adopt しない。delete 専用）。
+select_ruleset_id_name_only() {
+  jq -r --arg n "$RULESET_NAME" '[.[] | select(.name == $n) | .id] | .[0] // empty'
+}
+
+# rulesets list（lite）から branch ruleset を抽出し、各詳細を GET して正規化する。
+# lite list は conditions/rules を含まないため、include/exclude/has_status は詳細 GET から取る。
+build_ruleset_index() {
+  local list="$1"
+  local ids out id detail
+  out='[]'
+  ids=$(printf '%s' "$list" | jq -r '.[] | select(.target == "branch") | .id')
+  while IFS= read -r id; do
+    [[ -z "$id" ]] && continue
+    detail=$(gh api "repos/${REPO_FULL}/rulesets/${id}" 2>/dev/null || printf '{}')
+    out=$(printf '%s' "$out" | jq --argjson d "$detail" '. + [{
+      id: $d.id,
+      name: $d.name,
+      target: $d.target,
+      enforcement: $d.enforcement,
+      include: ($d.conditions.ref_name.include // []),
+      exclude: ($d.conditions.ref_name.exclude // []),
+      has_status: (($d.rules // []) | map(.type) | index("required_status_checks") != null)
+    }]')
+  done <<< "$ids"
+  printf '%s' "$out"
+}
+
+# create/update 用: 既存 ruleset を冪等に解決して EXISTING_RULESET_ID に格納する。
+# main シェルから直接呼ぶ（command substitution のサブシェルにしない）ことで exit 1 が確実に全体を止める。
+resolve_existing_ruleset_id() {
+  local list normalized rc=0
+  list=$(gh api --paginate "repos/${REPO_FULL}/rulesets" 2>/dev/null || printf '[]')
+  normalized=$(build_ruleset_index "$list")
+  # return 3（曖昧）を set -e で殺さず捕捉する。$? を即時取得するため間にコマンドを挟まない。
+  EXISTING_RULESET_ID="$(printf '%s' "$normalized" | select_managed_ruleset_id)" || rc=$?
+  if [[ "$rc" -eq 3 ]]; then
+    log_error "~ALL を対象とする vibecorp gate 相当の branch ruleset が複数存在します。"
+    log_error "どれを ${RULESET_NAME} として管理すべきか曖昧なため中断しました。"
+    log_error "不要な ruleset を削除/統合してから再実行してください。"
+    exit 1
+  elif [[ "$rc" -ne 0 ]]; then
+    log_error "既存 ruleset の解決に失敗しました（rc=${rc}）"
+    exit 1
+  fi
+  if [[ -n "$EXISTING_RULESET_ID" ]]; then
+    local matched_name
+    matched_name=$(printf '%s' "$normalized" | jq -r --arg id "$EXISTING_RULESET_ID" \
+      '.[] | select((.id|tostring) == $id) | .name')
+    if [[ "$matched_name" != "$RULESET_NAME" ]]; then
+      log_warn "既存 ruleset「${matched_name}」(ID: ${EXISTING_RULESET_ID}) を ${RULESET_NAME} として PUT 上書き（リネーム）します。これは破壊的操作です（重複作成は回避）。"
+    fi
+  fi
+}
+
+# delete 用: 名前完全一致の ID を解決する（adopt しない＝別名の稼働 ruleset を誤削除しない）。
+find_ruleset_id_by_name() {
+  local list
+  list=$(gh api --paginate "repos/${REPO_FULL}/rulesets" 2>/dev/null || printf '[]')
+  printf '%s' "$list" | select_ruleset_id_name_only
 }
 
 # ── ルールセット作成/更新 ──────────────────────────────
 
 create_or_update_ruleset() {
-  local existing_id
-  existing_id=$(find_existing_ruleset_id)
+  # EXISTING_RULESET_ID は main() が resolve_existing_ruleset_id で事前解決済み。
   local json
   json=$(generate_ruleset_json)
 
-  if [[ -n "$existing_id" ]]; then
-    # 既存を更新
+  if [[ -n "$EXISTING_RULESET_ID" ]]; then
+    # 既存を更新（adopt 時は別名 ruleset を vibecorp-protection に正規化＝リネーム、ID 不変）
     local response
     response=$(echo "$json" | gh api \
       --method PUT \
-      "repos/${REPO_FULL}/rulesets/${existing_id}" \
+      "repos/${REPO_FULL}/rulesets/${EXISTING_RULESET_ID}" \
       --input - 2>&1) || {
       handle_api_error "$response" "ルールセットの更新"
       return 1
     }
-    log_info "ルールセット '${RULESET_NAME}' を更新しました (ID: ${existing_id})"
+    log_info "ルールセット '${RULESET_NAME}' を更新しました (ID: ${EXISTING_RULESET_ID})"
   else
     # 新規作成
     local response
@@ -175,8 +270,9 @@ remove_legacy_branch_protection() {
 # ── ルールセット削除 ───────────────────────────────────
 
 delete_ruleset() {
+  # delete は名前完全一致のみ（adopt しない＝CEO の別名稼働 ruleset を誤削除しない）。
   local existing_id
-  existing_id=$(find_existing_ruleset_id)
+  existing_id=$(find_ruleset_id_by_name)
 
   if [[ -z "$existing_id" ]]; then
     log_info "ルールセット '${RULESET_NAME}' は存在しません（スキップ）"
@@ -224,9 +320,19 @@ main() {
   if [[ "$DELETE_MODE" == true ]]; then
     delete_ruleset
   else
-    create_or_update_ruleset
-    remove_legacy_branch_protection
+    resolve_existing_ruleset_id
+    # ruleset の作成/更新が成功してから classic protection を削除する。
+    # 順序を守らないと、upsert 失敗時に保護が一時的に外れる窓（gate 不在）が生じる。
+    if create_or_update_ruleset; then
+      remove_legacy_branch_protection
+    else
+      log_error "ルールセットの作成/更新に失敗したため、classic protection の削除を中止しました（gate 不在の窓を回避）"
+      exit 1
+    fi
   fi
 }
 
-main "$@"
+# 直接実行された場合のみ main を走らせる（テストから source して純粋関数を呼べるようにする）。
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/tests/test_setup_rulesets.sh
+++ b/tests/test_setup_rulesets.sh
@@ -167,6 +167,142 @@ fi
 
 # ============================================
 echo ""
+echo "=== C. 冪等性解決（純粋関数 select_managed_ruleset_id / select_ruleset_id_name_only） ==="
+# ============================================
+# setup-rulesets.sh を source して純粋関数を直接呼ぶ（main 実行ガードで main/gh は走らない）。
+# RULESET_NAME は source 後にデフォルト "vibecorp-protection" がセットされる。
+# shellcheck disable=SC1090
+source "$SETUP_SH"
+
+# C0. source ガード: 関数が定義され、main（gh API 呼び出し）が走っていない
+if declare -F select_managed_ruleset_id >/dev/null && declare -F select_ruleset_id_name_only >/dev/null; then
+  pass "source で純粋関数が定義される（main 実行ガードで main は走らない）"
+else
+  fail "source で純粋関数が定義されない"
+  exit 1
+fi
+
+# テスト用ヘルパ: 正規化済み ruleset 要素を組み立てる
+mk() {
+  # 引数: id name target enforcement include_json exclude_json has_status
+  jq -nc \
+    --argjson id "$1" --arg name "$2" --arg target "$3" --arg enf "$4" \
+    --argjson inc "$5" --argjson exc "$6" --argjson hs "$7" \
+    '{id: $id, name: $name, target: $target, enforcement: $enf, include: $inc, exclude: $exc, has_status: $hs}'
+}
+
+VP="vibecorp-protection"
+OTHER="全ブランチ保護"
+
+# C1. 名前一致 → その ID を返す
+JSON="[$(mk 999 "$VP" branch active '["~ALL"]' '[]' true)]"
+rc=0; out="$(printf '%s' "$JSON" | select_managed_ruleset_id)" || rc=$?
+if [ "$rc" -eq 0 ] && [ "$out" = "999" ]; then
+  pass "C1 名前一致 → ID 999 を返す"
+else
+  fail "C1 名前一致 (rc=$rc out=$out)"
+fi
+
+# C2. 名前不一致 + 単一の vibecorp gate 相当（~ALL/active/branch/status/exclude空）→ adopt
+JSON="[$(mk 14181995 "$OTHER" branch active '["~ALL"]' '[]' true)]"
+rc=0; out="$(printf '%s' "$JSON" | select_managed_ruleset_id)" || rc=$?
+if [ "$rc" -eq 0 ] && [ "$out" = "14181995" ]; then
+  pass "C2 名前不一致 + 単一適格 ~ALL → adopt (ID 14181995)"
+else
+  fail "C2 adopt (rc=$rc out=$out)"
+fi
+
+# C2b. include 多値 ["refs/heads/x","~ALL"] でも adopt（index 判定で取りこぼさない）
+JSON="[$(mk 222 "$OTHER" branch active '["refs/heads/x","~ALL"]' '[]' true)]"
+rc=0; out="$(printf '%s' "$JSON" | select_managed_ruleset_id)" || rc=$?
+if [ "$rc" -eq 0 ] && [ "$out" = "222" ]; then
+  pass "C2b include 多値に ~ALL を含む → adopt (ID 222)"
+else
+  fail "C2b include 多値 (rc=$rc out=$out)"
+fi
+
+# C3. 名前不一致 + ~ALL なし → 空（新規作成）
+JSON="[$(mk 333 "$OTHER" branch active '["refs/heads/main"]' '[]' true)]"
+rc=0; out="$(printf '%s' "$JSON" | select_managed_ruleset_id)" || rc=$?
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+  pass "C3 ~ALL なし → 空（新規作成へ）"
+else
+  fail "C3 ~ALL なし (rc=$rc out=$out)"
+fi
+
+# C4. 名前不一致 + 適格 ~ALL ruleset 複数 → rc=3（曖昧・中断）
+JSON="[$(mk 401 "$OTHER" branch active '["~ALL"]' '[]' true),$(mk 402 "別ゲート" branch active '["~ALL"]' '[]' true)]"
+rc=0; out="$(printf '%s' "$JSON" | select_managed_ruleset_id)" || rc=$?
+if [ "$rc" -eq 3 ]; then
+  pass "C4 適格 ~ALL 複数 → rc=3（中断）"
+else
+  fail "C4 複数中断 (rc=$rc out=$out)"
+fi
+
+# C5. ~ALL だが enforcement=disabled → adopt しない（空）
+JSON="[$(mk 501 "$OTHER" branch disabled '["~ALL"]' '[]' true)]"
+rc=0; out="$(printf '%s' "$JSON" | select_managed_ruleset_id)" || rc=$?
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+  pass "C5 enforcement=disabled → adopt しない（空）"
+else
+  fail "C5 disabled 除外 (rc=$rc out=$out)"
+fi
+
+# C6. ~ALL だが target=tag → adopt しない（空）
+JSON="[$(mk 601 "$OTHER" tag active '["~ALL"]' '[]' true)]"
+rc=0; out="$(printf '%s' "$JSON" | select_managed_ruleset_id)" || rc=$?
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+  pass "C6 target=tag → adopt しない（空）"
+else
+  fail "C6 tag 除外 (rc=$rc out=$out)"
+fi
+
+# C7. ~ALL だが exclude 非空 → adopt しない（空）🔒 除外設定を消さない
+JSON="[$(mk 701 "$OTHER" branch active '["~ALL"]' '["refs/heads/release/*"]' true)]"
+rc=0; out="$(printf '%s' "$JSON" | select_managed_ruleset_id)" || rc=$?
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+  pass "C7 exclude 非空 → adopt しない（空）"
+else
+  fail "C7 exclude 安全弁 (rc=$rc out=$out)"
+fi
+
+# C8. ~ALL active branch だが required_status_checks なし（has_status=false）→ adopt しない（空）🔒
+JSON="[$(mk 801 "$OTHER" branch active '["~ALL"]' '[]' false)]"
+rc=0; out="$(printf '%s' "$JSON" | select_managed_ruleset_id)" || rc=$?
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+  pass "C8 required_status_checks なし → adopt しない（空）"
+else
+  fail "C8 has_status 安全弁 (rc=$rc out=$out)"
+fi
+
+# C9. 空入力 [] → 空（新規作成）
+rc=0; out="$(printf '%s' '[]' | select_managed_ruleset_id)" || rc=$?
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+  pass "C9 空入力 → 空（新規作成へ）"
+else
+  fail "C9 空入力 (rc=$rc out=$out)"
+fi
+
+# C-del1. delete 用 name-only: 名前不一致のみ → 空（adopt しないことを実証）
+JSON="[$(mk 14181995 "$OTHER" branch active '["~ALL"]' '[]' true)]"
+out="$(printf '%s' "$JSON" | select_ruleset_id_name_only)"
+if [ -z "$out" ]; then
+  pass "C-del1 name-only は名前不一致 ~ALL を拾わない（誤削除防止）"
+else
+  fail "C-del1 name-only 誤検出 (out=$out)"
+fi
+
+# C-del2. delete 用 name-only: 名前一致 → その ID
+JSON="[$(mk 909 "$VP" branch active '["~ALL"]' '[]' true)]"
+out="$(printf '%s' "$JSON" | select_ruleset_id_name_only)"
+if [ "$out" = "909" ]; then
+  pass "C-del2 name-only は名前一致 → ID 909"
+else
+  fail "C-del2 name-only 名前一致 (out=$out)"
+fi
+
+# ============================================
+echo ""
 echo "=== 結果: $PASSED/$TOTAL passed, $FAILED failed ==="
 
 if [ "$FAILED" -gt 0 ]; then

--- a/tests/test_setup_rulesets.sh
+++ b/tests/test_setup_rulesets.sh
@@ -303,6 +303,40 @@ fi
 
 # ============================================
 echo ""
+echo "=== D. build_ruleset_index 失敗パス（gh スタブ） ==="
+# ============================================
+# gh をシェル関数でスタブし、detail 取得失敗時に continue でスキップされること
+# （スキップされた ID が正規化結果＝adopt 候補に混入しないこと）を検証する。
+REPO_FULL="owner/repo"
+gh() {
+  # $2 = "repos/owner/repo/rulesets/<id>"。111 は成功 JSON、222 は失敗（return 1）。
+  case "$2" in
+    */rulesets/111) printf '%s' '{"id":111,"name":"x","target":"branch","enforcement":"active","conditions":{"ref_name":{"include":["~ALL"],"exclude":[]}},"rules":[{"type":"required_status_checks"}]}' ;;
+    *) return 1 ;;
+  esac
+}
+
+out="$(build_ruleset_index '[{"id":111,"target":"branch"},{"id":222,"target":"branch"}]' 2>/dev/null)"
+ok111=$(printf '%s' "$out" | jq '[.[] | select(.id==111)] | length')
+no222=$(printf '%s' "$out" | jq '[.[] | select(.id==222)] | length')
+hs111=$(printf '%s' "$out" | jq -r '.[] | select(.id==111) | .has_status')
+if [ "$ok111" = "1" ] && [ "$no222" = "0" ] && [ "$hs111" = "true" ]; then
+  pass "D1 detail 取得失敗の ruleset は continue でスキップされ正規化結果に混入しない"
+else
+  fail "D1 build_ruleset_index 失敗パス (ok111=$ok111 no222=$no222 hs111=$hs111)"
+fi
+
+# D2: 成功した ruleset を select_managed_ruleset_id に通すと adopt 候補になる（端から端の整合）
+rc=0; sel="$(printf '%s' "$out" | select_managed_ruleset_id)" || rc=$?
+if [ "$rc" -eq 0 ] && [ "$sel" = "111" ]; then
+  pass "D2 build_ruleset_index → select_managed_ruleset_id で成功 ruleset が adopt される"
+else
+  fail "D2 端から端の整合 (rc=$rc sel=$sel)"
+fi
+unset -f gh
+
+# ============================================
+echo ""
 echo "=== 結果: $PASSED/$TOTAL passed, $FAILED failed ==="
 
 if [ "$FAILED" -gt 0 ]; then


### PR DESCRIPTION
## 🎯 背景

`setup-rulesets.sh` を再実行すると **重複した ruleset が作られ、稼働中の保護が壊れうる** 状態だった。原因は、スクリプトが ruleset を **名前の完全一致** でしか探さず、CEO が別名（「全ブランチ保護」）で作った稼働 ruleset を見つけられず新規作成に分岐していたこと。さらに classic protection を無条件削除するため、一時的に保護が外れる窓もあった。

#783 の CISO 合議レビューで判明した既存問題を切り出した Issue。

## 🔄 Before / After

| 観点 | 🔴 Before | 🟢 After |
|------|----------|---------|
| 再実行時 | 別名の稼働 ruleset を見つけられず**重複作成** | 既存を **adopt して冪等に更新**（重複なし） |
| classic protection 削除 | 無条件削除（gate 不在の窓） | **ruleset 更新成功後にのみ削除** |
| `--delete` | 名前一致のみ（変更なし・安全） | 名前一致のみを維持（adopt しない） |

## 🧭 設計判断

- **既存 ruleset の解決を冪等化**: ① 名前一致を最優先 → ② なければ「全ブランチ対象・active・branch・除外なし・status check 保有」の **単一の vibecorp gate 相当 ruleset を adopt**（PUT で正規化、ID 不変）。
- **adopt の安全弁**（CISO/security 合議の指摘反映）:
  - 🔒 `exclude` 空を必須にし、CEO の除外設定を消さないようにした。
  - 🔒 `required_status_checks` 保有を必須にし、別目的の ruleset を乗っ取らないようにした。
  - 適格 ruleset が複数あると**曖昧として中断**し、誤った上書きを防ぐ。
  - adopt 時は破壊的操作を **WARN ログ**で可視化する。
- **delete は名前一致のみ**（adopt しない）にし、稼働 ruleset の誤削除を防いだ。
- **gate は緩めない**: 必須チェック（`test` / `vibehawk`）と `enforcement: active` は不変。

## 🔍 動作不変性の担保（intent/infra）

- merge gate 定義（`generate_ruleset_json`）は一切変更していない。変えたのは「どの ruleset に適用するか」の解決ロジックのみ。
- 解決ロジックを純粋関数（API 非依存）に切り出し、`main` 実行ガードで source 可能にして単体テスト化。

## 🧪 テスト観点

`tests/test_setup_rulesets.sh` に冪等性解決の検証を追加（**31/31 PASS**）。

- C1 名前一致 / C2・C2b adopt（include 多値含む）/ C3 新規 / C4 複数中断 / C5 disabled 除外 / C6 tag 除外 / **C7 exclude 安全弁** / **C8 status 安全弁** / C9 空入力 / C-del 誤削除防止
- `--delete` ローカル実行で稼働 ruleset「全ブランチ保護」が消えないことを実機確認済み。

## 🚧 スコープ外

adopt が status check の **context 中身**までは照合しない点は意図的（移行前 `[test, CodeRabbit]` ruleset を更新するユースケースを壊さないため）。単一の全ブランチ status gate を vibecorp gate に正規化するのが冪等化の狙いで、WARN ログで可視化済み。

Closes #786
