### PR TITLE
🐛 fix: プラグイン導入先でエージェント16件がロードされず @ 呼び出しも Agent 召喚もできない

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -44,6 +44,24 @@
         "./skills/sync-check",
         "./skills/sync-edit",
         "./skills/worktree"
+      ],
+      "agents": [
+        "./agents/accounting-analyst.md",
+        "./agents/cfo.md",
+        "./agents/ciso.md",
+        "./agents/clo.md",
+        "./agents/cpo.md",
+        "./agents/cto.md",
+        "./agents/legal-analyst.md",
+        "./agents/plan-architect.md",
+        "./agents/plan-cost.md",
+        "./agents/plan-dx.md",
+        "./agents/plan-legal.md",
+        "./agents/plan-performance.md",
+        "./agents/plan-security.md",
+        "./agents/plan-testing.md",
+        "./agents/security-analyst.md",
+        "./agents/sm.md"
       ]
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vibecorp",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "AI エージェントチームによる再現可能なプロダクト開発フレームワーク",
   "hooks": "./hooks/hooks.json"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
 
 ### 修正
 
+- プラグイン導入先で C\*O / SM などエージェント 16 件がロードされず `@` 呼び出しもスキル内召喚もできない不具合を修正した。([Issue #790](https://github.com/hirokimry/vibecorp/issues/790))
+  - `marketplace.json` に agents が列挙されておらず、導入先でエージェントが 0 件になっていた。skills 同様に明示列挙するようにした。
+  - agents 変更時の version bump 忘れも CI で検知するようになった。
 - 旧構造で作られた知見バッファが新構造へ自動移行されるようになった。([Issue #543](https://github.com/hirokimry/vibecorp/issues/543))
   - `/sync-edit` / `/review-harvest` / `/knowledge-pr` の次回実行時に自動回復する。
   - 未プッシュのコミットは移行中に保全される。

--- a/scripts/check-plugin-version-bump.sh
+++ b/scripts/check-plugin-version-bump.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 # check-plugin-version-bump.sh — plugin.json bump 漏れ自動検知
 #
-# Issue #458: PR で .claude-plugin/marketplace.json の plugins[0].skills が変化したのに
+# Issue #458: PR で .claude-plugin/marketplace.json の plugins[0].skills / agents が変化したのに
 # .claude-plugin/plugin.json の version が bump されていない場合に警告する。
 # PR #459 で発生した「新スキル 3 件追加したのに plugin.json を 0.2.0 のまま放置」事象の再発防止。
+# Issue #790: agents も skills と同じ配布物なため検知対象に含める（agents 列挙漏れで導入先の agent 全欠落が発生した）。
 #
 # 使い方:
 #   bash scripts/check-plugin-version-bump.sh <BASE_REF> <HEAD_REF>
 #
 # 終了コード:
-#   0 — 問題なし（skills 不変、または skills 変更ありかつ version bump あり、または marketplace.json 不在）
-#   1 — 警告（skills 変更ありかつ plugin.json version 不変）
+#   0 — 問題なし（skills / agents 不変、または変更ありかつ version bump あり、または marketplace.json 不在）
+#   1 — 警告（skills / agents 変更ありかつ plugin.json version 不変）
 #   2 — 引数不足・前提コマンド不在等のエラー
 
 set -euo pipefail
@@ -57,9 +58,12 @@ fi
 
 base_skills=$(echo "$base_marketplace" | jq -c '.plugins[0].skills // []')
 head_skills=$(echo "$head_marketplace" | jq -c '.plugins[0].skills // []')
+# agents も skills と同じ配布物。列挙の増減で利用者が取得する agent が変わるため version bump が必要（#790）
+base_agents=$(echo "$base_marketplace" | jq -c '.plugins[0].agents // []')
+head_agents=$(echo "$head_marketplace" | jq -c '.plugins[0].agents // []')
 
-if [[ "$base_skills" == "$head_skills" ]]; then
-  echo "✅ marketplace.json の plugins[0].skills に変更なし"
+if [[ "$base_skills" == "$head_skills" && "$base_agents" == "$head_agents" ]]; then
+  echo "✅ marketplace.json の plugins[0].skills / agents に変更なし"
   exit 0
 fi
 
@@ -80,13 +84,13 @@ if [[ -z "$base_version" || -z "$head_version" ]]; then
 fi
 
 if [[ "$base_version" != "$head_version" ]]; then
-  echo "✅ skills 変更ありかつ plugin.json version が ${base_version} → ${head_version} に bump 済み"
+  echo "✅ skills / agents 変更ありかつ plugin.json version が ${base_version} → ${head_version} に bump 済み"
   exit 0
 fi
 
 {
-  echo "⚠️ marketplace.json の plugins[0].skills が変更されているが、plugin.json の version (${base_version}) が bump されていません。"
-  echo "   利用者は新しいスキルを取得するために version bump を必要とします。"
-  echo "   PR #459 と同種の取りこぼしを防ぐため、.claude-plugin/plugin.json の version を更新してください。"
+  echo "⚠️ marketplace.json の plugins[0].skills / agents が変更されているが、plugin.json の version (${base_version}) が bump されていません。"
+  echo "   利用者は新しいスキル / エージェントを取得するために version bump を必要とします。"
+  echo "   PR #459 / Issue #790 と同種の取りこぼしを防ぐため、.claude-plugin/plugin.json の version を更新してください。"
 } >&2
 exit 1

--- a/tests/test_plugin_autoload.sh
+++ b/tests/test_plugin_autoload.sh
@@ -121,6 +121,8 @@ if [[ "$agents_count" -ge 1 ]]; then
   pass "marketplace.json の plugin に agents 配列が存在する（${agents_count} 件）"
 else
   fail "marketplace.json の plugin に agents 配列が存在しない、または空"
+  # agents 配列不在なら後続の件数一致検証は前提が崩れるため即終了（testing.md 準拠）
+  exit 1
 fi
 
 # agents/ 直下は .md ファイルが並ぶ構造のため、skills（ディレクトリ数）と異なり .md ファイル数で数える

--- a/tests/test_plugin_autoload.sh
+++ b/tests/test_plugin_autoload.sh
@@ -114,6 +114,23 @@ else
   fail "skills 配列の件数（${skills_count}）が skills/ ディレクトリ数（${skills_dir_count}）と不一致"
 fi
 
+# agents 配列の存在と件数一致検証（#790: plugin native 配布移行時に agents 列挙が漏れ、
+# 導入先でエージェント全件がロードされなくなった。skills 同様に列挙必須なため回帰を検知する）
+agents_count=$(jq '.plugins[0].agents | length' "$MARKETPLACE")
+if [[ "$agents_count" -ge 1 ]]; then
+  pass "marketplace.json の plugin に agents 配列が存在する（${agents_count} 件）"
+else
+  fail "marketplace.json の plugin に agents 配列が存在しない、または空"
+fi
+
+# agents/ 直下は .md ファイルが並ぶ構造のため、skills（ディレクトリ数）と異なり .md ファイル数で数える
+agents_dir_count=$(find "${REPO_ROOT}/agents" -maxdepth 1 -name '*.md' | wc -l | tr -d ' ')
+if [[ "$agents_count" -eq "$agents_dir_count" ]]; then
+  pass "agents 配列の件数（${agents_count}）が agents/ ディレクトリの .md 数と一致"
+else
+  fail "agents 配列の件数（${agents_count}）が agents/ ディレクトリの .md 数（${agents_dir_count}）と不一致"
+fi
+
 # --- B. templates/claude/settings.json（単一 SSOT）の extraKnownMarketplaces / enabledPlugins ---
 
 if jq -e '.extraKnownMarketplaces.vibecorp.source.source == "github" and .extraKnownMarketplaces.vibecorp.source.repo == "hirokimry/vibecorp"' "$CLAUDE_SETTINGS" >/dev/null 2>&1; then

--- a/tests/test_plugin_version_bump_check.sh
+++ b/tests/test_plugin_version_bump_check.sh
@@ -9,6 +9,8 @@
 #   3. skills 不変 → exit 0
 #   4. marketplace.json が base に不在 → exit 0（graceful skip）
 #   5. skills 削除 + version 不変 → exit 1（警告）
+#   6. agents 追加 + version bump → exit 0（#790: agents も検知対象）
+#   7. agents 追加 + version 不変 → exit 1（警告、#790）
 
 set -euo pipefail
 
@@ -69,6 +71,25 @@ write_marketplace_json() {
     {
       "name": "vibecorp",
       "skills": ${skills_json}
+    }
+  ]
+}
+EOF
+}
+
+# skills は固定し agents のみ可変にした marketplace.json を書く（agents 検知ケース用、#790）
+write_marketplace_json_agents() {
+  local agents_json
+  agents_json=$(printf '"%s",' "$@")
+  agents_json="[${agents_json%,}]"
+  cat > .claude-plugin/marketplace.json <<EOF
+{
+  "name": "vibecorp",
+  "plugins": [
+    {
+      "name": "vibecorp",
+      "skills": ["./skills/a"],
+      "agents": ${agents_json}
     }
   ]
 }
@@ -185,6 +206,48 @@ git add -A
 git commit -q -m "remove skill c without bump"
 rc=$(run_check)
 assert_eq "Case 5: exit 1" "1" "$rc"
+cd "$SCRIPT_DIR"
+cleanup
+TMPDIR_ROOT=""
+
+# ============================================
+# Case 6: agents 追加 + version bump → exit 0
+# ============================================
+echo ""
+echo "--- Case 6: agents 追加 + version bump → exit 0 ---"
+setup_repo
+write_plugin_json "0.1.0"
+write_marketplace_json_agents "./agents/a.md"
+git add -A
+git commit -q -m "initial"
+git checkout -q -b pr
+write_plugin_json "0.2.0"
+write_marketplace_json_agents "./agents/a.md" "./agents/b.md"
+git add -A
+git commit -q -m "add agent b + bump"
+rc=$(run_check)
+assert_eq "Case 6: exit 0" "0" "$rc"
+cd "$SCRIPT_DIR"
+cleanup
+TMPDIR_ROOT=""
+
+# ============================================
+# Case 7: agents 追加 + version 不変 → exit 1
+# ============================================
+echo ""
+echo "--- Case 7: agents 追加 + version 不変 → exit 1 ---"
+setup_repo
+write_plugin_json "0.1.0"
+write_marketplace_json_agents "./agents/a.md"
+git add -A
+git commit -q -m "initial"
+git checkout -q -b pr
+write_plugin_json "0.1.0"
+write_marketplace_json_agents "./agents/a.md" "./agents/b.md"
+git add -A
+git commit -q -m "add agent b without bump"
+rc=$(run_check)
+assert_eq "Case 7: exit 1" "1" "$rc"
 cd "$SCRIPT_DIR"
 cleanup
 TMPDIR_ROOT=""


### PR DESCRIPTION
## 関連 Issue

close https://github.com/hirokimry/vibecorp/issues/790

## 概要

### 🐛 再現していた事象

プラグインを他リポジトリに導入すると、C\*O / SM など **エージェント 16 件が丸ごとロードされなくなっていた**。

- 導入先のプラグイン表示は `33 skills` のみで **agents は 0** だった。
- `@agent-vibecorp:cto` 等での呼び出しも、スキル内からの召喚もできなかった。

### 🎯 原因

`marketplace.json` の `plugins[0]` に **`agents` が列挙されていなかった**。

- `skills` は 33 件明示列挙されていたが `agents` キーが無かった。
- plugin native 配布への移行時（#738）に、skills と同じ列挙をやり忘れていた。
- 📍 根拠: #421 / #422 で「この環境では marketplace.json への明示列挙が必須」と確定済み。

### 🔄 Before / After

| 観点 | Before | After |
|------|--------|-------|
| agents ロード | ❌ 0 件 | ✅ 16 件 |
| `@agent-vibecorp:cto` 呼び出し | 呼べない | 呼べる |
| version bump 忘れ検知 | skills のみ | skills + agents |

### 🆕 変更点

- `marketplace.json` に agents 配列 16 件を明示列挙するようにした。
- `check-plugin-version-bump.sh` が agents 変更時も version bump 忘れを検知するようになった（#790 と同根の穴を塞いだ）。
- `plugin.json` を 0.3.4 に bump した（利用者が更新を取得できるようにするため）。
- `CHANGELOG` に修正を追記した。

### 🚧 スコープ外

- 導入先での実呼び出し確認は CEO の手動確認に委ねる（プラグイン表示に agents 件数が出るか）。

## テスト計画

- [ ] `bash tests/test_plugin_autoload.sh` → 緑（22/22、agents 16 件一致を検証）
- [ ] `bash tests/test_plugin_version_bump_check.sh` → 緑（7/7、agents の Case 6/7 追加）
- [ ] 本 PR diff に対する `check-plugin-version-bump.sh main HEAD` → exit 0（agents 変更 + bump 済みを検知）
